### PR TITLE
Use htmx-sse fork; to fix leaky connections

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "static/htmx-extensions"]
+	path = static/htmx-extensions
+	url = git@github.com:juspay/htmx-extensions.git
+	branch = sse-unload

--- a/src/Vira/Widgets.hs
+++ b/src/Vira/Widgets.hs
@@ -35,7 +35,11 @@ layout linkTo heading crumbs content = do
     htmx = do
       script_ [src_ "https://unpkg.com/htmx.org@2.0.3", integrity_ "sha384-0895/pl2MU10Hqc6jd4RvrthNlDiE9U1tWmX7WRESftEDRosgxNsQG/Ze9YMRzHq", crossorigin_ "anonymous"] $ mempty @Text
       script_ [src_ "https://unpkg.com/hyperscript.org@0.9.13"] $ mempty @Text
-      script_ [src_ "https://unpkg.com/htmx-ext-sse@2.2.2"] $ mempty @Text
+      script_ [src_ "https://unpkg.com/htmx-ext-debug@2.0.0/debug.js"] $ mempty @Text
+      -- We use a fork of htmx-ext-sse
+      -- See https://github.com/bigskysoftware/htmx-extensions/pull/147
+      -- script_ [src_ "https://unpkg.com/htmx-ext-sse@2.2.2"] $ mempty @Text
+      script_ [src_ "/htmx-extensions/src/sse/sse.js"] $ mempty @Text
 
 -- | Show breadcrumbs at the top of the page for navigation to parent routes
 breadcrumbs :: [(Html (), URI)] -> Html ()


### PR DESCRIPTION
On Google Chrome the issue is that overtime the connections hang, which is due to the SSE connections never getting closed and accumulating over time. This is not a problem on Safari.

Uses `htmx-sse` fork: https://github.com/bigskysoftware/htmx-extensions/pull/147