### PR TITLE
Stream build log in real-time

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -16,6 +16,8 @@
       - "-XTypeApplications"
       - "-XViewPatterns"
 - ignore:
+      name: Use if
+- ignore:
       name: Use head
 - ignore:
       name: Use Foldable.forM_

--- a/nix/modules/flake-parts/devshell.nix
+++ b/nix/modules/flake-parts/devshell.nix
@@ -16,6 +16,7 @@
         # vira extraBuildDepends from haskell.nix
         git
         cachix
+        coreutils # For `tail`
         inputs'.omnix.packages.default
       ];
     };

--- a/nix/modules/flake-parts/haskell.nix
+++ b/nix/modules/flake-parts/haskell.nix
@@ -62,6 +62,7 @@
           extraBuildDepends = [
             pkgs.git
             pkgs.cachix
+            pkgs.coreutils # For `tail`
             inputs'.omnix.packages.default
           ];
           stan = true;

--- a/src/Vira/App/LinkTo/Resolve.hs
+++ b/src/Vira/App/LinkTo/Resolve.hs
@@ -22,4 +22,5 @@ linkTo = \case
   Build repo branch -> fieldLink _jobs // JobPage._build /: repo /: branch
   Job jobId -> fieldLink _jobs // JobPage._view /: jobId
   JobLog jobId -> fieldLink _jobs // JobPage._log /: jobId // JobLog._rawLog
+  JobLogStream jobId -> fieldLink _jobs // JobPage._log /: jobId // JobLog._streamLog
   StatusGet -> fieldLink _status // Status._get

--- a/src/Vira/App/LinkTo/Type.hs
+++ b/src/Vira/App/LinkTo/Type.hs
@@ -16,6 +16,7 @@ data LinkTo
   | Build RepoName BranchName
   | Job JobId
   | JobLog JobId
+  | JobLogStream JobId
   | StatusGet
   | About
 
@@ -28,5 +29,6 @@ linkShortTitle = \case
   Build _ _ -> "Build" -- unused
   Job jobId -> "Job " <> show jobId
   JobLog jobId -> "Job Log " <> show jobId
+  JobLogStream jobId -> "Job Log Stream " <> show jobId
   StatusGet -> "Status"
   About -> "About"

--- a/src/Vira/Lib/HTMX.hs
+++ b/src/Vira/Lib/HTMX.hs
@@ -17,6 +17,9 @@ hxSseConnect_ = makeAttributes "sse-connect"
 hxSseSwap_ :: Text -> Attributes
 hxSseSwap_ = makeAttributes "sse-swap"
 
+hxSseClose_ :: Text -> Attributes
+hxSseClose_ = makeAttributes "sse-close"
+
 -- Fixed version of functions in htmx-servant
 -- https://github.com/JonathanLorimer/htmx/issues/16
 

--- a/src/Vira/Lib/Process/TailF.hs
+++ b/src/Vira/Lib/Process/TailF.hs
@@ -1,0 +1,50 @@
+-- | `tail -f` streaming in Haskell
+module Vira.Lib.Process.TailF where
+
+import Control.Concurrent (forkIO, threadDelay)
+import Control.Concurrent.STM (TQueue, flushTQueue, newTQueueIO, writeTQueue)
+import System.IO (hGetLine)
+import System.Process (CreateProcess (std_out), ProcessHandle, StdStream (CreatePipe), createProcess, proc)
+
+-- Represent a `tail -f` process along with its output gathered up in TChat
+data TailF = TailF FilePath (TQueue Text)
+
+new :: FilePath -> IO TailF
+new filePath = do
+  TailF filePath <$> newTQueueIO
+
+run :: TailF -> IO ProcessHandle
+run (TailF filePath chan) = do
+  -- Run `tail -f` using System.Process and stream its output to chan
+  (_, Just hOut, _, ph) <-
+    createProcess
+      ( proc
+          "tail"
+          [ "-n"
+          , "+1" -- This reads whole file; cf. https://askubuntu.com/a/509915/26624
+          , "-f"
+          , filePath
+          ]
+      )
+        { std_out = CreatePipe
+        }
+  hSetBuffering hOut LineBuffering
+  void $ forkIO $ do
+    let loop = do
+          hIsEOF hOut >>= \case
+            True -> pass
+            False -> do
+              line <- hGetLine hOut
+              atomically $ writeTQueue chan $ toText line
+              loop
+    loop
+  -- Give the process a chance to start up
+  threadDelay 100_000
+  pure ph
+
+tryRead :: TailF -> IO (Maybe Text)
+tryRead (TailF _ chan) = do
+  ls <- atomically $ flushTQueue chan
+  if null ls
+    then pure Nothing
+    else pure $ Just $ unlines ls

--- a/src/Vira/Lib/Process/TailF.hs
+++ b/src/Vira/Lib/Process/TailF.hs
@@ -50,7 +50,13 @@ tryRead (TailF _ _ chan) = do
     then pure Nothing
     else pure $ Just $ unlines ls
 
-stop :: TailF -> IO ()
-stop (TailF _ ph _) = do
+-- | Stop the tail process, and then returning the unread lines (the last lines, generally)
+stop :: TailF -> IO (Maybe Text)
+stop t@(TailF _ ph _) = do
+  -- HACK: Give the process a chance to finish writing to the queue
+  threadDelay 1000_000
+  s <- tryRead t
+  -- Then terminate.
   terminateProcess ph
   void $ waitForProcess ph
+  pure s

--- a/src/Vira/Lib/Process/TailF.hs
+++ b/src/Vira/Lib/Process/TailF.hs
@@ -31,7 +31,7 @@ run filePath chan = do
         }
   hSetBuffering hOut LineBuffering
   void $ forkIO $ do
-    let loop = do
+    let loop =
           hIsEOF hOut >>= \case
             True -> pass
             False -> do

--- a/src/Vira/Page/JobLog.hs
+++ b/src/Vira/Page/JobLog.hs
@@ -46,12 +46,12 @@ rawLogHandler jobId = do
   pure $ decodeUtf8 logText
 
 data LogChunk
-  = Chunk Int (Maybe TailF) (Html ())
+  = Chunk Int (Html ())
   | Stop Int
 
 instance ToServerEvent LogChunk where
   toServerEvent = \case
-    Chunk ident _handle t ->
+    Chunk ident t ->
       ServerEvent
         (Just "logchunk")
         (Just $ show ident)
@@ -93,7 +93,7 @@ streamHandler cfg jobId = S.fromStepT $ step 0 Nothing
           -- FIXME: Why poll after this?
           pure $ S.Yield (Stop n) $ step (n + 1) (Just logTail)
         (Just line, _) -> do
-          let msg = Chunk n (Just logTail) (pre_ $ toHtml line)
+          let msg = Chunk n (pre_ $ toHtml line)
           pure $ S.Yield msg $ step (n + 1) (Just logTail)
 
 viewStream :: (LinkTo.LinkTo -> Link) -> St.Job -> Html ()

--- a/src/Vira/Page/JobLog.hs
+++ b/src/Vira/Page/JobLog.hs
@@ -5,7 +5,8 @@
 
 module Vira.Page.JobLog where
 
-import Control.Concurrent (threadDelay)
+import Control.Concurrent (forkIO, threadDelay)
+import Control.Concurrent.STM (TChan, newTChanIO, tryReadTChan, writeTChan)
 import Effectful (Eff)
 import Effectful.Error.Static (throwError)
 import Htmx.Lucid.Core (hxSwap_)
@@ -16,7 +17,8 @@ import Servant.API.EventStream (ServerEvent (ServerEvent), ServerSentEvents, ToS
 import Servant.Server.Generic (AsServer)
 import Servant.Types.SourceT qualified as S
 import System.FilePath ((</>))
-import System.IO (hClose, hGetLine, openFile)
+import System.IO (hGetLine)
+import System.Process (CreateProcess (std_out), ProcessHandle, StdStream (CreatePipe), createProcess, proc, terminateProcess)
 import Vira.App qualified as App
 import Vira.App.LinkTo.Type qualified as LinkTo
 import Vira.Lib.HTMX (hxSseConnect_, hxSseSwap_)
@@ -47,7 +49,7 @@ rawLogHandler jobId = do
     liftIO $ readFileBS $ job.jobWorkingDir </> "output.log"
   pure $ decodeUtf8 logText
 
-data LogChunk = LogChunk Int (Maybe Handle) (Html ())
+data LogChunk = LogChunk Int (Maybe TailF) (Html ())
 
 instance ToServerEvent LogChunk where
   toServerEvent (LogChunk ident _handle t) =
@@ -56,37 +58,72 @@ instance ToServerEvent LogChunk where
       (Just $ show ident)
       (Lucid.renderBS t)
 
+-- Represent a `tail -f` process along with its output gathered up in TChat
+data TailF = TailF Int FilePath (TChan Text)
+
+newTailF :: Int -> FilePath -> IO TailF
+newTailF n filePath = do
+  TailF n filePath <$> newTChanIO
+
+runTailF :: TailF -> IO ProcessHandle
+runTailF (TailF n filePath chan) = do
+  -- Run `tail -f` using System.Process and stream its output to chan
+  (_, Just hOut, _, ph) <- createProcess (proc "tail" ["-n", show n, "-f", filePath]) {std_out = CreatePipe}
+  hSetBuffering hOut LineBuffering
+  -- hSeek hOut AbsoluteSeek 0
+  void $ forkIO $ do
+    let loop = do
+          hIsEOF hOut >>= \case
+            True -> pass
+            False -> do
+              line <- hGetLine hOut
+              atomically $ writeTChan chan $ toText line
+              loop
+    loop
+  pure ph
+
+tryReadTailF :: TailF -> IO (Maybe Text)
+tryReadTailF (TailF _ _ chan) = atomically $ tryReadTChan chan
+
 streamHandler :: App.AppState -> JobId -> S.SourceT IO LogChunk
 streamHandler cfg jobId = S.fromStepT $ step 0 Nothing
   where
-    step (n :: Int) (mh :: Maybe Handle) = S.Effect $ do
+    step (n :: Int) (mh :: Maybe (TailF, ProcessHandle)) = S.Effect $ do
       job :: Job <-
         App.runApp cfg $
           App.query (St.GetJobA jobId)
             >>= maybe (error "Job not found") pure
       let jobActive = job.jobStatus == St.JobRunning || job.jobStatus == St.JobPending
       let logFile = job.jobWorkingDir </> "output.log"
-      h <- maybe (liftIO $ openFile logFile ReadMode) pure mh
+      (h, p) <-
+        maybe
+          ( liftIO $ do
+              t <- newTailF 1000 logFile
+              p <- runTailF t
+              pure (t, p)
+          )
+          pure
+          mh
       -- TODO:
       -- 1. Read last N lines, rather than reading from scratch
       -- 2. Send chunks, not single line. And delay?
-      eof <- liftIO $ hIsEOF h
-      case (eof, jobActive) of
-        (True, True) -> do
+      mLine <- tryReadTailF h
+      case (mLine, jobActive) of
+        (Nothing, True) -> do
           threadDelay 100_000
-          pure $ S.Skip $ step (n + 1) (Just h)
-        (True, False) -> do
-          liftIO $ hClose h
+          pure $ S.Skip $ step (n + 1) (Just (h, p))
+        (Nothing, False) -> do
+          -- TODO: Drain all of tail -f's output first
+          terminateProcess p
           -- FIXME:
           -- pure S.Stop
           putStrLn "!!!!!! Due to sse bug, waiting infinitely"
           forever $ do
             threadDelay 1_000_000_000
             pure S.Stop
-        (False, _) -> do
-          chunk <- liftIO $ hGetLine h
-          let msg = LogChunk n (Just h) (pre_ $ toHtml chunk)
-          pure $ S.Yield msg $ step (n + 1) (Just h)
+        (Just line, _) -> do
+          let msg = LogChunk n (Just h) (pre_ $ toHtml line)
+          pure $ S.Yield msg $ step (n + 1) (Just (h, p))
 
 viewStream :: (LinkTo.LinkTo -> Link) -> St.Job -> Html ()
 viewStream linkTo job = do
@@ -96,14 +133,13 @@ viewStream linkTo job = do
         a_
           [target_ "blank", class_ "underline text-blue-500", href_ $ show . linkURI $ linkTo $ LinkTo.JobLog job.jobId]
           "View Full Log"
-    pre_ [class_ "bg-black text-white p-2 text-xs"] $ code_ $ do
-      let streamLink = show . linkURI $ linkTo $ LinkTo.JobLogStream job.jobId
-      div_
-        [ hxExt_ "sse"
-        , hxSseConnect_ streamLink
-        , hxSwap_ "beforeend"
-        , hxSseSwap_ "logchunk"
-        ]
-        $ do
-          "Loading log ..."
+    let streamLink = show . linkURI $ linkTo $ LinkTo.JobLogStream job.jobId
+    let sseAttrs =
+          [ hxExt_ "sse"
+          , hxSseConnect_ streamLink
+          , hxSwap_ "beforeend"
+          , hxSseSwap_ "logchunk"
+          ]
+    pre_ (sseAttrs <> [class_ "bg-black text-white p-2 text-xs", style_ "white-space: pre-wrap;"]) $ code_ $ do
+      "Loading log ..."
     div_ "TODO: add running or finished indicator"

--- a/src/Vira/Page/JobLog.hs
+++ b/src/Vira/Page/JobLog.hs
@@ -49,52 +49,66 @@ data LogChunk
   = Chunk Int (Html ())
   | Stop Int
 
+logChunkType :: LogChunk -> Text
+logChunkType = \case
+  Chunk _ _ -> "logchunk"
+  Stop _ -> "logstop"
+
+logChunkId :: LogChunk -> LByteString
+logChunkId = \case
+  Chunk ident _ -> show ident
+  Stop ident -> show ident
+
+logChunkMsg :: LogChunk -> LByteString
+logChunkMsg = \case
+  Chunk _ html -> Lucid.renderBS html
+  Stop _ -> "Log stopped"
+
 instance ToServerEvent LogChunk where
-  toServerEvent = \case
-    Chunk ident t ->
-      ServerEvent
-        (Just "logchunk")
-        (Just $ show ident)
-        (Lucid.renderBS t)
-    Stop ident ->
-      ServerEvent
-        (Just "logstop")
-        (Just $ show ident)
-        (Lucid.renderBS "Log stopped")
+  toServerEvent chunk =
+    ServerEvent
+      (Just $ encodeUtf8 $ logChunkType chunk)
+      (Just $ logChunkId chunk)
+      (logChunkMsg chunk)
+
+data StreamState = Init | Streaming TailF | Stopping
 
 streamHandler :: App.AppState -> JobId -> S.SourceT IO LogChunk
-streamHandler cfg jobId = S.fromStepT $ step 0 Nothing
+streamHandler cfg jobId = S.fromStepT $ step 0 Init
   where
-    step (n :: Int) (mh :: Maybe TailF) = S.Effect $ do
+    step (n :: Int) (st :: StreamState) = S.Effect $ do
       job :: Job <-
         App.runApp cfg $
           App.query (St.GetJobA jobId)
             >>= maybe (error "Job not found") pure
-      let jobActive = job.jobStatus == St.JobRunning || job.jobStatus == St.JobPending
       let logFile = job.jobWorkingDir </> "output.log"
-      logTail <-
-        maybe (liftIO $ TailF.new logFile) pure mh
-      -- TODO:
-      -- 1. Read last N lines, rather than reading from scratch
-      -- 2. Send chunks, not single line. And delay?
+      case st of
+        Init -> do
+          logTail <- liftIO $ TailF.new logFile
+          streamLog n job logTail
+        Streaming logTail -> do
+          streamLog n job logTail
+        Stopping -> do
+          -- Keep going unless client has time to catch up.
+          threadDelay 1000_000
+          pure $ S.Yield (Stop n) $ step (n + 1) st
+    streamLog n job logTail = do
+      let jobActive = job.jobStatus == St.JobRunning || job.jobStatus == St.JobPending
       mLine <- TailF.tryRead logTail
       case (mLine, jobActive) of
         (Nothing, True) -> do
           -- Job is active, but log yet to be updated; retry.
           threadDelay 100_000
-          pure $ S.Skip $ step (n + 1) (Just logTail)
+          pure $ S.Skip $ step n (Streaming logTail)
         (Nothing, False) -> do
           -- Job ended
           -- TODO: Drain all of tail -f's output first
           putStrLn "Job ended; ending stream"
           TailF.stop logTail
-          -- This delay is required lest we are called again.
-          threadDelay 1000_000
-          -- FIXME: Why poll after this?
-          pure $ S.Yield (Stop n) $ step (n + 1) (Just logTail)
+          pure $ S.Yield (Stop n) $ step (n + 1) Stopping
         (Just line, _) -> do
           let msg = Chunk n (pre_ $ toHtml line)
-          pure $ S.Yield msg $ step (n + 1) (Just logTail)
+          pure $ S.Yield msg $ step (n + 1) (Streaming logTail)
 
 viewStream :: (LinkTo.LinkTo -> Link) -> St.Job -> Html ()
 viewStream linkTo job = do
@@ -109,8 +123,8 @@ viewStream linkTo job = do
           [ hxExt_ "sse"
           , hxSseConnect_ streamLink
           , hxSwap_ "beforeend show:window:bottom"
-          , hxSseSwap_ "logchunk"
-          , hxSseClose_ "logstop"
+          , hxSseSwap_ $ logChunkType $ Chunk 0 mempty
+          , hxSseClose_ $ logChunkType $ Stop 0
           ]
     pre_ (sseAttrs <> [class_ "bg-black text-white p-2 text-xs", style_ "white-space: pre-wrap;"]) $ code_ $ do
       "Loading log ..."

--- a/src/Vira/Page/JobLog.hs
+++ b/src/Vira/Page/JobLog.hs
@@ -1,20 +1,35 @@
 {-# LANGUAGE OverloadedRecordDot #-}
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+
+{-# HLINT ignore "Use infinitely" #-}
 
 module Vira.Page.JobLog where
 
+import Control.Concurrent (threadDelay)
 import Effectful (Eff)
 import Effectful.Error.Static (throwError)
+import Htmx.Lucid.Core (hxSwap_)
+import Htmx.Lucid.Extra (hxExt_)
+import Lucid
 import Servant hiding (throwError)
+import Servant.API.EventStream (ServerEvent (ServerEvent), ServerSentEvents, ToServerEvent (toServerEvent))
 import Servant.Server.Generic (AsServer)
+import Servant.Types.SourceT qualified as S
 import System.FilePath ((</>))
+import System.IO (hClose, hGetLine, openFile)
 import Vira.App qualified as App
+import Vira.App.LinkTo.Type qualified as LinkTo
+import Vira.Lib.HTMX (hxSseConnect_, hxSseSwap_)
 import Vira.State.Acid qualified as St
-import Vira.State.Type (JobId, jobWorkingDir)
+import Vira.State.Type (Job, JobId, jobWorkingDir)
+import Vira.State.Type qualified as St
 import Prelude hiding (ask, asks)
 
-newtype Routes mode = Routes
+data Routes mode = Routes
   { -- Raw build log
-    _rawLog :: mode :- "log" :> Get '[PlainText] Text
+    _rawLog :: mode :- "raw" :> Get '[PlainText] Text
+  , -- Stream build log
+    _streamLog :: mode :- "stream" :> ServerSentEvents (SourceIO LogChunk)
   }
   deriving stock (Generic)
 
@@ -22,6 +37,7 @@ handlers :: App.AppState -> JobId -> Routes AsServer
 handlers cfg jobId = do
   Routes
     { _rawLog = App.runAppInServant cfg $ rawLogHandler jobId
+    , _streamLog = pure $ streamHandler cfg jobId
     }
 
 rawLogHandler :: JobId -> Eff App.AppServantStack Text
@@ -30,3 +46,64 @@ rawLogHandler jobId = do
   logText <-
     liftIO $ readFileBS $ job.jobWorkingDir </> "output.log"
   pure $ decodeUtf8 logText
+
+data LogChunk = LogChunk Int (Maybe Handle) (Html ())
+
+instance ToServerEvent LogChunk where
+  toServerEvent (LogChunk ident _handle t) =
+    ServerEvent
+      (Just "logchunk")
+      (Just $ show ident)
+      (Lucid.renderBS t)
+
+streamHandler :: App.AppState -> JobId -> S.SourceT IO LogChunk
+streamHandler cfg jobId = S.fromStepT $ step 0 Nothing
+  where
+    step (n :: Int) (mh :: Maybe Handle) = S.Effect $ do
+      job :: Job <-
+        App.runApp cfg $
+          App.query (St.GetJobA jobId)
+            >>= maybe (error "Job not found") pure
+      let jobActive = job.jobStatus == St.JobRunning || job.jobStatus == St.JobPending
+      let logFile = job.jobWorkingDir </> "output.log"
+      h <- maybe (liftIO $ openFile logFile ReadMode) pure mh
+      -- TODO:
+      -- 1. Read last N lines, rather than reading from scratch
+      -- 2. Send chunks, not single line. And delay?
+      eof <- liftIO $ hIsEOF h
+      case (eof, jobActive) of
+        (True, True) -> do
+          threadDelay 100_000
+          pure $ S.Skip $ step (n + 1) (Just h)
+        (True, False) -> do
+          liftIO $ hClose h
+          -- FIXME:
+          -- pure S.Stop
+          putStrLn "!!!!!! Due to sse bug, waiting infinitely"
+          forever $ do
+            threadDelay 1_000_000_000
+            pure S.Stop
+        (False, _) -> do
+          chunk <- liftIO $ hGetLine h
+          let msg = LogChunk n (Just h) (pre_ $ toHtml chunk)
+          pure $ S.Yield msg $ step (n + 1) (Just h)
+
+viewStream :: (LinkTo.LinkTo -> Link) -> St.Job -> Html ()
+viewStream linkTo job = do
+  div_ $ do
+    div_ [class_ "my-2"] $ do
+      p_ $ do
+        a_
+          [target_ "blank", class_ "underline text-blue-500", href_ $ show . linkURI $ linkTo $ LinkTo.JobLog job.jobId]
+          "View Full Log"
+    pre_ [class_ "bg-black text-white p-2 text-xs"] $ code_ $ do
+      let streamLink = show . linkURI $ linkTo $ LinkTo.JobLogStream job.jobId
+      div_
+        [ hxExt_ "sse"
+        , hxSseConnect_ streamLink
+        , hxSwap_ "beforeend"
+        , hxSseSwap_ "logchunk"
+        ]
+        $ do
+          "Loading log ..."
+    div_ "TODO: add running or finished indicator"

--- a/src/Vira/Page/JobPage.hs
+++ b/src/Vira/Page/JobPage.hs
@@ -12,7 +12,6 @@ import Lucid
 import Servant hiding (throwError)
 import Servant.API.ContentTypes.Lucid (HTML)
 import Servant.Server.Generic (AsServer)
-import System.FilePath ((</>))
 import Vira.App qualified as App
 import Vira.App.LinkTo.Type qualified as LinkTo
 import Vira.App.Logging
@@ -54,26 +53,12 @@ buildHandler repoName branch = do
 
 viewHandler :: JobId -> Eff App.AppServantStack (Html ())
 viewHandler jobId = do
-  cfg <- ask
   job <- App.query (St.GetJobA jobId) >>= maybe (throwError err404) pure
-  logText <-
-    -- TODO: Streaming!
-    liftIO $ fmap (decodeUtf8 @Text) . readFileBS $ job.jobWorkingDir </> "output.log"
   let crumbs = [LinkTo.RepoListing, LinkTo.Repo job.jobRepo, LinkTo.Job jobId]
+  cfg <- ask
   pure $ W.layout cfg (show jobId) crumbs $ do
     viewJob cfg.linkTo job
-    div_ $ do
-      let linesToShow = 20
-      div_ [class_ "my-2"] $ do
-        p_ $ do
-          "Displaying only last " <> show linesToShow <> " lines of the log. "
-          a_
-            [target_ "blank", class_ "underline text-blue-500", href_ $ show . linkURI $ cfg.linkTo $ LinkTo.JobLog job.jobId]
-            "View Full Log"
-        p_ "NOTE: You must refresh this page, since logs are not being streamed (yet)"
-      pre_ [class_ "bg-black text-white p-2 text-xs"] $ code_ $ do
-        "[..]\n"
-        toHtml $ getLastNLines linesToShow logText
+    JobLog.viewStream cfg.linkTo job
 
 getLastNLines :: Int -> Text -> Text
 getLastNLines n = unlines . lastN n . lines

--- a/src/Vira/Status.hs
+++ b/src/Vira/Status.hs
@@ -4,6 +4,7 @@
 module Vira.Status (
   -- * Views
   view,
+  indicator,
 
   -- * Route handlers
   Routes (..),

--- a/vira.cabal
+++ b/vira.cabal
@@ -120,6 +120,7 @@ library
     Vira.Lib.HTMX
     Vira.Lib.Omnix
     Vira.Lib.Process
+    Vira.Lib.Process.TailF
     Vira.Page.JobLog
     Vira.Page.JobPage
     Vira.Page.RegistryPage


### PR DESCRIPTION
Stream build log using [SSE](https://htmx.org/extensions/sse/). 

We rely on `tail -f` rather than a direct lead due to concurrency issues with file handles on Haskell. The streaming code should potentially be simplified in future using a streaming library; for now, servant's SourceT does the job.