### PR TITLE
chore: Use `SIGINT` to close Vira gracefully during `just run` shutdown

### DIFF
--- a/nix/modules/flake-parts/haskell.nix
+++ b/nix/modules/flake-parts/haskell.nix
@@ -94,6 +94,8 @@
                   --setup ":set args --cachix-name scratch-vira-dev --cachix-auth-token eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiI5NDI4ZjhkZi1mZWM5LTQ1ZjctYjMzYi01MTFiZTljNTNkNjciLCJzY29wZXMiOiJjYWNoZSJ9.WgPWUSYIie2rUdfuPqHS5mxrkT0lc7KIN7QPBPH4H-U --base-path ''${BASE_PATH:-/}"
             '';
             depends_on.tailwind.condition = "process_started";
+            # Without `SIGINT (2)` Vira doesn't close gracefully
+            shutdown.signal = 2;
           };
           tailwind =
             let


### PR DESCRIPTION
Otherwise the server process remains hanging and requires one to manually find the PID and `kill`