### PR TITLE
Static log view for finished jobs

### DIFF
--- a/src/Vira/Page/JobLog.hs
+++ b/src/Vira/Page/JobLog.hs
@@ -54,11 +54,5 @@ view linkTo job = do
 viewStaticLog :: (LinkTo -> Link) -> Job -> Eff App.AppServantStack (Html ())
 viewStaticLog linkTo job = do
   logText <- readJobLogFull job
-  pure $ Log.viewLogWith linkTo job $ do
-    pre_
-      [ class_ "bg-black text-white p-2 text-xs"
-      , style_ "white-space: pre-wrap;"
-      ]
-      $ code_
-      $ do
-        toHtml logText
+  pure $ Log.logViewerWidget linkTo job mempty $ do
+    toHtml logText

--- a/src/Vira/Page/JobLog.hs
+++ b/src/Vira/Page/JobLog.hs
@@ -38,12 +38,6 @@ rawLogHandler jobId = do
     liftIO $ readFileBS $ job.jobWorkingDir </> "output.log"
   pure $ decodeUtf8 logText
 
-readJobLogFull :: (MonadIO m) => Job -> m Text
-readJobLogFull job = do
-  logText <-
-    liftIO $ readFileBS $ job.jobWorkingDir </> "output.log"
-  pure $ decodeUtf8 logText
-
 view :: (LinkTo -> Link) -> Job -> Eff App.AppServantStack (Html ())
 view linkTo job = do
   let jobActive = job.jobStatus == St.JobRunning || job.jobStatus == St.JobPending
@@ -56,3 +50,9 @@ viewStaticLog linkTo job = do
   logText <- readJobLogFull job
   pure $ Log.logViewerWidget linkTo job $ do
     toHtml logText
+
+readJobLogFull :: (MonadIO m) => Job -> m Text
+readJobLogFull job = do
+  logText <-
+    liftIO $ readFileBS $ job.jobWorkingDir </> "output.log"
+  pure $ decodeUtf8 logText

--- a/src/Vira/Page/JobLog.hs
+++ b/src/Vira/Page/JobLog.hs
@@ -54,5 +54,5 @@ view linkTo job = do
 viewStaticLog :: (LinkTo -> Link) -> Job -> Eff App.AppServantStack (Html ())
 viewStaticLog linkTo job = do
   logText <- readJobLogFull job
-  pure $ Log.logViewerWidget linkTo job mempty $ do
+  pure $ Log.logViewerWidget linkTo job $ do
     toHtml logText

--- a/src/Vira/Page/RepoPage.hs
+++ b/src/Vira/Page/RepoPage.hs
@@ -90,4 +90,4 @@ viewRepo linkTo repo branches = do
             "Build"
         ul_ $ forM_ jobs $ \job -> do
           li_ [class_ "my-2 py-1"] $ do
-            JobPage.viewJob linkTo job
+            JobPage.viewJobHeader linkTo job

--- a/src/Vira/Stream/Log.hs
+++ b/src/Vira/Stream/Log.hs
@@ -8,6 +8,7 @@ module Vira.Stream.Log (
 
   -- * View
   viewStream,
+  viewLogWith,
 ) where
 
 import Control.Concurrent (threadDelay)
@@ -111,12 +112,7 @@ streamRouteHandler cfg jobId = S.fromStepT $ step 0 Init
 
 viewStream :: (LinkTo.LinkTo -> Link) -> St.Job -> Html ()
 viewStream linkTo job = do
-  div_ $ do
-    div_ [class_ "my-2"] $ do
-      p_ $ do
-        a_
-          [target_ "blank", class_ "underline text-blue-500", href_ $ show . linkURI $ linkTo $ LinkTo.JobLog job.jobId]
-          "View Full Log"
+  viewLogWith linkTo job $ do
     let streamLink = show . linkURI $ linkTo $ LinkTo.JobLogStream job.jobId
     let sseAttrs =
           [ hxExt_ "sse"
@@ -139,3 +135,13 @@ viewStream linkTo job = do
         ]
         $ do
           Status.indicator True
+
+viewLogWith :: (LinkTo.LinkTo -> Link) -> Job -> Html () -> Html ()
+viewLogWith linkTo job w = do
+  div_ $ do
+    div_ [class_ "my-2"] $ do
+      p_ $ do
+        a_
+          [target_ "blank", class_ "underline text-blue-500", href_ $ show . linkURI $ linkTo $ LinkTo.JobLog job.jobId]
+          "View Full Log"
+    w

--- a/src/Vira/Stream/Log.hs
+++ b/src/Vira/Stream/Log.hs
@@ -119,6 +119,7 @@ viewStream linkTo job = do
         , hxSseClose_ $ logChunkType $ Stop 0
         ]
   div_ sseAttrs $ do
+    -- Div containing log messages
     div_
       [ hxSseSwap_ $ logChunkType $ Chunk 0 mempty
       , hxSwap_ "beforeend show:window:bottom"
@@ -127,6 +128,7 @@ viewStream linkTo job = do
       $ do
         logViewerWidget linkTo job $ do
           "Loading log ..."
+    -- Div containing streaming status
     div_
       [ hxSseSwap_ $ logChunkType $ Stop 0
       , hxSwap_ "innerHTML"

--- a/src/Vira/Stream/Log.hs
+++ b/src/Vira/Stream/Log.hs
@@ -125,7 +125,7 @@ viewStream linkTo job = do
       , hxTarget_ ("#" <> sseTarget)
       ]
       $ do
-        logViewerWidget linkTo job [] $ do
+        logViewerWidget linkTo job $ do
           "Loading log ..."
     div_
       [ hxSseSwap_ $ logChunkType $ Stop 0
@@ -135,16 +135,21 @@ viewStream linkTo job = do
         Status.indicator True
 
 -- | Log viewer widget agnostic to static or streaming nature.
-logViewerWidget :: (LinkTo.LinkTo -> Link) -> Job -> [Attributes] -> Html () -> Html ()
-logViewerWidget linkTo job attrs w = do
+logViewerWidget :: (LinkTo.LinkTo -> Link) -> Job -> Html () -> Html ()
+logViewerWidget linkTo job w = do
   div_ $ do
     div_ [class_ "my-2"] $ do
       p_ $ do
         a_
           [target_ "blank", class_ "underline text-blue-500", href_ $ show . linkURI $ linkTo $ LinkTo.JobLog job.jobId]
           "View Full Log"
-    pre_ (attrs <> [id_ sseTarget, class_ "bg-black text-white p-2 text-xs", style_ "white-space: pre-wrap;"]) $ do
-      code_ w
+    pre_
+      [ id_ sseTarget
+      , class_ "bg-black text-white p-2 text-xs"
+      , style_ "white-space: pre-wrap;"
+      ]
+      $ do
+        code_ w
 
 -- | ID of the HTML element targetted by SSE message swaps (log streaming)
 sseTarget :: Text


### PR DESCRIPTION
#20 caused job page for **finished** builds to unnecessarily stream. This PR fixes that by making those views as static (fast) as before.

(The optimization of log streaming itself will happen in another PR)