### PR TITLE
feat: Support `attic` caches

### DIFF
--- a/nix/modules/flake-parts/devshell.nix
+++ b/nix/modules/flake-parts/devshell.nix
@@ -16,6 +16,7 @@
         # vira extraBuildDepends from haskell.nix
         git
         cachix
+        attic-client
         coreutils # For `tail`
         omnix
       ];

--- a/nix/modules/flake-parts/haskell.nix
+++ b/nix/modules/flake-parts/haskell.nix
@@ -52,6 +52,7 @@
           extraBuildDepends = [
             pkgs.git
             pkgs.cachix
+            pkgs.attic-client
             pkgs.coreutils # For `tail`
             pkgs.omnix
           ];

--- a/src/Vira/App/CLI.hs
+++ b/src/Vira/App/CLI.hs
@@ -6,6 +6,7 @@ module Vira.App.CLI (
   Settings (..),
   RepoSettings (..),
   CachixSettings (..),
+  AtticSettings (..),
 
   -- * Function
   parseCLI,
@@ -49,6 +50,17 @@ data RepoSettings = RepoSettings
   -- ^ Limit to building these branches to build
   , cachix :: Maybe CachixSettings
   -- ^ Cachix settings
+  , attic :: Maybe AtticSettings
+  }
+  deriving stock (Show)
+
+data AtticSettings = AtticSettings
+  { atticLoginName :: Text
+  -- ^ Login name for attic
+  , atticCacheUrl :: Text
+  -- ^ URL of the attic cache
+  , atticToken :: Text
+  -- ^ Auth token for the attic cache
   }
   deriving stock (Show)
 
@@ -151,7 +163,31 @@ repoSettingsParser = do
           <> showDefault
       )
   cachix <- optional cachixSettingsParser
+  attic <- optional atticSettingsParser
   pure RepoSettings {..}
+
+-- | Parser for AtticSettings
+atticSettingsParser :: Parser AtticSettings
+atticSettingsParser = do
+  atticLoginName <-
+    strOption
+      ( long "attic-login-name"
+          <> metavar "ATTIC_LOGIN_NAME"
+          <> help "Login name for attic"
+      )
+  atticCacheUrl <-
+    strOption
+      ( long "attic-cache-url"
+          <> metavar "ATTIC_CACHE_URL"
+          <> help "URL of the attic cache"
+      )
+  atticToken <-
+    strOption
+      ( long "attic-token"
+          <> metavar "ATTIC_TOKEN"
+          <> help "Auth token for the attic cache"
+      )
+  pure AtticSettings {..}
 
 -- | Parser for CachixSettings
 cachixSettingsParser :: Parser CachixSettings

--- a/src/Vira/App/CLI.hs
+++ b/src/Vira/App/CLI.hs
@@ -59,6 +59,8 @@ data AtticSettings = AtticSettings
   -- ^ Login name for attic
   , atticCacheUrl :: Text
   -- ^ URL of the attic cache
+  , atticCacheName :: Text
+  -- ^ Name of the cache in atticCacheUrl
   , atticToken :: Text
   -- ^ Auth token for the attic cache
   }
@@ -183,9 +185,15 @@ atticSettingsParser = do
       )
   atticToken <-
     strOption
-      ( long "attic-token"
-          <> metavar "ATTIC_TOKEN"
+      ( long "attic-login-token"
+          <> metavar "ATTIC_LOGIN_TOKEN"
           <> help "Auth token for the attic cache"
+      )
+  atticCacheName <-
+    strOption
+      ( long "attic-cache-name"
+          <> metavar "ATTIC_CACHE_NAME"
+          <> help "Name of the cache in ATTIC_CACHE_URL"
       )
   pure AtticSettings {..}
 

--- a/src/Vira/App/CLI.hs
+++ b/src/Vira/App/CLI.hs
@@ -55,14 +55,14 @@ data RepoSettings = RepoSettings
   deriving stock (Show)
 
 data AtticSettings = AtticSettings
-  { atticLoginName :: Text
-  -- ^ Login name for attic
-  , atticCacheUrl :: Text
-  -- ^ URL of the attic cache
+  { atticServerName :: Text
+  -- ^ A shorthand for `atticServerUrl`
+  , atticServerUrl :: Text
+  -- ^ Server address (eg. https://cache.example.org)
   , atticCacheName :: Text
-  -- ^ Name of the cache in atticCacheUrl
+  -- ^ Name of the cache hosted in `atticServerUrl`
   , atticToken :: Text
-  -- ^ Auth token for the attic cache
+  -- ^ Access token for `atticServerUrl`
   }
   deriving stock (Show)
 
@@ -171,29 +171,30 @@ repoSettingsParser = do
 -- | Parser for AtticSettings
 atticSettingsParser :: Parser AtticSettings
 atticSettingsParser = do
-  atticLoginName <-
+  atticServerName <-
     strOption
-      ( long "attic-login-name"
-          <> metavar "ATTIC_LOGIN_NAME"
-          <> help "Login name for attic"
+      ( long "attic-server-name"
+          <> metavar "ATTIC_SERVER_NAME"
+          <> help "A shorthand for ATTIC_SERVER_URL"
       )
-  atticCacheUrl <-
+  atticServerUrl <-
     strOption
-      ( long "attic-cache-url"
-          <> metavar "ATTIC_CACHE_URL"
-          <> help "URL of the attic cache"
+      ( long "attic-server-url"
+          <> metavar "ATTIC_SERVER_URL"
+          <> help "Server address (e.g., https://cache.example.org)"
       )
-  atticToken <-
-    strOption
-      ( long "attic-login-token"
-          <> metavar "ATTIC_LOGIN_TOKEN"
-          <> help "Auth token for the attic cache"
-      )
+
   atticCacheName <-
     strOption
       ( long "attic-cache-name"
           <> metavar "ATTIC_CACHE_NAME"
-          <> help "Name of the cache in ATTIC_CACHE_URL"
+          <> help "Name of the cache hosted in ATTIC_SERVER_URL"
+      )
+  atticToken <-
+    strOption
+      ( long "attic-token"
+          <> metavar "ATTIC_TOKEN"
+          <> help "Access token for ATTIC_SERVER_URL"
       )
   pure AtticSettings {..}
 

--- a/src/Vira/Lib/Attic.hs
+++ b/src/Vira/Lib/Attic.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+-- | Working with cachix
+module Vira.Lib.Attic where
+
+import System.Process (CreateProcess, proc)
+import System.Which (staticWhich)
+
+{- | Path to the `attic` executable
+
+This should be available in the PATH, thanks to Nix and `which` library.
+-}
+atticBin :: FilePath
+atticBin = $(staticWhich "attic")
+
+atticPushProcess :: Text -> Text -> FilePath -> CreateProcess
+atticPushProcess serverName cacheName path = proc atticBin ["push", toString serverName <> ":" <> toString cacheName, path]
+
+{- | Saves the access token for the attic server
+
+Run this process before other attic processes.
+
+TODO: Remove after https://github.com/zhaofengli/attic/issues/243 is resolved to provide stateless access
+-}
+atticLoginProcess :: Text -> Text -> Text -> CreateProcess
+atticLoginProcess serverName serverUrl token = proc atticBin ["login", toString serverName, toString serverUrl, toString token]

--- a/src/Vira/Lib/Attic.hs
+++ b/src/Vira/Lib/Attic.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE TemplateHaskell #-}
 
--- | Working with cachix
+-- | Working with attic cache servers
 module Vira.Lib.Attic where
 
 import System.Process (CreateProcess, proc)

--- a/src/Vira/Lib/Cachix.hs
+++ b/src/Vira/Lib/Cachix.hs
@@ -13,5 +13,15 @@ This should be available in the PATH, thanks to Nix and `which` library.
 cachixBin :: FilePath
 cachixBin = $(staticWhich "cachix")
 
+-- | Path to the `attic` executable
+atticBin :: FilePath
+atticBin = $(staticWhich "attic")
+
 cachixPushProcess :: Text -> FilePath -> CreateProcess
 cachixPushProcess cache path = proc cachixBin ["push", "-v", toString cache, path]
+
+atticPushProcess :: Text -> FilePath -> CreateProcess
+atticPushProcess cacheIdentifier path = proc atticBin ["push", "-v", toString cacheIdentifier, path]
+
+atticLoginProcess :: Text -> Text -> Text -> CreateProcess
+atticLoginProcess loginName cacheUrl token = proc atticBin ["login", toString loginName, toString cacheUrl, "--token", toString token]

--- a/src/Vira/Lib/Cachix.hs
+++ b/src/Vira/Lib/Cachix.hs
@@ -13,15 +13,5 @@ This should be available in the PATH, thanks to Nix and `which` library.
 cachixBin :: FilePath
 cachixBin = $(staticWhich "cachix")
 
--- | Path to the `attic` executable
-atticBin :: FilePath
-atticBin = $(staticWhich "attic")
-
 cachixPushProcess :: Text -> FilePath -> CreateProcess
 cachixPushProcess cache path = proc cachixBin ["push", "-v", toString cache, path]
-
-atticPushProcess :: Text -> FilePath -> CreateProcess
-atticPushProcess cacheIdentifier path = proc atticBin ["push", toString cacheIdentifier, path]
-
-atticLoginProcess :: Text -> Text -> Text -> CreateProcess
-atticLoginProcess loginName cacheUrl token = proc atticBin ["login", toString loginName, toString cacheUrl, toString token]

--- a/src/Vira/Lib/Cachix.hs
+++ b/src/Vira/Lib/Cachix.hs
@@ -21,7 +21,7 @@ cachixPushProcess :: Text -> FilePath -> CreateProcess
 cachixPushProcess cache path = proc cachixBin ["push", "-v", toString cache, path]
 
 atticPushProcess :: Text -> FilePath -> CreateProcess
-atticPushProcess cacheIdentifier path = proc atticBin ["push", "-v", toString cacheIdentifier, path]
+atticPushProcess cacheIdentifier path = proc atticBin ["push", toString cacheIdentifier, path]
 
 atticLoginProcess :: Text -> Text -> Text -> CreateProcess
-atticLoginProcess loginName cacheUrl token = proc atticBin ["login", toString loginName, toString cacheUrl, "--token", toString token]
+atticLoginProcess loginName cacheUrl token = proc atticBin ["login", toString loginName, toString cacheUrl, toString token]

--- a/src/Vira/Page/JobPage.hs
+++ b/src/Vira/Page/JobPage.hs
@@ -138,6 +138,6 @@ getStages repo branch mCachix mAttic = do
         , cwd = Just "project"
         }
     stageAtticPush attic =
-      (atticPushProcess (attic.atticLoginName <> ":" <> attic.atticCacheUrl) "result")
+      (atticPushProcess (attic.atticLoginName <> ":" <> attic.atticCacheName) "result")
         { cwd = Just "project"
         }

--- a/vira.cabal
+++ b/vira.cabal
@@ -116,6 +116,7 @@ library
     Vira.App.Logging
     Vira.App.Servant
     Vira.App.Stack
+    Vira.Lib.Attic
     Vira.Lib.Cachix
     Vira.Lib.Git
     Vira.Lib.HTMX


### PR DESCRIPTION
resolves #29 

https://github.com/juspay/vira/pull/34/commits/bf23ea6ec0b615fa1159d41e399e43ddd2bbb7fd was generated using Gemini 2.5 pro preview and https://github.com/yetone/avante.nvim

The above commit compiles but doesn’t have the expected runtime behaviour, which was fixed manually in https://github.com/juspay/vira/pull/34/commits/95408b41a8881dfae385448b0b22557f3536a768

TODO:
- [x] Heteroreferential description for attic arguments (done in https://github.com/juspay/vira/pull/34/commits/cbc08417d0cae0ca30648e04bee9b6e5b82b307e)
-  ~~`atticCacheName` can be derived from `atticCacheUrl`~~
   - ~~`atticCacheName` is the path in the `atticCacheUrl`, i.e, in `https://cache.nixos.asia/oss`, `oss` is the `atticCacheName`~~

A screenshot example of how the `jobPage` with the `attic push` looks like:
![image](https://github.com/user-attachments/assets/5897de55-589d-4486-898c-e134b8c159f6)

