### PR TITLE
Add `cachix push` stage

### DIFF
--- a/nix/modules/flake-parts/devshell.nix
+++ b/nix/modules/flake-parts/devshell.nix
@@ -15,6 +15,7 @@
         ghciwatch
         # vira extraBuildDepends from haskell.nix
         git
+        cachix
         inputs'.omnix.packages.default
       ];
     };

--- a/nix/modules/flake-parts/haskell.nix
+++ b/nix/modules/flake-parts/haskell.nix
@@ -77,7 +77,12 @@
     process-compose."vira-dev" = {
       settings = {
         processes = {
-          haskell.command = "ghcid -c 'cabal repl exe:vira --flags=ghcid' -T :main";
+          # The cachix token here is for a dummy cache, managed by Srid.
+          haskell.command = ''
+            set -x
+            ghcid -c 'cabal repl exe:vira --flags=ghcid' -T Main.main \
+                --setup ':set args --repo-cachix-name scratch-vira-dev --repo-cachix-auth-token eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiI5NDI4ZjhkZi1mZWM5LTQ1ZjctYjMzYi01MTFiZTljNTNkNjciLCJzY29wZXMiOiJjYWNoZSJ9.WgPWUSYIie2rUdfuPqHS5mxrkT0lc7KIN7QPBPH4H-U'
+          '';
           tailwind = {
             # Suppress tailwind output so only ghcid log comes through
             command = "echo Running tailwind silently.; ${lib.getExe pkgs.haskellPackages.tailwind} -w -o ./static/tailwind.css './src/**/*.hs' > tailwind.log 2>&1";

--- a/nix/modules/flake-parts/haskell.nix
+++ b/nix/modules/flake-parts/haskell.nix
@@ -49,6 +49,7 @@
         vira = {
           extraBuildDepends = [
             pkgs.git
+            pkgs.cachix
             inputs'.omnix.packages.default
           ];
           stan = true;

--- a/src/Vira/App/CLI.hs
+++ b/src/Vira/App/CLI.hs
@@ -27,6 +27,16 @@ data RepoSettings = RepoSettings
   -- ^ Repositories (git clone URL) to watch and build
   , branchWhitelist :: Set Text
   -- ^ Limit to building these branches to build
+  , cachix :: Maybe CachixSettings
+  -- ^ Cachix settings
+  }
+  deriving stock (Show)
+
+data CachixSettings = CachixSettings
+  { cachixName :: Text
+  -- ^ Name of the cachix cache
+  , authToken :: Text
+  -- ^ Auth token for the cachix cache
   }
   deriving stock (Show)
 
@@ -77,7 +87,39 @@ instance HasParser RepoSettings where
         , name "branch-whitelist"
         , value defaultBranchesToBuild
         ]
+    cachix <- Just <$> subSettings "cachix"
     pure RepoSettings {..}
+
+instance HasParser CachixSettings where
+  settingsParser = withoutConfig $ do
+    cachixName <-
+      setting
+        [ reader str
+        , metavar "CACHIX_NAME"
+        , help "Name of the cachix cache"
+        , name "name"
+        , value $ cachixName dummyCachix
+        ]
+    authToken <-
+      setting
+        [ reader str
+        , metavar "CACHIX_AUTH_TOKEN"
+        , help "Auth token for the cachix cache"
+        , name "auth-token"
+        , value $ authToken dummyCachix
+        ]
+    pure CachixSettings {..}
+
+{- | A dummy cache used in development only
+
+Managed by Srid: https://app.cachix.org/cache/scratch-vira-dev
+-}
+dummyCachix :: CachixSettings
+dummyCachix =
+  CachixSettings
+    { cachixName = "scratch-vira-dev"
+    , authToken = "eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiI5NDI4ZjhkZi1mZWM5LTQ1ZjctYjMzYi01MTFiZTljNTNkNjciLCJzY29wZXMiOiJjYWNoZSJ9.WgPWUSYIie2rUdfuPqHS5mxrkT0lc7KIN7QPBPH4H-U"
+    }
 
 defaultRepos :: [Text]
 defaultRepos =

--- a/src/Vira/App/CLI.hs
+++ b/src/Vira/App/CLI.hs
@@ -87,7 +87,7 @@ instance HasParser RepoSettings where
         , name "branch-whitelist"
         , value defaultBranchesToBuild
         ]
-    cachix <- Just <$> subSettings "cachix"
+    cachix <- optional $ subSettings "cachix"
     pure RepoSettings {..}
 
 instance HasParser CachixSettings where
@@ -98,7 +98,6 @@ instance HasParser CachixSettings where
         , metavar "CACHIX_NAME"
         , help "Name of the cachix cache"
         , name "name"
-        , value $ cachixName dummyCachix
         ]
     authToken <-
       setting
@@ -106,20 +105,8 @@ instance HasParser CachixSettings where
         , metavar "CACHIX_AUTH_TOKEN"
         , help "Auth token for the cachix cache"
         , name "auth-token"
-        , value $ authToken dummyCachix
         ]
     pure CachixSettings {..}
-
-{- | A dummy cache used in development only
-
-Managed by Srid: https://app.cachix.org/cache/scratch-vira-dev
--}
-dummyCachix :: CachixSettings
-dummyCachix =
-  CachixSettings
-    { cachixName = "scratch-vira-dev"
-    , authToken = "eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiI5NDI4ZjhkZi1mZWM5LTQ1ZjctYjMzYi01MTFiZTljNTNkNjciLCJzY29wZXMiOiJjYWNoZSJ9.WgPWUSYIie2rUdfuPqHS5mxrkT0lc7KIN7QPBPH4H-U"
-    }
 
 defaultRepos :: [Text]
 defaultRepos =


### PR DESCRIPTION
Optionally configure auth token in CLI. Then, all builds will have their full outputs (from omnix) pushed to cachix.

Until MVP release, we are hardcoing a placeholder (per-cache) token for testing (`scratch-vira-dev.cachix.org` - not used anywhere else, of course).

<img width="399" alt="image" src="https://github.com/user-attachments/assets/da7a78ef-ee88-426e-9122-065b8e9b9fc9" />


<img width="645" alt="image" src="https://github.com/user-attachments/assets/3866713d-b85e-45f9-8087-9345c6161ac7" />
