### PR TITLE
Allow repos & branches to be specified from CLI

### DIFF
--- a/src/Vira/State/Acid.hs
+++ b/src/Vira/State/Acid.hs
@@ -36,6 +36,13 @@ data ViraState = ViraState
 
 $(deriveSafeCopy 0 'base ''ViraState)
 
+setAllReposA :: [Repo] -> Update ViraState ()
+setAllReposA repos = do
+  modify $ \s ->
+    s
+      { repos = Ix.fromList repos
+      }
+
 -- | Get all repositories
 getAllReposA :: Query ViraState [Repo]
 getAllReposA = do
@@ -123,7 +130,8 @@ markRunningJobsAsStaleA = do
 
 $( makeAcidic
     ''ViraState
-    [ 'getAllReposA
+    [ 'setAllReposA
+    , 'getAllReposA
     , 'getRepoByNameA
     , 'getBranchesByRepoA
     , 'getBranchByNameA

--- a/src/Vira/State/Core.hs
+++ b/src/Vira/State/Core.hs
@@ -13,25 +13,16 @@ module Vira.State.Core (
 ) where
 
 import Data.Acid
-import Data.IxSet.Typed qualified as Ix
 import Vira.State.Acid
 import Vira.State.Type
 
 -- | Open vira database
-openViraState :: IO (AcidState ViraState)
-openViraState = do
-  st <- openLocalState $ ViraState sampleRepos mempty mempty
+openViraState :: [Repo] -> IO (AcidState ViraState)
+openViraState repos = do
+  st <- openLocalState $ ViraState mempty mempty mempty
+  update st $ SetAllReposA repos
   update st MarkRunningJobsAsStaleA
   pure st
-  where
-    sampleRepos =
-      Ix.fromList
-        [ Repo "emanote" "https://github.com/srid/emanote.git"
-        , Repo "omnix" "https://github.com/juspay/omnix.git"
-        , Repo "haskell-flake" "https://github.com/srid/haskell-flake.git"
-        , Repo "hyperswitch" "https://github.com/juspay/hyperswitch.git"
-        , Repo "superposition" "https://github.com/juspay/superposition.git"
-        ]
 
 {- | Close vira database
 

--- a/src/Vira/Supervisor/Type.hs
+++ b/src/Vira/Supervisor/Type.hs
@@ -12,7 +12,10 @@ data TaskState
   | Killed
   deriving stock (Generic, Show)
 
--- TODO Use ixset-typed
+{- | Supervisor for managing tasks
+
+TODO Use ixset-typed
+-}
 data TaskSupervisor = TaskSupervisor
   { tasks :: MVar (Map TaskId Task)
   -- ^ Current tasks, running or not


### PR DESCRIPTION
- Added two options `--repos` & `--branch-whitelist` (see screenshot)
    - Because we use `opt-env-conf`, these can also be specified in config file or in a Nix module.
- Build only a whitelist of branches (since some repos have many undeleted branches)

<img width="1145" alt="image" src="https://github.com/user-attachments/assets/52fe727a-b0e7-4000-a037-d9a7b2a4e0a2" />
