### PR TITLE
ci: Switch to github runner for aarch64-darwin

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,18 +7,22 @@ on:
   pull_request:
 jobs:
   build:
-    runs-on: ${{ matrix.system }}
+    runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        # Our Mac Studios are b0rked, so we use GitHub mac runner.
-        system: [x86_64-linux, macos-latest]
+        include:
+          - runner: x86_64-linux
+            system: x86_64-linux
+            # Our Mac Studios are b0rked, so we use GitHub mac runner.
+          - runner: macos-latest
+            system: aarch64-darwin
     steps:
       - uses: actions/checkout@v4
       - name: "Install Nix"
-        if: matrix.system == 'macos-latest'
+        if: matrix.runner == 'macos-latest'
         uses: DeterminateSystems/nix-installer-action@main
       - name: "Install attic and omnix"
-        if: matrix.system == 'macos-latest'
+        if: matrix.runner == 'macos-latest'
         run: |
           nix profile install nixpkgs#attic-client nixpkgs#omnix
       - name: "Attic: Configure"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,13 @@ jobs:
         system: [x86_64-linux, macos-latest]
     steps:
       - uses: actions/checkout@v4
+      - name: "Install Nix"
+        if: matrix.system == 'macos-latest'
+        uses: DeterminateSystems/nix-installer-action@main
+      - name: "Install attic and omnix"
+        if: matrix.system == 'macos-latest'
+        run: |
+          nix profile install nixpkgs#attic-client nixpkgs#omnix
       - name: "Attic: Configure"
         run: |
           attic login chutney https://cache.nixos.asia ${{ secrets.ATTIC_LOGIN_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,10 @@ jobs:
         system: [x86_64-linux, aarch64-darwin]
     steps:
       - uses: actions/checkout@v4
+      - name: "Attic: Configure"
+        run: |
+          attic login chutney https://cache.nixos.asia ${{ secrets.ATTIC_LOGIN_TOKEN }}
+          attic use chutney:oss
       - name: Build all flake outputs
         id: om_ci
         run: |
@@ -21,7 +25,6 @@ jobs:
       - name: Run Tests
         run: |
           nix --option system "${{ matrix.system }}" run .#vira-tests
-      - name: Push to Attic
+      - name: "Attic: Push"
         run: |
-          attic login chutney https://cache.nixos.asia ${{ secrets.ATTIC_LOGIN_TOKEN }}
           attic push chutney:oss ${{ steps.om_ci.outputs.result }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,8 @@ jobs:
     runs-on: ${{ matrix.system }}
     strategy:
       matrix:
-        system: [x86_64-linux, aarch64-darwin]
+        # Our Mac Studios are b0rked, so we use GitHub mac runner.
+        system: [x86_64-linux, macos-latest]
     steps:
       - uses: actions/checkout@v4
       - name: "Attic: Configure"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,6 +18,8 @@ jobs:
             system: aarch64-darwin
     steps:
       - uses: actions/checkout@v4
+
+      # ⤵️ The steps are run only on GitHub runners
       - name: "Install Nix"
         if: matrix.runner == 'macos-latest'
         uses: DeterminateSystems/nix-installer-action@main
@@ -25,18 +27,22 @@ jobs:
         if: matrix.runner == 'macos-latest'
         run: |
           nix profile install nixpkgs#attic-client nixpkgs#omnix
+      # ⤴️
+
       - name: "Attic: Configure"
         run: |
           attic login chutney https://cache.nixos.asia ${{ secrets.ATTIC_LOGIN_TOKEN }}
           attic use chutney:oss
+
       - name: Build all flake outputs
-        id: om_ci
+        id: om-ci
         run: |
           om ci run --systems "${{ matrix.system }}"
           echo "result=$(readlink result)" >> "$GITHUB_OUTPUT"
       - name: Run Tests
         run: |
           nix --option system "${{ matrix.system }}" run .#vira-tests
+
       - name: "Attic: Push"
         run: |
-          attic push chutney:oss ${{ steps.om_ci.outputs.result }}
+          attic push chutney:oss ${{ steps.om-ci.outputs.result }}


### PR DESCRIPTION
Our Mac Studios are being retired. Switch to github runners until we setup proper self-hosted mac runners.