### PR TITLE
Add real-time status in top-bar

### DIFF
--- a/nix/modules/flake-parts/haskell.nix
+++ b/nix/modules/flake-parts/haskell.nix
@@ -55,6 +55,9 @@
           ];
           stan = true;
         };
+        servant-event-stream = {
+          broken = false;
+        };
         safe-coloured-text-layout = {
           check = false;
           broken = false;

--- a/src/Vira/Lib/HTMX.hs
+++ b/src/Vira/Lib/HTMX.hs
@@ -1,0 +1,15 @@
+-- | HTMLX utilities
+module Vira.Lib.HTMX where
+
+import Lucid
+import Lucid.Base
+
+-- | The [hyperscript](https://hyperscript.org/) attribute
+hyperscript_ :: Text -> Attributes
+hyperscript_ = makeAttributes "_"
+
+hxSseConnect_ :: Text -> Attributes
+hxSseConnect_ = makeAttributes "sse-connect"
+
+hxSseSwap_ :: Text -> Attributes
+hxSseSwap_ = makeAttributes "sse-swap"

--- a/src/Vira/Status.hs
+++ b/src/Vira/Status.hs
@@ -1,0 +1,37 @@
+-- | Real-time status of the Vira system.
+module Vira.Status where
+
+import Control.Concurrent (threadDelay)
+import Htmx.Lucid.Extra (hxExt_)
+import Lucid
+import Servant.API (SourceIO)
+import Servant.API.EventStream
+import Servant.Types.SourceT qualified as S
+import Vira.Lib.HTMX
+import Prelude hiding (Reader, ask, runReader)
+
+data Status = Status Int (Html ())
+
+instance ToServerEvent Status where
+  toServerEvent (Status ident t) =
+    ServerEvent
+      (Just "status")
+      (Just $ show ident)
+      (Lucid.renderBS t)
+
+handler :: SourceIO Status
+handler = S.fromStepT $ step 0
+  where
+    step (n :: Int) = S.Effect $ do
+      when (n > 0) $
+        threadDelay 1000000
+      let msg = Status n $ do
+            div_ [class_ "flex items-center space-x-4"] $ do
+              b_ "Count"
+              code_ $ toHtml @Text $ show n
+      pure $ S.Yield msg $ step (n + 1)
+
+view :: Html ()
+view = do
+  div_ [hxExt_ "sse", hxSseConnect_ "/status", hxSseSwap_ "status"] $ do
+    "Loading status..."

--- a/src/Vira/Toplevel.hs
+++ b/src/Vira/Toplevel.hs
@@ -21,8 +21,9 @@ import Network.Wai.Middleware.Static (
  )
 import OptEnvConf qualified
 import Paths_vira qualified
-import Servant.API (Get, NamedRoutes, (:>))
+import Servant.API (Get, NamedRoutes, SourceIO, (:>))
 import Servant.API.ContentTypes.Lucid (HTML)
+import Servant.API.EventStream (ServerSentEvents)
 import Servant.API.Generic (GenericMode (type (:-)))
 import Servant.Links (Link, fieldLink, linkURI)
 import Servant.Server.Generic (AsServer, genericServe)
@@ -35,6 +36,7 @@ import Vira.Page.RegistryPage qualified as RegistryPage
 import Vira.Page.RepoPage qualified as RepoPage
 import Vira.State.Core (closeViraState, openViraState)
 import Vira.State.Type qualified as State
+import Vira.Status qualified as Status
 import Vira.Supervisor qualified
 import Vira.Widgets qualified as W
 import Prelude hiding (Reader, ask, runReader)
@@ -44,6 +46,7 @@ data Routes mode = Routes
   , _repos :: mode :- "r" Servant.API.:> NamedRoutes RegistryPage.Routes
   , _jobs :: mode :- "j" Servant.API.:> NamedRoutes JobPage.Routes
   , _about :: mode :- "about" Servant.API.:> Get '[HTML] (Html ())
+  , _status :: mode :- "status" Servant.API.:> ServerSentEvents (SourceIO Status.Status)
   }
   deriving stock (Generic)
 
@@ -63,6 +66,7 @@ handlers cfg =
         pure $ W.layout cfg.linkTo "About Vira" [About] $ do
           div_ $ do
             a_ [href_ "https://github.com/juspay/vira"] "GitHub Repo"
+    , _status = pure Status.handler
     }
   where
     linkText = show . linkURI

--- a/static/tailwind.css
+++ b/static/tailwind.css
@@ -560,6 +560,9 @@
   .w-24 {
     width: calc(var(--spacing) * 24);
   }
+  .flex-1 {
+    flex: 1;
+  }
   .items-center {
     align-items: center;
   }

--- a/vira.cabal
+++ b/vira.cabal
@@ -84,9 +84,12 @@ common library-shared
     , relude                 >=1.0
     , safecopy
     , servant
+    , servant-event-stream
     , servant-server
     , shower
     , sqlite-simple
+    , stm
+    , streaming
     , time
     , wai-extra
     , wai-middleware-static
@@ -108,6 +111,7 @@ library
     Vira.App.Servant
     Vira.App.Stack
     Vira.Lib.Git
+    Vira.Lib.HTMX
     Vira.Lib.Omnix
     Vira.Lib.Process
     Vira.Page.JobPage
@@ -116,6 +120,7 @@ library
     Vira.State.Acid
     Vira.State.Core
     Vira.State.Type
+    Vira.Status
     Vira.Supervisor
     Vira.Supervisor.Type
     Vira.Toplevel


### PR DESCRIPTION
Presently, this just shows a clock. Next, we'll modify it to show build status.

Uses https://htmx.org/extensions/sse/ with servant.

---

<img width="127" alt="image" src="https://github.com/user-attachments/assets/027b7b96-1779-4ae9-b96a-14ad84a33ec2" />

.

<img width="552" alt="image" src="https://github.com/user-attachments/assets/9cc0aa8b-bff9-417d-a445-0de364517fad" />
