### PR TITLE
Show real-time job status in nav bar

### DIFF
--- a/src/Vira/State/Acid.hs
+++ b/src/Vira/State/Acid.hs
@@ -92,6 +92,12 @@ getJobsByBranchA repo branch = do
   ViraState {jobs} <- ask
   pure $ Ix.toDescList (Proxy @JobId) $ jobs @= repo @= branch
 
+-- | Get all running jobs
+getRunningJobs :: Query ViraState [Job]
+getRunningJobs = do
+  ViraState {jobs} <- ask
+  pure $ Ix.toList $ jobs @+ [JobPending, JobRunning]
+
 getJobA :: JobId -> Query ViraState (Maybe Job)
 getJobA jobId = do
   ViraState {jobs} <- ask
@@ -163,6 +169,7 @@ $( makeAcidic
     , 'setRepoA
     , 'setRepoBranchesA
     , 'getJobsByBranchA
+    , 'getRunningJobs
     , 'getJobA
     , 'addNewJobA
     , 'jobUpdateStatusA

--- a/src/Vira/State/Type.hs
+++ b/src/Vira/State/Type.hs
@@ -81,7 +81,7 @@ data Job = Job
   }
   deriving stock (Generic, Show, Typeable, Data, Eq, Ord)
 
-type JobIxs = '[RepoName, BranchName, CommitID, JobId]
+type JobIxs = '[RepoName, BranchName, CommitID, JobId, JobStatus]
 type IxJob = IxSet JobIxs Job
 
 instance Indexable JobIxs Job where
@@ -91,6 +91,7 @@ instance Indexable JobIxs Job where
       (ixFun $ \Job {jobBranch} -> [jobBranch])
       (ixFun $ \Job {jobCommit} -> [jobCommit])
       (ixFun $ \Job {jobId} -> [jobId])
+      (ixFun $ \Job {jobStatus} -> [jobStatus])
 
 data JobStatus
   = JobPending

--- a/src/Vira/Supervisor/Type.hs
+++ b/src/Vira/Supervisor/Type.hs
@@ -10,7 +10,7 @@ data TaskState
   = Running
   | Finished ExitCode
   | Killed
-  deriving stock (Generic, Show)
+  deriving stock (Eq, Generic, Show)
 
 {- | Supervisor for managing tasks
 


### PR DESCRIPTION
Running builds now show up in real-time on the top-right of the page (no need for page refresh), thanks to SSE.

For eg., if two builds are running at the same time, they show up like this. You can click this to go to the build log.

<img width="281" alt="image" src="https://github.com/user-attachments/assets/2c82b9f4-8b95-4456-b19b-6ea4b5c22011" />
