### PR TITLE
Display all branches

### DIFF
--- a/src/Vira/App/CLI.hs
+++ b/src/Vira/App/CLI.hs
@@ -12,7 +12,6 @@ module Vira.App.CLI (
   parseCLI,
 ) where
 
-import Data.Set qualified as Set
 import Data.Text qualified as T
 import Data.Version (showVersion)
 import Network.HostName (HostName, getHostName)
@@ -47,8 +46,6 @@ data Settings = Settings
 data RepoSettings = RepoSettings
   { cloneUrls :: [Repo]
   -- ^ Repositories (git clone URL) to watch and build
-  , branchWhitelist :: Set Text
-  -- ^ Limit to building these branches to build
   , cachix :: Maybe CachixSettings
   -- ^ Cachix settings
   , attic :: Maybe AtticSettings
@@ -84,9 +81,6 @@ defaultRepos =
   , "https://github.com/juspay/superposition.git"
   , "https://github.com/juspay/services-flake.git"
   ]
-
-defaultBranchesToBuild :: Set Text
-defaultBranchesToBuild = Set.fromList ["main", "master", "staging", "develop", "trunk"]
 
 -- | Parser for Settings
 settingsParser :: HostName -> Parser Settings
@@ -154,15 +148,6 @@ repoSettingsParser = do
             <> value defaultRepos
             <> showDefault
         )
-  branchWhitelist <-
-    option
-      (Set.fromList <$> commaSeparatedTextList)
-      ( long "branch-whitelist"
-          <> metavar "BRANCH_WHITELIST"
-          <> help "Limit to building these branches (comma-separated list)"
-          <> value defaultBranchesToBuild
-          <> showDefault
-      )
   cachix <- optional cachixSettingsParser
   attic <- optional atticSettingsParser
   pure RepoSettings {..}

--- a/src/Vira/Page/RepoPage.hs
+++ b/src/Vira/Page/RepoPage.hs
@@ -2,11 +2,9 @@
 
 module Vira.Page.RepoPage where
 
-import Data.Map.Strict qualified as Map
-import Data.Set qualified as Set
 import Effectful (Eff)
 import Effectful.Error.Static (throwError)
-import Effectful.Reader.Dynamic (ask, asks)
+import Effectful.Reader.Dynamic (ask)
 import Htmx.Lucid.Core (hxSwapS_)
 import Htmx.Servant.Response
 import Htmx.Swap (Swap (AfterEnd))
@@ -63,9 +61,7 @@ updateHandler :: RepoName -> Eff App.AppServantStack (Headers '[HXRefresh] Text)
 updateHandler name = do
   repo <- App.query (St.GetRepoByNameA name) >>= maybe (throwError err404) pure
   allBranches <- liftIO $ Git.remoteBranches repo.cloneUrl
-  branchWhitelist <- asks $ App.branchWhitelist . App.repo . App.settings
-  let branches = Map.filterWithKey (\k _ -> (toText . toString) k `Set.member` branchWhitelist) allBranches
-  App.update $ St.SetRepoBranchesA repo.name branches
+  App.update $ St.SetRepoBranchesA repo.name allBranches
   pure $ addHeader True "Ok"
 
 -- TODO: Can we use `HtmlT (ReaderT ..) ()` to avoid threading the linkTo function?


### PR DESCRIPTION
Removes branch whitelist option (#41)

I tried to include 'lastUpdated' for each branch, but `git for-each-ref` doesn't work with remote repositories. Looks like we'll need to do a shallow clone, which makes Refresh operation a bit expensive. Will reevaluate in future.

The branches are therefore listed in alphabetical order.