### PR TITLE
Working copy dir; log file; Per-job page

### DIFF
--- a/src/Vira/App/LinkTo.hs
+++ b/src/Vira/App/LinkTo.hs
@@ -2,7 +2,7 @@
 module Vira.App.LinkTo where
 
 import Vira.Lib.Git (BranchName)
-import Vira.State.Type (RepoName)
+import Vira.State.Type (JobId, RepoName)
 
 {- | The part of the application the caller intends to link to
 
@@ -14,6 +14,7 @@ data LinkTo
   | Repo RepoName
   | RepoUpdate RepoName
   | Build RepoName BranchName
+  | Job JobId
   | About
 
 linkShortTitle :: LinkTo -> Text
@@ -23,4 +24,5 @@ linkShortTitle = \case
   Repo name -> toText . toString $ name
   RepoUpdate _ -> "Update" -- unused
   Build _ _ -> "Build" -- unused
+  Job jobId -> "Job " <> show jobId
   About -> "About"

--- a/src/Vira/Lib/Git.hs
+++ b/src/Vira/Lib/Git.hs
@@ -12,10 +12,6 @@ import Data.Data (Data)
 import Data.Map.Strict qualified as Map
 import Data.SafeCopy
 import Data.Text qualified as T
-import Database.Beam (FromBackendRow, HasSqlEqualityCheck)
-import Database.Beam.Backend (HasSqlValueSyntax)
-import Database.Beam.Sqlite.Connection (Sqlite)
-import Database.Beam.Sqlite.Syntax (SqliteValueSyntax)
 import Servant (FromHttpApiData, ToHttpApiData)
 import System.Process
 import System.Which (staticWhich)
@@ -35,8 +31,6 @@ newtype CommitID = CommitID {unCommitID :: Text}
     ( IsString
     , ToJSON
     , ToString
-    , FromBackendRow Sqlite
-    , HasSqlValueSyntax SqliteValueSyntax
     , ToHttpApiData
     , FromHttpApiData
     )
@@ -49,9 +43,6 @@ newtype BranchName = BranchName {unBranchName :: Text}
     ( IsString
     , ToJSON
     , ToString
-    , FromBackendRow Sqlite
-    , HasSqlValueSyntax SqliteValueSyntax
-    , HasSqlEqualityCheck Sqlite
     , ToHttpApiData
     , FromHttpApiData
     )

--- a/src/Vira/Page/JobPage.hs
+++ b/src/Vira/Page/JobPage.hs
@@ -4,32 +4,39 @@ module Vira.Page.JobPage where
 
 import Effectful (Eff)
 import Effectful.Error.Static (throwError)
-import Effectful.Reader.Dynamic (asks)
+import Effectful.Reader.Dynamic (ask, asks)
 import GHC.IO.Exception (ExitCode (..))
 import Htmx.Servant.Response
+import Lucid
 import Servant hiding (throwError)
 import Servant.API.ContentTypes.Lucid (HTML)
 import Servant.Server.Generic (AsServer)
+import System.FilePath ((</>))
 import Vira.App qualified as App
+import Vira.App.LinkTo qualified as LinkTo
 import Vira.App.Logging
 import Vira.Lib.Git (BranchName)
+import Vira.Lib.Git qualified as Git
 import Vira.State.Acid qualified as St
 import Vira.State.Core qualified as St
-import Vira.State.Type (RepoName)
+import Vira.State.Type (JobId, RepoName, jobWorkingDir)
 import Vira.Supervisor qualified as Supervisor
-import Vira.Supervisor.Type (TaskOutput (..))
+import Vira.Widgets qualified as W
 import Prelude hiding (ask, asks)
 
-newtype Routes mode = Routes
+data Routes mode = Routes
   { -- Trigger a new build
-    _build :: mode :- "new" :> Capture "branch" BranchName :> Post '[HTML] (Headers '[HXRefresh] Text)
+    _build :: mode :- "new" :> Capture "repo" RepoName :> Capture "branch" BranchName :> Post '[HTML] (Headers '[HXRefresh] Text)
+  , -- View a job
+    _view :: mode :- Capture "job" JobId :> Get '[HTML] (Html ())
   }
   deriving stock (Generic)
 
-handlers :: App.AppState -> RepoName -> Routes AsServer
-handlers cfg repoName = do
+handlers :: App.AppState -> Routes AsServer
+handlers cfg = do
   Routes
-    { _build = App.runAppInServant cfg . buildHandler repoName
+    { _build = \x -> App.runAppInServant cfg . buildHandler x
+    , _view = App.runAppInServant cfg . viewHandler
     }
 
 buildHandler :: RepoName -> BranchName -> Eff App.AppServantStack (Headers '[HXRefresh] Text)
@@ -37,6 +44,43 @@ buildHandler repoName branch = do
   triggerNewBuild repoName branch >>= \case
     Nothing -> throwError err404
     Just () -> pure $ addHeader True "Ok"
+
+viewHandler :: JobId -> Eff App.AppServantStack (Html ())
+viewHandler jobId = do
+  cfg <- ask
+  job <- App.query (St.GetJobA jobId) >>= maybe (throwError err404) pure
+  logText <- case jobWorkingDir job.jobStatus of
+    Nothing -> pure ""
+    Just workDir -> do
+      -- TODO: Streaming!
+      liftIO $ readFileBS $ workDir </> "output.log"
+  pure $ W.layout cfg.linkTo (show jobId) [LinkTo.Job jobId] $ do
+    viewJob cfg.linkTo job
+    div_ $ do
+      pre_ [class_ "bg-black text-white p-2 text-xs"] $ code_ $ do
+        toHtml logText
+
+viewJob :: (LinkTo.LinkTo -> Link) -> St.Job -> Html ()
+viewJob linkTo job = do
+  a_ [title_ "View Job Details", href_ $ show . linkURI $ linkTo $ LinkTo.Job job.jobId] $ do
+    div_ [class_ "flex items-center justify-start space-x-4 hover:bg-blue-100"] $ do
+      div_ [class_ "w-24"] $ do
+        b_ $ "Job #" <> toHtml (show @Text job.jobId)
+      viewCommit job.jobCommit
+      viewJobStatus job.jobStatus
+
+viewCommit :: Git.CommitID -> Html ()
+viewCommit (Git.CommitID commit) = do
+  code_ [class_ "text-gray-700 hover:text-black"] $ toHtml commit
+
+viewJobStatus :: St.JobStatus -> Html ()
+viewJobStatus status = do
+  case status of
+    St.JobRunning _ -> span_ [class_ "text-blue-700"] "🚧 Running"
+    St.JobPending -> span_ [class_ "text-yellow-700"] "⏳ Pending"
+    St.JobFinished _ St.JobSuccess -> span_ [class_ "text-green-700"] "✅ Success"
+    St.JobFinished _ St.JobFailure -> span_ [class_ "text-red-700"] "❌ Failure"
+    St.JobKilled _ -> span_ [class_ "text-red-700"] "💀 Killed"
 
 -- TODO:
 -- 1. Fail if a build is already happening (until we support queuing)
@@ -49,16 +93,14 @@ triggerNewBuild repoName branchName = do
   asks App.supervisor >>= \supervisor -> do
     job <- App.update $ St.AddNewJobA repoName branchName branch.headCommit
     log Info $ "Added job " <> show job
-    -- TODO We need a concept of 'working copy' to which source should be checked out. Then `nix build .` on that.
     let cmd = "nix build -L --no-link --print-out-paths " <> toString (gitFlakeUrl repo.cloneUrl) <> "/" <> toString branch.headCommit
-    taskId <- Supervisor.startTask supervisor job.jobId cmd $ \taskOutput -> do
-      -- TODO: Set stdout
-      let status = case taskOutput.exitCode of
-            ExitSuccess -> St.JobFinished St.JobSuccess
-            ExitFailure _code -> St.JobFinished St.JobFailure
-      App.update $ St.JobUpdateStatusA job.jobId status $ toText taskOutput.output
-    App.update $ St.JobUpdateStatusA job.jobId St.JobRunning ""
-    log Info $ "Started task " <> show taskId
+    workDir <- Supervisor.startTask supervisor job.jobId cmd $ \workDir exitCode -> do
+      let status = case exitCode of
+            ExitSuccess -> St.JobFinished workDir St.JobSuccess
+            ExitFailure _code -> St.JobFinished workDir St.JobFailure
+      App.update $ St.JobUpdateStatusA job.jobId status
+    App.update $ St.JobUpdateStatusA job.jobId $ St.JobRunning workDir
+    log Info $ "Started task " <> show job.jobId
   pure $ Just ()
   where
     gitFlakeUrl :: Text -> Text

--- a/src/Vira/Supervisor.hs
+++ b/src/Vira/Supervisor.hs
@@ -4,10 +4,15 @@
 module Vira.Supervisor where
 
 import Data.Map.Strict qualified as Map
-import Effectful (Eff, (:>))
+import Effectful (Eff, IOE, (:>))
 import Effectful.Concurrent.Async
 import Effectful.Concurrent.MVar (modifyMVar, modifyMVar_, readMVar)
-import Effectful.Process (Process, readProcessWithExitCode)
+import Effectful.FileSystem (FileSystem, createDirectory)
+import Effectful.FileSystem.IO (openFile)
+import Effectful.Process (CreateProcess (cwd, std_err, std_out), Process, StdStream (UseHandle), createProcess, shell, waitForProcess)
+import System.Directory (createDirectoryIfMissing, getCurrentDirectory, makeAbsolute)
+import System.Exit (ExitCode)
+import System.FilePath ((</>))
 import Vira.App qualified as App
 import Vira.App.Logging
 import Vira.Supervisor.Type
@@ -16,7 +21,10 @@ import Prelude hiding (readMVar)
 newSupervisor :: (MonadIO m) => m TaskSupervisor
 newSupervisor = do
   tasks <- newMVar mempty
-  pure $ TaskSupervisor tasks ()
+  pwd <- liftIO getCurrentDirectory
+  workDir <- liftIO $ makeAbsolute $ pwd </> "state" </> "workspace" -- keep it alongside acid-state db
+  liftIO $ createDirectoryIfMissing True workDir
+  pure $ TaskSupervisor tasks workDir
 
 logSupervisorState :: (HasCallStack, Concurrent :> es, Log Message :> es) => TaskSupervisor -> Eff es ()
 logSupervisorState supervisor = do
@@ -26,15 +34,26 @@ logSupervisorState supervisor = do
     taskState <- getTaskStatus supervisor taskId
     withFrozenCallStack $ log Debug $ "Task " <> show taskId <> " state: " <> show taskState
 
--- | Start a new task
+-- | Start a new a task, returning its working directory.
 startTask ::
-  (Concurrent :> es, Process :> es, Log Message :> es, HasCallStack) =>
+  ( Concurrent :> es
+  , Process :> es
+  , Log Message :> es
+  , FileSystem :> es
+  , IOE :> es
+  , HasCallStack
+  ) =>
   TaskSupervisor ->
   TaskId ->
   String ->
   -- Handler to call after the task finishes
-  (TaskOutput -> Eff es ()) ->
-  Eff es TaskId
+  ( -- \| Working directory
+    FilePath ->
+    -- \| Exit code
+    ExitCode ->
+    Eff es ()
+  ) ->
+  Eff es FilePath
 startTask supervisor taskId cmd h = do
   logSupervisorState supervisor
   log Info $ "Starting task: " <> toText cmd
@@ -42,15 +61,25 @@ startTask supervisor taskId cmd h = do
     if Map.member taskId tasks
       then do
         log Error $ "Task " <> show taskId <> " already exists"
-        pure (tasks, taskId)
+        die $ "Task " <> show taskId <> " already exists"
       else do
+        let pwd = workDir supervisor </> show taskId
+        createDirectory pwd
         task <- async $ do
-          (exitCode, output, _) <- readProcessWithExitCode "sh" ["-c", cmd <> " 2>&1"] ""
+          -- Send all output to a file under working directory.
+          outputHandle <- openFile (pwd </> "output.log") WriteMode
+          let process =
+                (shell cmd)
+                  { cwd = Just pwd
+                  , std_out = UseHandle outputHandle
+                  , std_err = UseHandle outputHandle
+                  }
+          (_, _, _, ph) <- createProcess process
+          exitCode <- waitForProcess ph
           log Info $ "Task " <> show taskId <> " finished with exit code " <> show exitCode
-          let out = TaskOutput output exitCode
-          h out
-          pure out
-        pure (Map.insert taskId task tasks, taskId)
+          h pwd exitCode
+          pure exitCode
+        pure (Map.insert taskId task tasks, pwd)
 
 -- | Kill a task
 killTask :: TaskSupervisor -> TaskId -> Eff App.AppStack ()

--- a/src/Vira/Supervisor/Type.hs
+++ b/src/Vira/Supervisor/Type.hs
@@ -1,25 +1,21 @@
 module Vira.Supervisor.Type where
 
-import Effectful.Concurrent.Async
+import Effectful.Concurrent.Async (Async)
 import System.Exit (ExitCode)
 import Vira.State.Type (JobId)
 
 type TaskId = JobId
 
-data TaskOutput = TaskOutput
-  { output :: String -- stdout/stderr
-  , exitCode :: ExitCode
-  }
-  deriving stock (Generic, Show)
-
 data TaskState
   = Running
-  | Finished TaskOutput
+  | Finished ExitCode
   | Killed
   deriving stock (Generic, Show)
 
 -- TODO Use ixset-typed
 data TaskSupervisor = TaskSupervisor
-  { tasks :: MVar (Map TaskId (Async TaskOutput))
-  , dummy :: ()
+  { tasks :: MVar (Map TaskId (Async ExitCode))
+  -- ^ Current tasks, running or not
+  , workDir :: FilePath
+  -- ^ Base working directory for all tasks. This assigns `${workDir}/${taskId}/` as $PWD for each task.
   }

--- a/src/Vira/Toplevel.hs
+++ b/src/Vira/Toplevel.hs
@@ -40,6 +40,7 @@ import Prelude hiding (Reader, ask, runReader)
 data Routes mode = Routes
   { _home :: mode :- Get '[HTML] (Html ())
   , _repos :: mode :- "r" Servant.API.:> NamedRoutes RegistryPage.Routes
+  , _jobs :: mode :- "j" Servant.API.:> NamedRoutes JobPage.Routes
   , _about :: mode :- "about" Servant.API.:> Get '[HTML] (Html ())
   }
   deriving stock (Generic)
@@ -55,6 +56,7 @@ handlers cfg =
               a_ [href_ url, class_ "flex items-center p-3 space-x-3 text-blue-700 font-bold transition-colors rounded-md hover:bg-gray-100"] $ do
                 name
     , _repos = RegistryPage.handlers cfg
+    , _jobs = JobPage.handlers cfg
     , _about = do
         pure $ W.layout cfg.linkTo "About Vira" [About] $ do
           div_ $ do
@@ -103,4 +105,5 @@ linkTo = \case
   RepoListing -> fieldLink _repos // RegistryPage._listing
   Repo name -> fieldLink _repos // RegistryPage._repo /: name // RepoPage._view
   RepoUpdate name -> fieldLink _repos // RegistryPage._repo /: name // RepoPage._update
-  Build repo branch -> fieldLink _repos // RegistryPage._repo /: repo // RepoPage._job // JobPage._build /: branch
+  Build repo branch -> fieldLink _jobs // JobPage._build /: repo /: branch
+  Job jobId -> fieldLink _jobs // JobPage._view /: jobId

--- a/static/tailwind.css
+++ b/static/tailwind.css
@@ -987,6 +987,11 @@ select {
   transition-duration: 150ms;
 }
 
+.hover\:bg-blue-100:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(219 234 254 / var(--tw-bg-opacity));
+}
+
 .hover\:bg-gray-100:hover {
   --tw-bg-opacity: 1;
   background-color: rgb(243 244 246 / var(--tw-bg-opacity));


### PR DESCRIPTION
- Each job has a dedicated working copy directory
- Output of the build is sent to a file under this directory
- Each job has a page in UI, including the build output
  - If the build is still running, the output would be partial.

In future, we will support build log streaming.