### PR TITLE
Allow setting `<base>` URL from CLI

### DIFF
--- a/src/Vira/App/CLI.hs
+++ b/src/Vira/App/CLI.hs
@@ -24,6 +24,8 @@ data Settings = Settings
   -- ^ Repositories settings
   , instanceName :: Text
   -- ^ Name of the instance; uses hostname if unspecified
+  , basePath :: Text
+  -- ^ Base URL path for the http server
   }
   deriving stock (Show)
 
@@ -87,6 +89,14 @@ instance HasParser Settings where
         , help "Name of the instance; uses hostname if unspecified"
         , name "instance-name"
         , value ""
+        ]
+    basePath <-
+      setting
+        [ reader str
+        , metavar "BASE_PATH"
+        , help "Base URL path for the http server"
+        , name "base-path"
+        , value "/"
         ]
     pure Settings {..}
 

--- a/src/Vira/Lib/HTMX.hs
+++ b/src/Vira/Lib/HTMX.hs
@@ -1,8 +1,11 @@
 -- | HTMLX utilities
 module Vira.Lib.HTMX where
 
+import Htmx.Lucid.Core (hxPost_)
 import Lucid
 import Lucid.Base
+import Servant.API (toUrlPiece)
+import Servant.Links (Link)
 
 -- | The [hyperscript](https://hyperscript.org/) attribute
 hyperscript_ :: Text -> Attributes
@@ -13,3 +16,9 @@ hxSseConnect_ = makeAttributes "sse-connect"
 
 hxSseSwap_ :: Text -> Attributes
 hxSseSwap_ = makeAttributes "sse-swap"
+
+-- Fixed version of functions in htmx-servant
+-- https://github.com/JonathanLorimer/htmx/issues/16
+
+hxPostSafe_ :: Link -> Attributes
+hxPostSafe_ = hxPost_ . toUrlPiece

--- a/src/Vira/Page/RepoPage.hs
+++ b/src/Vira/Page/RepoPage.hs
@@ -8,7 +8,6 @@ import Effectful (Eff)
 import Effectful.Error.Static (throwError)
 import Effectful.Reader.Dynamic (ask, asks)
 import Htmx.Lucid.Core (hxSwapS_)
-import Htmx.Servant.Lucid (hxPostSafe_)
 import Htmx.Servant.Response
 import Htmx.Swap (Swap (AfterEnd))
 import Lucid
@@ -19,6 +18,7 @@ import Vira.App qualified as App
 import Vira.App.LinkTo.Type (LinkTo (RepoUpdate))
 import Vira.App.LinkTo.Type qualified as LinkTo
 import Vira.Lib.Git qualified as Git
+import Vira.Lib.HTMX (hxPostSafe_)
 import Vira.Page.JobPage qualified as JobPage
 import Vira.State.Acid qualified as St
 import Vira.State.Core qualified as St

--- a/src/Vira/Widgets.hs
+++ b/src/Vira/Widgets.hs
@@ -9,6 +9,7 @@ module Vira.Widgets (
 import Lucid
 import Servant.Links (Link, URI (..), linkURI)
 import Vira.App (AppState (linkTo, settings), instanceName)
+import Vira.App.CLI (Settings (basePath))
 import Vira.App.LinkTo.Type (LinkTo, linkShortTitle)
 import Vira.Lib.HTMX
 import Vira.Status qualified as Status
@@ -21,9 +22,9 @@ layout cfg heading crumbs content = do
     head_ $ do
       mobileFriendly
       title_ $ toHtml @Text $ "Vira (" <> cfg.settings.instanceName <> ")"
-      base_ [href_ "/"]
+      base_ [href_ cfg.settings.basePath]
       htmx
-      link_ [rel_ "stylesheet", type_ "text/css", href_ "/tailwind.css"]
+      link_ [rel_ "stylesheet", type_ "text/css", href_ "tailwind.css"]
     body_ [class_ "bg-gray-100"] $ do
       div_ [class_ "container mx-auto p-4 mt-8 bg-white"] $ do
         let crumbs' = crumbs <&> \l -> (toHtml $ linkShortTitle l, linkURI $ cfg.linkTo l)
@@ -42,7 +43,7 @@ layout cfg heading crumbs content = do
       -- We use a fork of htmx-ext-sse
       -- See https://github.com/bigskysoftware/htmx-extensions/pull/147
       -- script_ [src_ "https://unpkg.com/htmx-ext-sse@2.2.2"] $ mempty @Text
-      script_ [src_ "/htmx-extensions/src/sse/sse.js"] $ mempty @Text
+      script_ [src_ "htmx-extensions/src/sse/sse.js"] $ mempty @Text
 
 -- | Show breadcrumbs at the top of the page for navigation to parent routes
 breadcrumbs :: (LinkTo -> Link) -> [(Html (), URI)] -> Html ()


### PR DESCRIPTION
This is useful when reverse proxying from nginx[^n] and the like.

Also, use forked `hxPostSafe_` for correct behaviour (see https://github.com/JonathanLorimer/htmx/issues/16).

[^n]: For example, with this config:
    ```nix
      services.nginx = {
        enable = true;
        additionalModules = with pkgs.nginxModules; [ subsFilter ];
        virtualHosts."pureintent" =
          let
            viraPrefix = "vira";
          in {
            locations."/${viraPrefix}/" = {
              proxyPass = "http://localhost:5005/";
              proxyWebsockets = true;
            };
          };
      };
    ```