### PR TITLE
log: Stream only last 50 lines of log

### DIFF
--- a/src/Vira/Lib/Process/TailF.hs
+++ b/src/Vira/Lib/Process/TailF.hs
@@ -31,7 +31,9 @@ run filePath chan = do
       ( proc
           "tail"
           [ "-n"
-          , "+1" -- This reads whole file; cf. https://askubuntu.com/a/509915/26624
+          , -- , "+1" -- This reads whole file; cf. https://askubuntu.com/a/509915/26624
+            -- Limit, for https://github.com/juspay/vira/issues/61
+            "50"
           , "-f"
           , filePath
           ]

--- a/src/Vira/Lib/Process/TailF.hs
+++ b/src/Vira/Lib/Process/TailF.hs
@@ -26,12 +26,10 @@ new filePath = do
 
 tailFArgs :: Maybe Int -> FilePath -> [String]
 tailFArgs lastNLines fp =
-  case lastNLines of
-    Just n ->
-      ["-n", show n, "-f", fp]
-    Nothing ->
-      -- , "+1" -- This reads whole file; cf. https://askubuntu.com/a/509915/26624
-      ["-n", "+1", "-f", fp]
+  -- "+1" will read whole file.
+  -- cf. https://askubuntu.com/a/509915/26624
+  let n = maybe "+1" show lastNLines
+   in ["-n", n, "-f", fp]
 
 run :: FilePath -> TQueue Text -> IO ProcessHandle
 run filePath chan = do

--- a/src/Vira/Lib/Process/TailF.hs
+++ b/src/Vira/Lib/Process/TailF.hs
@@ -33,7 +33,7 @@ tailFArgs lastNLines fp =
 
 run :: FilePath -> TQueue Text -> IO ProcessHandle
 run filePath chan = do
-  -- We don't stream whole file for performanc reasons
+  -- We don't stream whole file for performance reasons
   -- See https://github.com/juspay/vira/issues/61
   -- Ideally, we should move away from `tail -f` to native streaming
   let lastNLines = Just 50

--- a/src/Vira/Lib/Process/TailF.hs
+++ b/src/Vira/Lib/Process/TailF.hs
@@ -24,19 +24,26 @@ new filePath = do
   ph <- run filePath queue
   pure $ TailF filePath ph queue
 
+tailFArgs :: Maybe Int -> FilePath -> [String]
+tailFArgs lastNLines fp =
+  case lastNLines of
+    Just n ->
+      ["-n", show n, "-f", fp]
+    Nothing ->
+      -- , "+1" -- This reads whole file; cf. https://askubuntu.com/a/509915/26624
+      ["-n", "+1", "-f", fp]
+
 run :: FilePath -> TQueue Text -> IO ProcessHandle
 run filePath chan = do
+  -- We don't stream whole file for performanc reasons
+  -- See https://github.com/juspay/vira/issues/61
+  -- Ideally, we should move away from `tail -f` to native streaming
+  let lastNLines = Just 50
   (_, Just hOut, _, ph) <-
     createProcess
       ( proc
           "tail"
-          [ "-n"
-          , -- , "+1" -- This reads whole file; cf. https://askubuntu.com/a/509915/26624
-            -- Limit, for https://github.com/juspay/vira/issues/61
-            "50"
-          , "-f"
-          , filePath
-          ]
+          (tailFArgs lastNLines filePath)
       )
         { std_out = CreatePipe
         }


### PR DESCRIPTION
Until we have a native log tail (i.e., not reliant on `tail -f`) implementation. This resolves #61
