### PR TITLE
Restyle with AI; create `DESIGN.md` for future UI work

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,13 @@
 See README.md for general project information.
 
+## Design System
+
+- **Follow the Vira Design System**: All UI/frontend code must follow the guidelines in `DESIGN.md`
+- **Use Existing Widgets**: Always check `src/Vira/Widgets.hs` for existing components before creating new ones
+- **Design Consistency**: Maintain the established color palette, typography, and spacing patterns
+- **Component Naming**: New widgets should follow the `vira[ComponentName]_` naming convention
+- **Responsive Design**: Ensure all UI components work across mobile, tablet, and desktop breakpoints
+
 ## Coding Guidelines
 
 - Haskell guidelines

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -22,6 +22,7 @@ See README.md for general project information.
     - After making code changes, run `pre-commit run -a` to format the code and check for linting issues (this runs fourmolu and hlint).
 - Refactoring & design
     - Prefer Juval Löwy's Volatility-Based Decomposition principle. For details, see https://www.informit.com/articles/article.aspx?p=2995357&seqNum=2
+- When updating code (especially styling) keep that in sync with DESIGN.md (bidirectional)
 
 ## Running vira
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,372 @@
+# Vira Design System
+
+This document defines the official design system and brand guidelines for the Vira CI/CD application. Follow these guidelines to maintain visual consistency and a professional appearance across all UI components.
+
+## 🎨 Brand Identity
+
+### Core Principles
+- **Modern & Professional**: Clean, contemporary design that inspires confidence
+- **Clarity & Focus**: Clear information hierarchy with minimal cognitive load
+- **Consistency**: Unified visual language across all interfaces
+- **Accessibility**: Inclusive design that works for all users
+
+### Visual Style
+- **Aesthetic**: Modern glass-morphism with subtle gradients
+- **Personality**: Professional, reliable, efficient, innovative
+- **Tone**: Technical but approachable, confident without being flashy
+
+## 🌈 Color Palette
+
+### Primary Colors
+```css
+/* Primary Brand Colors - Use for main actions and branding */
+--primary-50:  #eef2ff   /* Very light indigo backgrounds */
+--primary-100: #e0e7ff   /* Light indigo backgrounds */
+--primary-500: #6366f1   /* Primary indigo - main brand color */
+--primary-600: #4f46e5   /* Primary button color */
+--primary-700: #4338ca   /* Primary button hover */
+--primary-900: #312e81   /* Dark indigo text */
+
+/* Secondary Purple Accent */
+--purple-600: #9333ea    /* Used in gradients */
+--blue-600:   #2563eb    /* Used in gradients */
+```
+
+### Semantic Colors
+```css
+/* Success - Green */
+--success-50:  #f0fdf4
+--success-100: #dcfce7
+--success-500: #22c55e
+--success-700: #15803d
+--success-800: #166534
+
+/* Error - Red */
+--error-50:   #fef2f2
+--error-100:  #fee2e2
+--error-500:  #ef4444
+--error-700:  #dc2626
+--error-800:  #991b1b
+
+/* Warning - Yellow */
+--warning-50:  #fefce8
+--warning-100: #fef3c7
+--warning-500: #eab308
+--warning-700: #a16207
+--warning-800: #854d0e
+
+/* Info - Blue */
+--info-50:   #eff6ff
+--info-100:  #dbeafe
+--info-500:  #3b82f6
+--info-700:  #1d4ed8
+--info-800:  #1e40af
+```
+
+### Neutral Colors
+```css
+/* Grays - For text, borders, backgrounds */
+--gray-50:   #f9fafb   /* Light backgrounds */
+--gray-100:  #f3f4f6   /* Card backgrounds */
+--gray-200:  #e5e7eb   /* Borders */
+--gray-300:  #d1d5db   /* Disabled states */
+--gray-500:  #6b7280   /* Secondary text */
+--gray-600:  #4b5563   /* Primary text on light */
+--gray-700:  #374151   /* Headings */
+--gray-800:  #1f2937   /* Dark text */
+--gray-900:  #111827   /* Darkest text */
+
+/* White/Transparent */
+--white:     #ffffff
+--slate-50:  #f8fafc   /* Background gradient start */
+--blue-50:   #eff6ff   /* Background gradient end */
+```
+
+## 📝 Typography
+
+### Font Family
+```css
+font-family: 'Inter', ui-sans-serif, system-ui, sans-serif;
+```
+
+### Type Scale
+```css
+/* Headings */
+h1: text-3xl font-bold tracking-tight (30px, 700 weight)
+h2: text-2xl font-bold (24px, 700 weight)
+h3: text-xl font-semibold (20px, 600 weight)
+h4: text-lg font-semibold (18px, 600 weight)
+
+/* Body Text */
+body: text-sm (14px, 400 weight)
+large: text-base (16px, 400 weight)
+small: text-xs (12px, 400 weight)
+
+/* Labels */
+label: text-sm font-semibold (14px, 600 weight)
+
+/* Code */
+code: text-sm font-mono (14px, monospace)
+```
+
+### Text Colors
+- **Primary Text**: `text-gray-900` (headings, important content)
+- **Secondary Text**: `text-gray-600` (descriptions, metadata)
+- **Muted Text**: `text-gray-500` (captions, placeholders)
+- **Link Text**: `text-indigo-600 hover:text-indigo-800`
+
+## 🧩 Component Library
+
+All reusable UI components are defined in `src/Vira/Widgets.hs`. Always use these components for consistency:
+
+### Core Components
+
+#### Layout Components
+- `viraSection_` - Page section wrapper with consistent spacing
+- `viraCard_` - Card container with elegant shadows and rounded corners
+- `viraPageHeader_` - Standardized page headers with title and subtitle
+- `viraDivider_` - Visual content separator
+
+#### Interactive Components
+- `viraButton_` - Primary action buttons with hover states
+- `viraIconButton_` - Icon-only buttons for secondary actions
+- `viraInput_` - Form input fields with proper focus states
+- `viraLabel_` - Form labels with consistent typography
+
+#### Display Components
+- `viraStatusBadge_` - Status indicators with semantic colors
+- `viraCodeBlock_` - Code display with proper formatting
+- `viraAlert_` - Alert messages (success, error, warning, info)
+- `viraFormGroup_` - Form field grouping for consistent layouts
+
+### Component Usage Guidelines
+
+#### Buttons
+```haskell
+-- Primary action (most important action on page)
+W.viraButton_ [class_ "bg-indigo-600 hover:bg-indigo-700 focus:ring-indigo-500"] "Save Changes"
+
+-- Success action
+W.viraButton_ [class_ "bg-green-600 hover:bg-green-700 focus:ring-green-500"] "✅ Build"
+
+-- Destructive action
+W.viraButton_ [class_ "bg-red-600 hover:bg-red-700 focus:ring-red-500"] "🗑️ Delete"
+
+-- Secondary action
+W.viraIconButton_ [] "⚙️"
+```
+
+#### Status Badges
+```haskell
+-- Success
+W.viraStatusBadge_ "Success" "bg-green-100 text-green-800 border-green-200"
+
+-- Error
+W.viraStatusBadge_ "Failed" "bg-red-100 text-red-800 border-red-200"
+
+-- Warning/Pending
+W.viraStatusBadge_ "Pending" "bg-yellow-100 text-yellow-800 border-yellow-200"
+
+-- Info/Running
+W.viraStatusBadge_ "Running" "bg-blue-100 text-blue-800 border-blue-200"
+```
+
+#### Alerts
+```haskell
+-- Success message
+W.viraAlert_ "success" "bg-green-50 border-green-200" $ do
+  p_ [class_ "text-green-800"] "Repository successfully added!"
+
+-- Error message
+W.viraAlert_ "error" "bg-red-50 border-red-200" $ do
+  p_ [class_ "text-red-800"] "Failed to connect to repository"
+```
+
+## 🎛️ Layout Guidelines
+
+### Spacing System
+Use Tailwind's spacing scale consistently:
+- `space-y-2` (8px) - Tight spacing within components
+- `space-y-4` (16px) - Normal spacing between related elements
+- `space-y-6` (24px) - Spacing between sections
+- `space-y-8` (32px) - Large spacing between major sections
+
+### Grid & Cards
+```haskell
+-- Repository grid
+div_ [class_ "grid gap-6 md:grid-cols-2 lg:grid-cols-3"] $ do
+  forM_ repos $ \repo ->
+    W.viraCard_ [class_ "p-6"] $ do
+      -- Card content
+
+-- Two-column layout
+div_ [class_ "grid gap-6 lg:grid-cols-2"] $ do
+  W.viraCard_ [class_ "p-6"] leftContent
+  W.viraCard_ [class_ "p-6"] rightContent
+```
+
+### Page Structure
+```haskell
+pageContent = do
+  W.viraSection_ [] $ do
+    -- Page header
+    W.viraPageHeader_ "Page Title" $ do
+      p_ [class_ "text-gray-600"] "Page description"
+    
+    -- Main content cards
+    W.viraCard_ [class_ "p-6 mb-6"] $ do
+      -- Primary content
+    
+    W.viraCard_ [class_ "p-6"] $ do
+      -- Secondary content
+```
+
+## 🎭 Visual Effects
+
+### Shadows
+```css
+/* Component shadows */
+.shadow-elegant: box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+
+/* Card hover states */
+hover:shadow-lg
+hover:shadow-xl
+```
+
+### Gradients
+```css
+/* Background gradient */
+bg-gradient-to-br from-slate-50 to-blue-50
+
+/* Header gradients */
+bg-gradient-to-r from-indigo-600 via-purple-600 to-blue-600
+bg-gradient-to-r from-indigo-50 to-blue-50
+```
+
+### Transitions
+```css
+/* Smooth transitions for all interactive elements */
+.transition-smooth: transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+```
+
+### Glass Morphism
+```css
+/* For overlay elements */
+backdrop-blur-sm
+bg-white/80
+border border-white/20
+```
+
+## 📱 Responsive Design
+
+### Breakpoints
+- Mobile: Default (< 768px)
+- Tablet: `md:` (768px+)
+- Desktop: `lg:` (1024px+)
+- Large: `xl:` (1280px+)
+
+### Responsive Patterns
+```haskell
+-- Responsive grid
+div_ [class_ "grid gap-4 md:grid-cols-2 lg:grid-cols-3"] $ do
+
+-- Responsive padding
+div_ [class_ "p-4 lg:p-8"] $ do
+
+-- Responsive text
+h1_ [class_ "text-2xl lg:text-3xl"] $ do
+```
+
+## ♿ Accessibility Guidelines
+
+### Focus States
+All interactive elements must have visible focus indicators:
+```css
+focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2
+```
+
+### Color Contrast
+- Ensure 4.5:1 contrast ratio for normal text
+- Ensure 3:1 contrast ratio for large text
+- Don't rely solely on color to convey information
+
+### Semantic HTML
+- Use proper heading hierarchy (h1 → h2 → h3)
+- Use semantic elements (`nav`, `main`, `section`, `article`)
+- Include `alt` text for images
+- Use `role` attributes when needed
+
+## 🚀 Implementation Guidelines
+
+### When Creating New Components
+1. **Check existing widgets first** - Use components from `Widgets.hs`
+2. **Follow naming convention** - `vira[ComponentName]_` for new widgets
+3. **Include proper attributes** - Accept `[Attributes]` parameter
+4. **Use design tokens** - Follow the color palette and spacing system
+5. **Add hover/focus states** - Include interactive feedback
+6. **Test responsiveness** - Ensure it works on all screen sizes
+
+### Code Style
+```haskell
+-- Good: Using design system
+W.viraCard_ [class_ "p-6"] $ do
+  W.viraPageHeader_ "Settings" $ do
+    p_ [class_ "text-gray-600"] "Configure your application"
+
+-- Bad: Inline styles without consistency
+div_ [class_ "bg-white p-4 rounded shadow"] $ do
+  h1_ [class_ "text-lg font-bold"] "Settings"
+```
+
+### Class Naming Patterns
+- **Layout**: `p-6`, `m-4`, `space-y-6`, `grid`, `flex`
+- **Colors**: `bg-white`, `text-gray-900`, `border-gray-200`
+- **Interactions**: `hover:bg-gray-50`, `focus:ring-2`, `transition-smooth`
+- **Responsive**: `md:grid-cols-2`, `lg:p-8`, `xl:max-w-6xl`
+
+## 🔄 Status System
+
+### Build Statuses
+- **Running**: Blue (`bg-blue-100 text-blue-800`) with "🚧" or spinner
+- **Pending**: Yellow (`bg-yellow-100 text-yellow-800`) with "⏳"
+- **Success**: Green (`bg-green-100 text-green-800`) with "✅"
+- **Failed**: Red (`bg-red-100 text-red-800`) with "❌"
+- **Killed**: Gray (`bg-gray-100 text-gray-800`) with "💀"
+
+### Connection Statuses
+- **Connected**: Green alert with service details
+- **Disconnected**: Blue info alert with setup instructions
+- **Error**: Red alert with error message
+
+## 📋 Common Patterns
+
+### Empty States
+```haskell
+W.viraCard_ [class_ "p-12 text-center"] $ do
+  div_ [class_ "text-gray-400 mb-4"] $ span_ [class_ "text-6xl"] "📦"
+  h3_ [class_ "text-xl font-semibold text-gray-700 mb-2"] "No items yet"
+  p_ [class_ "text-gray-500 mb-6"] "Description of what to do"
+  -- Call to action button
+```
+
+### Loading States
+```haskell
+-- Button loading state
+W.viraButton_ [disabled_ "", class_ "opacity-50 cursor-not-allowed"] $ do
+  "⏳ Loading..."
+```
+
+### Form Validation
+```haskell
+-- Error state
+W.viraAlert_ "error" "bg-red-50 border-red-200" $ do
+  p_ [class_ "text-red-800"] "Please fix the following errors:"
+
+-- Success state
+W.viraAlert_ "success" "bg-green-50 border-green-200" $ do
+  p_ [class_ "text-green-800"] "Settings saved successfully!"
+```
+
+---
+
+**Remember**: This design system exists to maintain consistency and quality. When in doubt, refer to existing components in `Widgets.hs` or follow the patterns established in this document. Always prioritize user experience and accessibility in your implementations.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -117,70 +117,48 @@ code: text-sm font-mono (14px, monospace)
 
 ## 🧩 Component Library
 
-All reusable UI components are defined in `src/Vira/Widgets.hs`. Always use these components for consistency:
+All reusable UI components are defined in `src/Vira/Widgets.hs` with comprehensive documentation.
 
-### Core Components
+### Using Components
 
-#### Layout Components
-- `viraSection_` - Page section wrapper with consistent spacing
-- `viraCard_` - Card container with elegant shadows and rounded corners
-- `viraPageHeader_` - Standardized page headers with title and subtitle
-- `viraDivider_` - Visual content separator
+Always use these components instead of raw HTML to maintain design consistency:
 
-#### Interactive Components
-- `viraButton_` - Primary action buttons with hover states
-- `viraIconButton_` - Icon-only buttons for secondary actions
-- `viraInput_` - Form input fields with proper focus states
-- `viraLabel_` - Form labels with consistent typography
-
-#### Display Components
-- `viraStatusBadge_` - Status indicators with semantic colors
-- `viraCodeBlock_` - Code display with proper formatting
-- `viraAlert_` - Alert messages (success, error, warning, info)
-- `viraFormGroup_` - Form field grouping for consistent layouts
-
-### Component Usage Guidelines
-
-#### Buttons
 ```haskell
--- Primary action (most important action on page)
-W.viraButton_ [class_ "bg-indigo-600 hover:bg-indigo-700 focus:ring-indigo-500"] "Save Changes"
+import Vira.Widgets qualified as W
 
--- Success action
-W.viraButton_ [class_ "bg-green-600 hover:bg-green-700 focus:ring-green-500"] "✅ Build"
-
--- Destructive action
-W.viraButton_ [class_ "bg-red-600 hover:bg-red-700 focus:ring-red-500"] "🗑️ Delete"
-
--- Secondary action
-W.viraIconButton_ [] "⚙️"
+-- Use components with proper imports
+W.viraButton_ [type_ "submit"] "Save Changes"
+W.viraCard_ [class_ "p-6"] $ do
+  W.viraPageHeader_ "Settings" $ do
+    p_ [class_ "text-gray-600"] "Configure your application"
 ```
 
-#### Status Badges
-```haskell
--- Success
-W.viraStatusBadge_ "Success" "bg-green-100 text-green-800 border-green-200"
+### Component Documentation
 
--- Error
-W.viraStatusBadge_ "Failed" "bg-red-100 text-red-800 border-red-200"
+Each component in `Widgets.hs` includes:
+- **Purpose and design rationale**
+- **Usage examples with code samples**  
+- **Styling guidelines and color schemes**
+- **Accessibility considerations**
+- **When to use vs alternatives**
 
--- Warning/Pending
-W.viraStatusBadge_ "Pending" "bg-yellow-100 text-yellow-800 border-yellow-200"
+### Component Categories
 
--- Info/Running
-W.viraStatusBadge_ "Running" "bg-blue-100 text-blue-800 border-blue-200"
-```
+See `src/Vira/Widgets.hs` for the complete component library:
 
-#### Alerts
-```haskell
--- Success message
-W.viraAlert_ "success" "bg-green-50 border-green-200" $ do
-  p_ [class_ "text-green-800"] "Repository successfully added!"
+- **Layout Components**: `viraSection_`, `viraCard_`, `viraPageHeader_`, `viraDivider_`
+- **Interactive Components**: `viraButton_`, `viraIconButton_`, `viraInput_`, `viraLabel_`  
+- **Display Components**: `viraStatusBadge_`, `viraCodeBlock_`, `viraCodeInline_`, `viraAlert_`, `viraFormGroup_`
 
--- Error message
-W.viraAlert_ "error" "bg-red-50 border-red-200" $ do
-  p_ [class_ "text-red-800"] "Failed to connect to repository"
-```
+### Creating New Components
+
+When creating new components:
+1. **Check existing widgets first** - Avoid duplication
+2. **Follow naming convention** - `vira[ComponentName]_` pattern
+3. **Include comprehensive documentation** - Follow existing examples
+4. **Accept `[Attributes]` parameter** - For extensibility
+5. **Use design system colors** - Follow the established palette
+6. **Add to export list** - Make it available to other modules
 
 ## 🎛️ Layout Guidelines
 
@@ -205,58 +183,6 @@ div_ [class_ "grid gap-6 lg:grid-cols-2"] $ do
   W.viraCard_ [class_ "p-6"] rightContent
 ```
 
-### Page Structure
-```haskell
-pageContent = do
-  W.viraSection_ [] $ do
-    -- Page header
-    W.viraPageHeader_ "Page Title" $ do
-      p_ [class_ "text-gray-600"] "Page description"
-    
-    -- Main content cards
-    W.viraCard_ [class_ "p-6 mb-6"] $ do
-      -- Primary content
-    
-    W.viraCard_ [class_ "p-6"] $ do
-      -- Secondary content
-```
-
-## 🎭 Visual Effects
-
-### Shadows
-```css
-/* Component shadows */
-.shadow-elegant: box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
-
-/* Card hover states */
-hover:shadow-lg
-hover:shadow-xl
-```
-
-### Gradients
-```css
-/* Background gradient */
-bg-gradient-to-br from-slate-50 to-blue-50
-
-/* Header gradients */
-bg-gradient-to-r from-indigo-600 via-purple-600 to-blue-600
-bg-gradient-to-r from-indigo-50 to-blue-50
-```
-
-### Transitions
-```css
-/* Smooth transitions for all interactive elements */
-.transition-smooth: transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-```
-
-### Glass Morphism
-```css
-/* For overlay elements */
-backdrop-blur-sm
-bg-white/80
-border border-white/20
-```
-
 ## 📱 Responsive Design
 
 ### Breakpoints
@@ -265,46 +191,24 @@ border border-white/20
 - Desktop: `lg:` (1024px+)
 - Large: `xl:` (1280px+)
 
-### Responsive Patterns
-```haskell
--- Responsive grid
-div_ [class_ "grid gap-4 md:grid-cols-2 lg:grid-cols-3"] $ do
-
--- Responsive padding
-div_ [class_ "p-4 lg:p-8"] $ do
-
--- Responsive text
-h1_ [class_ "text-2xl lg:text-3xl"] $ do
-```
-
 ## ♿ Accessibility Guidelines
 
-### Focus States
 All interactive elements must have visible focus indicators:
 ```css
 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2
 ```
 
-### Color Contrast
-- Ensure 4.5:1 contrast ratio for normal text
-- Ensure 3:1 contrast ratio for large text
-- Don't rely solely on color to convey information
-
-### Semantic HTML
+- Ensure 4.5:1 contrast ratio for text
 - Use proper heading hierarchy (h1 → h2 → h3)
-- Use semantic elements (`nav`, `main`, `section`, `article`)
-- Include `alt` text for images
-- Use `role` attributes when needed
+- Include `alt` text for images and `title` for icon buttons
 
 ## 🚀 Implementation Guidelines
 
-### When Creating New Components
+### Creating New Components
 1. **Check existing widgets first** - Use components from `Widgets.hs`
 2. **Follow naming convention** - `vira[ComponentName]_` for new widgets
-3. **Include proper attributes** - Accept `[Attributes]` parameter
-4. **Use design tokens** - Follow the color palette and spacing system
-5. **Add hover/focus states** - Include interactive feedback
-6. **Test responsiveness** - Ensure it works on all screen sizes
+3. **Accept `[Attributes]` parameter** - For extensibility
+4. **Use design system colors** - Follow the established palette
 
 ### Code Style
 ```haskell
@@ -318,20 +222,14 @@ div_ [class_ "bg-white p-4 rounded shadow"] $ do
   h1_ [class_ "text-lg font-bold"] "Settings"
 ```
 
-### Class Naming Patterns
-- **Layout**: `p-6`, `m-4`, `space-y-6`, `grid`, `flex`
-- **Colors**: `bg-white`, `text-gray-900`, `border-gray-200`
-- **Interactions**: `hover:bg-gray-50`, `focus:ring-2`, `transition-smooth`
-- **Responsive**: `md:grid-cols-2`, `lg:p-8`, `xl:max-w-6xl`
-
 ## 🔄 Status System
 
 ### Build Statuses
-- **Running**: Blue (`bg-blue-100 text-blue-800`) with "🚧" or spinner
-- **Pending**: Yellow (`bg-yellow-100 text-yellow-800`) with "⏳"
-- **Success**: Green (`bg-green-100 text-green-800`) with "✅"
-- **Failed**: Red (`bg-red-100 text-red-800`) with "❌"
-- **Killed**: Gray (`bg-gray-100 text-gray-800`) with "💀"
+- **Running**: Blue (`bg-blue-100 text-blue-800`)
+- **Pending**: Yellow (`bg-yellow-100 text-yellow-800`)
+- **Success**: Green (`bg-green-100 text-green-800`)
+- **Failed**: Red (`bg-red-100 text-red-800`)
+- **Killed**: Darker red (`bg-red-200 text-red-900`)
 
 ### Connection Statuses
 - **Connected**: Green alert with service details
@@ -349,24 +247,6 @@ W.viraCard_ [class_ "p-12 text-center"] $ do
   -- Call to action button
 ```
 
-### Loading States
-```haskell
--- Button loading state
-W.viraButton_ [disabled_ "", class_ "opacity-50 cursor-not-allowed"] $ do
-  "⏳ Loading..."
-```
-
-### Form Validation
-```haskell
--- Error state
-W.viraAlert_ "error" "bg-red-50 border-red-200" $ do
-  p_ [class_ "text-red-800"] "Please fix the following errors:"
-
--- Success state
-W.viraAlert_ "success" "bg-green-50 border-green-200" $ do
-  p_ [class_ "text-green-800"] "Settings saved successfully!"
-```
-
 ---
 
-**Remember**: This design system exists to maintain consistency and quality. When in doubt, refer to existing components in `Widgets.hs` or follow the patterns established in this document. Always prioritize user experience and accessibility in your implementations.
+**Remember**: This design system exists to maintain consistency and quality. When in doubt, refer to existing components in `Widgets.hs` or follow the patterns established in this document.

--- a/src/Vira/Page/BranchPage.hs
+++ b/src/Vira/Page/BranchPage.hs
@@ -75,6 +75,6 @@ viewJobListing linkTo jobs = do
     then div_ [class_ "text-center py-12 text-gray-500"] $ do
       p_ [class_ "text-lg"] "No builds yet"
       p_ [class_ "text-sm mt-2"] "Start your first build using the button above"
-    else div_ [class_ "space-y-3"] $ forM_ jobs $ \job -> do
-      div_ [class_ "bg-gray-50 rounded-lg p-4 border border-gray-200 hover:bg-blue-50 hover:border-blue-300 transition-all duration-200"] $ do
+    else div_ [class_ "divide-y divide-gray-200"] $ forM_ jobs $ \job -> do
+      div_ [class_ "py-4 hover:bg-gray-50 transition-colors duration-150"] $ do
         JobPage.viewJobHeader linkTo job

--- a/src/Vira/Page/BranchPage.hs
+++ b/src/Vira/Page/BranchPage.hs
@@ -42,27 +42,39 @@ viewHandler repoName branchName = do
 -- TODO: Can we use `HtmlT (ReaderT ..) ()` to avoid threading the linkTo function?
 viewRepoBranch :: (LinkTo.LinkTo -> Link) -> St.Repo -> St.Branch -> [St.Job] -> Html ()
 viewRepoBranch linkTo repo branch jobs = do
-  div_ [class_ ""] $ do
-    h2_ [class_ "text-2xl py-2 my-4 border-b-2 flex items-start flex-col"] $ do
-      div_ $ toHtml $ toString branch.branchName
-      div_ $ JobPage.viewCommit branch.headCommit
-    -- TODO: Replace this with parent UX flow
-    -- cf. https://github.com/juspay/vira/issues/47#issuecomment-3014376804
-    W.viraButton_
-      [ hxPostSafe_ $ linkTo $ RepoUpdate repo.name
-      , hxSwapS_ AfterEnd
-      ]
-      "Refresh branches"
-    div_ [class_ "mb-4"] $
-      W.viraButton_
-        [ hxPostSafe_ $ linkTo $ LinkTo.Build repo.name branch.branchName
-        , hxSwapS_ AfterEnd
-        ]
-        "Build"
-    viewJobListing linkTo jobs
+  W.viraSection_ [] $ do
+    -- Branch header
+    W.viraCard_ [class_ "p-6 mb-8"] $ do
+      W.viraPageHeader_ (toText $ toString branch.branchName) $ do
+        JobPage.viewCommit branch.headCommit
+
+      div_ [class_ "flex gap-3 mt-6"] $ do
+        -- TODO: Replace this with parent UX flow
+        -- cf. https://github.com/juspay/vira/issues/47#issuecomment-3014376804
+        W.viraButton_
+          [ hxPostSafe_ $ linkTo $ RepoUpdate repo.name
+          , hxSwapS_ AfterEnd
+          , class_ "bg-blue-600 hover:bg-blue-700 focus:ring-blue-500"
+          ]
+          "🔄 Refresh Branches"
+        W.viraButton_
+          [ hxPostSafe_ $ linkTo $ LinkTo.Build repo.name branch.branchName
+          , hxSwapS_ AfterEnd
+          , class_ "bg-green-600 hover:bg-green-700 focus:ring-green-500"
+          ]
+          "🚀 Build"
+
+    -- Jobs listing
+    W.viraCard_ [class_ "p-6"] $ do
+      h3_ [class_ "text-xl font-semibold text-gray-900 mb-6"] "Build History"
+      viewJobListing linkTo jobs
 
 viewJobListing :: (LinkTo.LinkTo -> Link) -> [St.Job] -> Html ()
 viewJobListing linkTo jobs = do
-  ul_ [class_ "space-y-2 mb-4"] $ forM_ jobs $ \job -> do
-    li_ [class_ "bg-gray-50 rounded px-3 py-2 border-l-4 border-gray-300 hover:bg-blue-100 transition-all duration-300"] $ do
-      JobPage.viewJobHeader linkTo job
+  if null jobs
+    then div_ [class_ "text-center py-12 text-gray-500"] $ do
+      p_ [class_ "text-lg"] "No builds yet"
+      p_ [class_ "text-sm mt-2"] "Start your first build using the button above"
+    else div_ [class_ "space-y-3"] $ forM_ jobs $ \job -> do
+      div_ [class_ "bg-gray-50 rounded-lg p-4 border border-gray-200 hover:bg-blue-50 hover:border-blue-300 transition-all duration-200"] $ do
+        JobPage.viewJobHeader linkTo job

--- a/src/Vira/Page/BranchPage.hs
+++ b/src/Vira/Page/BranchPage.hs
@@ -52,15 +52,15 @@ viewRepoBranch linkTo repo branch jobs = do
         -- TODO: Replace this with parent UX flow
         -- cf. https://github.com/juspay/vira/issues/47#issuecomment-3014376804
         W.viraButton_
+          W.ButtonSecondary
           [ hxPostSafe_ $ linkTo $ RepoUpdate repo.name
           , hxSwapS_ AfterEnd
-          , class_ "bg-blue-600 hover:bg-blue-700 focus:ring-blue-500"
           ]
           "🔄 Refresh Branches"
         W.viraButton_
+          W.ButtonSuccess
           [ hxPostSafe_ $ linkTo $ LinkTo.Build repo.name branch.branchName
           , hxSwapS_ AfterEnd
-          , class_ "bg-green-600 hover:bg-green-700 focus:ring-green-500"
           ]
           "🚀 Build"
 

--- a/src/Vira/Page/JobPage.hs
+++ b/src/Vira/Page/JobPage.hs
@@ -122,17 +122,7 @@ viewCommit (Git.CommitID commit) = do
 
 viewJobStatus :: St.JobStatus -> Html ()
 viewJobStatus status = do
-  case status of
-    St.JobRunning ->
-      W.viraStatusBadge_ "Running" "bg-blue-100 text-blue-800 border-blue-200"
-    St.JobPending ->
-      W.viraStatusBadge_ "Pending" "bg-yellow-100 text-yellow-800 border-yellow-200"
-    St.JobFinished St.JobSuccess ->
-      W.viraStatusBadge_ "Success" "bg-green-100 text-green-800 border-green-200"
-    St.JobFinished St.JobFailure ->
-      W.viraStatusBadge_ "Failed" "bg-red-100 text-red-800 border-red-200"
-    St.JobKilled ->
-      W.viraStatusBadge_ "Killed" "bg-red-200 text-red-900 border-red-300"
+  W.viraStatusBadge_ status
 
 -- TODO:
 -- 1. Fail if a build is already happening (until we support queuing)

--- a/src/Vira/Page/JobPage.hs
+++ b/src/Vira/Page/JobPage.hs
@@ -2,6 +2,7 @@
 
 module Vira.Page.JobPage where
 
+import Data.Text qualified as T
 import Effectful (Eff)
 import Effectful.Error.Static (throwError)
 import Effectful.Process (CreateProcess (cwd), env, proc)
@@ -80,37 +81,58 @@ viewJob :: (LinkTo.LinkTo -> Link) -> St.Job -> Eff App.AppServantStack (Html ()
 viewJob linkTo job = do
   let jobActive = job.jobStatus == St.JobRunning || job.jobStatus == St.JobPending
   logView <- JobLog.view linkTo job
-  pure $ do
-    viewJobHeader linkTo job
-    logView
-    when jobActive $
-      W.viraButton_
-        [ hxPostSafe_ $ linkTo $ LinkTo.Kill job.jobId
-        , hxSwapS_ AfterEnd
-        ]
-        "Kill"
+  pure $ W.viraSection_ [] $ do
+    -- Job header card
+    W.viraCard_ [class_ "p-6 mb-8"] $ do
+      div_ [class_ "flex items-center justify-between"] $ do
+        div_ $ do
+          W.viraPageHeader_ ("Job #" <> (toText @String $ show job.jobId)) $ do
+            div_ [class_ "flex items-center space-x-4 text-sm text-gray-600"] $ do
+              span_ "Commit:"
+              viewCommit job.jobCommit
+        div_ [class_ "flex items-center space-x-4"] $ do
+          viewJobStatus job.jobStatus
+          when jobActive $
+            W.viraButton_
+              [ hxPostSafe_ $ linkTo $ LinkTo.Kill job.jobId
+              , hxSwapS_ AfterEnd
+              , class_ "bg-red-600 hover:bg-red-700 focus:ring-red-500"
+              ]
+              "🛑 Kill Job"
+
+    -- Job logs
+    W.viraCard_ [class_ "p-6"] $ do
+      h3_ [class_ "text-xl font-semibold text-gray-900 mb-4"] "Build Logs"
+      logView
 
 viewJobHeader :: (LinkTo.LinkTo -> Link) -> St.Job -> Html ()
 viewJobHeader linkTo job = do
-  a_ [title_ "View Job Details", href_ $ show . linkURI $ linkTo $ LinkTo.Job job.jobId] $ do
-    div_ [class_ "flex items-center justify-start space-x-4"] $ do
-      div_ [class_ "w-24"] $ do
-        b_ $ "Job #" <> toHtml (show @Text job.jobId)
-      viewCommit job.jobCommit
+  a_ [title_ "View Job Details", href_ $ show . linkURI $ linkTo $ LinkTo.Job job.jobId, class_ "block"] $ do
+    div_ [class_ "flex items-center justify-between"] $ do
+      div_ [class_ "flex items-center space-x-4"] $ do
+        div_ [class_ "flex-shrink-0"] $ do
+          span_ [class_ "inline-flex items-center px-3 py-1 rounded-full text-sm font-semibold bg-gray-100 text-gray-800"] $ do
+            "Job #" <> toHtml (show @Text job.jobId)
+        viewCommit job.jobCommit
       viewJobStatus job.jobStatus
 
 viewCommit :: Git.CommitID -> Html ()
 viewCommit (Git.CommitID commit) = do
-  code_ [class_ "text-gray-600 text-sm hover:text-black"] $ toHtml commit
+  W.viraCodeBlock_ (T.take 8 $ toText commit)
 
 viewJobStatus :: St.JobStatus -> Html ()
 viewJobStatus status = do
   case status of
-    St.JobRunning -> span_ [class_ "text-blue-700"] "🚧 Running"
-    St.JobPending -> span_ [class_ "text-yellow-700"] "⏳ Pending"
-    St.JobFinished St.JobSuccess -> span_ [class_ "text-green-700"] "✅ Success"
-    St.JobFinished St.JobFailure -> span_ [class_ "text-red-700"] "❌ Failure"
-    St.JobKilled -> span_ [class_ "text-red-700"] "💀 Killed"
+    St.JobRunning ->
+      W.viraStatusBadge_ "Running" "bg-blue-100 text-blue-800 border-blue-200"
+    St.JobPending ->
+      W.viraStatusBadge_ "Pending" "bg-yellow-100 text-yellow-800 border-yellow-200"
+    St.JobFinished St.JobSuccess ->
+      W.viraStatusBadge_ "Success" "bg-green-100 text-green-800 border-green-200"
+    St.JobFinished St.JobFailure ->
+      W.viraStatusBadge_ "Failed" "bg-red-100 text-red-800 border-red-200"
+    St.JobKilled ->
+      W.viraStatusBadge_ "Killed" "bg-gray-100 text-gray-800 border-gray-200"
 
 -- TODO:
 -- 1. Fail if a build is already happening (until we support queuing)

--- a/src/Vira/Page/JobPage.hs
+++ b/src/Vira/Page/JobPage.hs
@@ -132,7 +132,7 @@ viewJobStatus status = do
     St.JobFinished St.JobFailure ->
       W.viraStatusBadge_ "Failed" "bg-red-100 text-red-800 border-red-200"
     St.JobKilled ->
-      W.viraStatusBadge_ "Killed" "bg-gray-100 text-gray-800 border-gray-200"
+      W.viraStatusBadge_ "Killed" "bg-red-200 text-red-900 border-red-300"
 
 -- TODO:
 -- 1. Fail if a build is already happening (until we support queuing)

--- a/src/Vira/Page/JobPage.hs
+++ b/src/Vira/Page/JobPage.hs
@@ -94,9 +94,9 @@ viewJob linkTo job = do
           viewJobStatus job.jobStatus
           when jobActive $
             W.viraButton_
+              W.ButtonDestructive
               [ hxPostSafe_ $ linkTo $ LinkTo.Kill job.jobId
               , hxSwapS_ AfterEnd
-              , class_ "bg-red-600 hover:bg-red-700 focus:ring-red-500"
               ]
               "🛑 Kill Job"
 

--- a/src/Vira/Page/JobPage.hs
+++ b/src/Vira/Page/JobPage.hs
@@ -118,7 +118,7 @@ viewJobHeader linkTo job = do
 
 viewCommit :: Git.CommitID -> Html ()
 viewCommit (Git.CommitID commit) = do
-  W.viraCodeBlock_ (T.take 8 $ toText commit)
+  W.viraCodeInline_ (T.take 8 $ toText commit)
 
 viewJobStatus :: St.JobStatus -> Html ()
 viewJobStatus status = do

--- a/src/Vira/Page/RegistryPage.hs
+++ b/src/Vira/Page/RegistryPage.hs
@@ -60,7 +60,7 @@ addRepoHandler repo = do
       -- Show error message instead of redirecting
       pure $ noHeader $ do
         newRepoForm cfg.linkTo
-        W.viraAlert_ "error" "bg-red-50 border-red-200" $ do
+        W.viraAlert_ W.AlertError $ do
           p_ [class_ "text-red-800 font-medium"] $ do
             "Repository "
             strong_ $ toHtml $ toString repo.name

--- a/src/Vira/Page/RegistryPage.hs
+++ b/src/Vira/Page/RegistryPage.hs
@@ -122,7 +122,6 @@ newRepoForm linkTo = do
               [ type_ "text"
               , name_ name
               , placeholder_ "my-awesome-project"
-              , class_ "w-full"
               , required_ ""
               ]
         )
@@ -135,7 +134,6 @@ newRepoForm linkTo = do
               [ type_ "url"
               , name_ name
               , placeholder_ "https://github.com/user/repo.git"
-              , class_ "w-full"
               , required_ ""
               ]
         )

--- a/src/Vira/Page/RegistryPage.hs
+++ b/src/Vira/Page/RegistryPage.hs
@@ -147,7 +147,7 @@ newRepoForm linkTo = do
         ]
 
     div_ [class_ "flex justify-end"] $ do
-      W.viraButton_ [type_ "submit", class_ "bg-indigo-600 hover:bg-indigo-700 focus:ring-indigo-500 px-8"] $ do
+      W.viraButton_ W.ButtonPrimary [type_ "submit", class_ "px-8"] $ do
         span_ [class_ "mr-2"] "🚀"
         "Add Repository"
 

--- a/src/Vira/Page/RegistryPage.hs
+++ b/src/Vira/Page/RegistryPage.hs
@@ -60,8 +60,8 @@ addRepoHandler repo = do
       -- Show error message instead of redirecting
       pure $ noHeader $ do
         newRepoForm cfg.linkTo
-        div_ [class_ "mt-4 p-4 bg-red-50 border border-red-200 rounded-md"] $ do
-          p_ [class_ "text-sm text-red-700"] $ do
+        W.viraAlert_ "error" "bg-red-50 border-red-200" $ do
+          p_ [class_ "text-red-800 font-medium"] $ do
             "Repository "
             strong_ $ toHtml $ toString repo.name
             " already exists."
@@ -74,53 +74,75 @@ addRepoHandler repo = do
 
 viewRepoList :: (LinkTo.LinkTo -> Link) -> [St.Repo] -> Html ()
 viewRepoList linkTo registry = do
-  div_ [class_ "space-y-6 max-w-4xl"] $ do
-    -- Repository listing
-    div_ $ do
-      h2_ [class_ "text-2xl font-semibold mb-6 text-gray-800"] "Repositories"
-      if null registry
-        then div_ [class_ "text-center py-8 text-gray-500"] $ do
-          p_ "No repositories yet."
-        else div_ [class_ "space-y-2"] $ do
-          -- Show existing repositories as clean list
+  W.viraSection_ [] $ do
+    W.viraPageHeader_ "Repositories" $ do
+      p_ [class_ "text-gray-600"] "Manage your CI/CD repositories and monitor builds"
+
+    if null registry
+      then W.viraCard_ [class_ "p-12 text-center"] $ do
+        div_ [class_ "text-gray-400 mb-4"] $ do
+          span_ [class_ "text-6xl"] "📦"
+        h3_ [class_ "text-xl font-semibold text-gray-700 mb-2"] "No repositories yet"
+        p_ [class_ "text-gray-500 mb-6"] "Add your first repository to start building and monitoring your projects"
+        newRepoForm linkTo
+      else do
+        -- Repository grid
+        div_ [class_ "grid gap-6 mb-8 md:grid-cols-2 lg:grid-cols-3"] $ do
           forM_ registry $ \repo -> do
             let url = linkURI $ linkTo $ LinkTo.Repo repo.name
-            a_ [href_ $ show url, class_ "block p-4 bg-white border border-gray-200 rounded-lg hover:bg-gray-50 hover:border-gray-300 transition-colors"] $ do
-              div_ [class_ "flex items-center justify-between"] $ do
-                h3_ [class_ "text-lg font-medium text-gray-900 hover:text-blue-600"] $
-                  toHtml $
-                    toString repo.name
-                span_ [class_ "text-xs text-gray-400 font-mono truncate ml-4 max-w-md"] $
-                  toHtml repo.cloneUrl
+            W.viraCard_ [class_ "p-6 hover:shadow-xl transition-all duration-300 cursor-pointer group"] $ do
+              a_ [href_ $ show url, class_ "block"] $ do
+                div_ [class_ "flex items-start justify-between mb-4"] $ do
+                  h3_ [class_ "text-xl font-bold text-gray-900 group-hover:text-indigo-600 transition-colors"] $
+                    toHtml $
+                      toString repo.name
+                  span_ [class_ "text-gray-400 group-hover:text-indigo-500 transition-colors"] "→"
+                div_ [class_ "mb-4"] $ do
+                  W.viraCodeBlock_ (toText repo.cloneUrl)
+                div_ [class_ "flex items-center text-sm text-gray-500"] $ do
+                  span_ [class_ "mr-2"] "🔗"
+                  "View branches and builds"
 
-    -- Add new repository section - more prominent
-    div_ [class_ "mt-8 pt-6 border-t border-gray-200 mb-8"] $ do
-      div_ [class_ "bg-gray-50 border border-gray-300 rounded-lg p-6"] $ do
-        h3_ [class_ "text-lg font-medium text-gray-900 mb-4"] "Add Repository"
-        newRepoForm linkTo
+        W.viraDivider_
+
+        -- Add new repository section
+        W.viraCard_ [class_ "p-6 bg-gradient-to-r from-indigo-50 to-blue-50 border-indigo-200"] $ do
+          h3_ [class_ "text-xl font-semibold text-gray-900 mb-4 flex items-center"] $ do
+            span_ [class_ "mr-2"] "➕"
+            "Add New Repository"
+          newRepoForm linkTo
 
 newRepoForm :: (LinkTo.LinkTo -> Link) -> Html ()
 newRepoForm linkTo = do
-  form_ [hxPostSafe_ $ linkTo LinkTo.RepoAdd, hxSwapS_ InnerHTML, class_ "space-y-4"] $ do
-    div_ [class_ "grid grid-cols-1 md:grid-cols-2 gap-4"] $ do
-      div_ $ do
-        withFieldName @Repo @"name" $ \name -> do
-          W.viraLabel_ [for_ name] "Repository Name"
-          W.viraInput_
-            [ type_ "text"
-            , name_ name
-            , placeholder_ "my-project"
-            , class_ "w-full"
-            ]
-      div_ $ do
-        withFieldName @Repo @"cloneUrl" $ \name -> do
-          W.viraLabel_ [for_ name] "Git Clone URL"
-          W.viraInput_
-            [ type_ "url"
-            , name_ name
-            , placeholder_ "https://github.com/user/repo.git"
-            , class_ "w-full"
-            ]
+  form_ [hxPostSafe_ $ linkTo LinkTo.RepoAdd, hxSwapS_ InnerHTML, class_ "space-y-6"] $ do
+    div_ [class_ "grid grid-cols-1 lg:grid-cols-2 gap-6"] $ do
+      W.viraFormGroup_
+        ( withFieldName @Repo @"name" $ \name ->
+            W.viraLabel_ [for_ name] "Repository Name"
+        )
+        ( withFieldName @Repo @"name" $ \name ->
+            W.viraInput_
+              [ type_ "text"
+              , name_ name
+              , placeholder_ "my-awesome-project"
+              , class_ "w-full"
+              , required_ ""
+              ]
+        )
+      W.viraFormGroup_
+        ( withFieldName @Repo @"cloneUrl" $ \name ->
+            W.viraLabel_ [for_ name] "Git Clone URL"
+        )
+        ( withFieldName @Repo @"cloneUrl" $ \name ->
+            W.viraInput_
+              [ type_ "url"
+              , name_ name
+              , placeholder_ "https://github.com/user/repo.git"
+              , class_ "w-full"
+              , required_ ""
+              ]
+        )
+
     -- Hidden dummy settings field (required by form structure)
     withFieldName @RepoSettings @"dummy" $ \name -> do
       W.viraInput_
@@ -128,8 +150,11 @@ newRepoForm linkTo = do
         , name_ name
         , value_ ""
         ]
+
     div_ [class_ "flex justify-end"] $ do
-      W.viraButton_ [type_ "submit", class_ "bg-blue-600 hover:bg-blue-700"] "Add Repository"
+      W.viraButton_ [type_ "submit", class_ "bg-indigo-600 hover:bg-indigo-700 focus:ring-indigo-500 px-8"] $ do
+        span_ [class_ "mr-2"] "🚀"
+        "Add Repository"
 
 withFieldName ::
   forall record field a r.

--- a/src/Vira/Page/RegistryPage.hs
+++ b/src/Vira/Page/RegistryPage.hs
@@ -92,16 +92,13 @@ viewRepoList linkTo registry = do
             let url = linkURI $ linkTo $ LinkTo.Repo repo.name
             W.viraCard_ [class_ "p-6 hover:shadow-xl transition-all duration-300 cursor-pointer group"] $ do
               a_ [href_ $ show url, class_ "block"] $ do
-                div_ [class_ "flex items-start justify-between mb-4"] $ do
+                div_ [class_ "flex items-start justify-between mb-3"] $ do
                   h3_ [class_ "text-xl font-bold text-gray-900 group-hover:text-indigo-600 transition-colors"] $
                     toHtml $
                       toString repo.name
                   span_ [class_ "text-gray-400 group-hover:text-indigo-500 transition-colors"] "→"
-                div_ [class_ "mb-4"] $ do
-                  W.viraCodeBlock_ (toText repo.cloneUrl)
-                div_ [class_ "flex items-center text-sm text-gray-500"] $ do
-                  span_ [class_ "mr-2"] "🔗"
-                  "View branches and builds"
+                p_ [class_ "text-sm text-gray-500 font-mono truncate"] $
+                  toHtml repo.cloneUrl
 
         W.viraDivider_
 

--- a/src/Vira/Page/RepoPage.hs
+++ b/src/Vira/Page/RepoPage.hs
@@ -91,15 +91,15 @@ viewRepo linkTo repo branches = do
             toHtml repo.cloneUrl
         div_ [class_ "flex gap-3 ml-6"] $ do
           W.viraButton_
+            W.ButtonSecondary
             [ hxPostSafe_ $ linkTo $ LinkTo.RepoUpdate repo.name
             , hxSwapS_ AfterEnd
-            , class_ "bg-blue-600 hover:bg-blue-700 focus:ring-blue-500"
             ]
             "🔄 Refresh Branches"
           W.viraButton_
+            W.ButtonDestructive
             [ hxPostSafe_ $ linkTo $ LinkTo.RepoDelete repo.name
             , hxSwapS_ AfterEnd
-            , class_ "bg-red-600 hover:bg-red-700 focus:ring-red-500"
             , hxConfirm_ "Are you sure you want to delete this repository? This action cannot be undone."
             ]
             "🗑️ Delete Repository"
@@ -120,9 +120,9 @@ viewRepo linkTo repo branches = do
                   JobPage.viewCommit branch.headCommit
               div_ $ do
                 W.viraButton_
+                  W.ButtonSuccess
                   [ hxPostSafe_ $ linkTo $ LinkTo.Build repo.name branch.branchName
                   , hxSwapS_ AfterEnd
-                  , class_ "bg-green-600 hover:bg-green-700 focus:ring-green-500"
                   ]
                   "🚀 Build"
 

--- a/src/Vira/Page/RepoPage.hs
+++ b/src/Vira/Page/RepoPage.hs
@@ -79,38 +79,55 @@ deleteHandler name = do
 -- TODO: Can we use `HtmlT (ReaderT ..) ()` to avoid threading the linkTo function?
 viewRepo :: (LinkTo.LinkTo -> Link) -> St.Repo -> [(St.Branch, [St.Job])] -> Html ()
 viewRepo linkTo repo branches = do
-  div_ $ do
-    div_ [class_ "flex items-center justify-between mb-4"] $ do
-      pre_ [class_ "rounded py-2 flex-1"] $ code_ $ toHtml repo.cloneUrl
-      div_ [class_ "flex gap-2 ml-4"] $ do
-        W.viraButton_
-          [ hxPostSafe_ $ linkTo $ LinkTo.RepoUpdate repo.name
-          , hxSwapS_ AfterEnd
-          , class_ "bg-blue-600 hover:bg-blue-700"
-          ]
-          "Refresh branches"
-        W.viraButton_
-          [ hxPostSafe_ $ linkTo $ LinkTo.RepoDelete repo.name
-          , hxSwapS_ AfterEnd
-          , class_ "bg-red-600 hover:bg-red-700"
-          , hxConfirm_ "Are you sure you want to delete this repository? This action cannot be undone."
-          ]
-          "Delete Repository"
-    div_ [class_ "space-y-8"] $ do
+  W.viraSection_ [] $ do
+    -- Repository header with improved styling
+    W.viraCard_ [class_ "p-6 mb-8"] $ do
+      div_ [class_ "flex items-center justify-between"] $ do
+        div_ [class_ "flex-1"] $ do
+          W.viraPageHeader_ (toText $ toString repo.name) $ do
+            W.viraCodeBlock_ (toText repo.cloneUrl)
+        div_ [class_ "flex gap-3 ml-6"] $ do
+          W.viraButton_
+            [ hxPostSafe_ $ linkTo $ LinkTo.RepoUpdate repo.name
+            , hxSwapS_ AfterEnd
+            , class_ "bg-blue-600 hover:bg-blue-700 focus:ring-blue-500"
+            ]
+            "🔄 Refresh Branches"
+          W.viraButton_
+            [ hxPostSafe_ $ linkTo $ LinkTo.RepoDelete repo.name
+            , hxSwapS_ AfterEnd
+            , class_ "bg-red-600 hover:bg-red-700 focus:ring-red-500"
+            , hxConfirm_ "Are you sure you want to delete this repository? This action cannot be undone."
+            ]
+            "🗑️ Delete Repository"
+
+    -- Branches section
+    div_ [class_ "space-y-6"] $ do
       forM_ branches $ \(branch, jobs) -> do
-        section_ [id_ (toText $ "branch-" <> toString branch.branchName), class_ "bg-white border-2 border-gray-300 rounded-xl shadow-md hover:shadow-lg hover:border-blue-400 transition-all duration-300 p-4 my-6"] $ do
-          let url = linkURI $ linkTo $ LinkTo.RepoBranch repo.name branch.branchName
-          h2_ [class_ "text-2xl font-semibold mb-3 border-b-2 border-blue-100 pb-2"] $ do
-            a_ [href_ $ show url, class_ "text-blue-600 hover:text-blue-800 hover:underline"] $ do
-              toHtml $ toString branch.branchName
-          div_ [class_ "mb-4 text-gray-600"] $ do
-            JobPage.viewCommit branch.headCommit
-          div_ [class_ "mb-4"] $
-            W.viraButton_
-              [ hxPostSafe_ $ linkTo $ LinkTo.Build repo.name branch.branchName
-              , hxSwapS_ AfterEnd
-              ]
-              "Build"
-          BranchPage.viewJobListing linkTo jobs
-          div_ [class_ "text-right"] $ do
-            a_ [href_ $ show url, class_ "text-blue-600 hover:text-blue-800 text-sm font-medium hover:underline"] "View all jobs →"
+        let url = linkURI $ linkTo $ LinkTo.RepoBranch repo.name branch.branchName
+        W.viraCard_ [id_ (toText $ "branch-" <> toString branch.branchName), class_ "overflow-hidden hover:shadow-xl transition-all duration-300"] $ do
+          -- Branch header
+          div_ [class_ "bg-gradient-to-r from-indigo-50 to-blue-50 p-6 border-b border-gray-100"] $ do
+            div_ [class_ "flex items-center justify-between"] $ do
+              div_ $ do
+                h2_ [class_ "text-2xl font-bold text-gray-900 mb-2"] $ do
+                  a_ [href_ $ show url, class_ "text-indigo-600 hover:text-indigo-800 transition-colors hover:underline"] $ do
+                    toHtml $ toString branch.branchName
+                div_ [class_ "text-gray-600"] $ do
+                  JobPage.viewCommit branch.headCommit
+              div_ $ do
+                W.viraButton_
+                  [ hxPostSafe_ $ linkTo $ LinkTo.Build repo.name branch.branchName
+                  , hxSwapS_ AfterEnd
+                  , class_ "bg-green-600 hover:bg-green-700 focus:ring-green-500"
+                  ]
+                  "🚀 Build"
+
+          -- Jobs listing
+          div_ [class_ "p-6"] $ do
+            BranchPage.viewJobListing linkTo jobs
+            W.viraDivider_
+            div_ [class_ "flex justify-end"] $ do
+              a_ [href_ $ show url, class_ "inline-flex items-center text-indigo-600 hover:text-indigo-800 font-medium transition-colors group"] $ do
+                "View all jobs"
+                span_ [class_ "ml-2 transform transition-transform group-hover:translate-x-1"] "→"

--- a/src/Vira/Page/RepoPage.hs
+++ b/src/Vira/Page/RepoPage.hs
@@ -82,10 +82,13 @@ viewRepo linkTo repo branches = do
   W.viraSection_ [] $ do
     -- Repository header with improved styling
     W.viraCard_ [class_ "p-6 mb-8"] $ do
-      div_ [class_ "flex items-center justify-between"] $ do
+      div_ [class_ "flex items-start justify-between"] $ do
         div_ [class_ "flex-1"] $ do
-          W.viraPageHeader_ (toText $ toString repo.name) $ do
-            W.viraCodeBlock_ (toText repo.cloneUrl)
+          h1_ [class_ "text-3xl font-bold text-gray-900 tracking-tight mb-3"] $
+            toHtml $
+              toString repo.name
+          p_ [class_ "text-sm text-gray-500 font-mono break-all"] $
+            toHtml repo.cloneUrl
         div_ [class_ "flex gap-3 ml-6"] $ do
           W.viraButton_
             [ hxPostSafe_ $ linkTo $ LinkTo.RepoUpdate repo.name
@@ -109,11 +112,11 @@ viewRepo linkTo repo branches = do
           -- Branch header
           div_ [class_ "bg-gradient-to-r from-indigo-50 to-blue-50 p-6 border-b border-gray-100"] $ do
             div_ [class_ "flex items-center justify-between"] $ do
-              div_ $ do
-                h2_ [class_ "text-2xl font-bold text-gray-900 mb-2"] $ do
+              div_ [class_ "flex items-center space-x-4"] $ do
+                h2_ [class_ "text-xl font-bold text-gray-900"] $ do
                   a_ [href_ $ show url, class_ "text-indigo-600 hover:text-indigo-800 transition-colors hover:underline"] $ do
                     toHtml $ toString branch.branchName
-                div_ [class_ "text-gray-600"] $ do
+                div_ [class_ "text-sm text-gray-500"] $ do
                   JobPage.viewCommit branch.headCommit
               div_ $ do
                 W.viraButton_

--- a/src/Vira/Page/SettingsPage.hs
+++ b/src/Vira/Page/SettingsPage.hs
@@ -162,7 +162,7 @@ viewSettings linkTo mCachix mAttic = do
           )
 
         div_ [class_ "flex items-center gap-3 pt-4"] $ do
-          W.viraButton_ [type_ "submit", form_ "cachix-update", class_ "bg-indigo-600 hover:bg-indigo-700 focus:ring-indigo-500"] $ do
+          W.viraButton_ W.ButtonPrimary [type_ "submit", form_ "cachix-update"] $ do
             case mCachixSettings of
               Nothing -> "Connect Cachix"
               Just _ -> "Update Settings"
@@ -170,7 +170,7 @@ viewSettings linkTo mCachix mAttic = do
       -- Disconnect form outside the main form to avoid nesting
       whenJust mCachixSettings $ \_ ->
         form_ [hxPostSafe_ $ linkTo LinkTo.SettingsDeleteCachix, hxSwapS_ InnerHTML, hxConfirm_ "Are you sure you want to disconnect Cachix? This action cannot be undone.", class_ "mt-3"] $ do
-          W.viraButton_ [type_ "submit", class_ "bg-red-600 hover:bg-red-700 focus:ring-red-500"] "Disconnect"
+          W.viraButton_ W.ButtonDestructive [type_ "submit"] "Disconnect"
 
     atticForm :: Maybe AtticSettings -> Html ()
     atticForm mAtticSettings = do
@@ -230,7 +230,7 @@ viewSettings linkTo mCachix mAttic = do
             )
 
         div_ [class_ "flex items-center gap-3 pt-4"] $ do
-          W.viraButton_ [type_ "submit", form_ "attic-update", class_ "bg-indigo-600 hover:bg-indigo-700 focus:ring-indigo-500"] $ do
+          W.viraButton_ W.ButtonPrimary [type_ "submit", form_ "attic-update"] $ do
             case mAtticSettings of
               Nothing -> "Connect Attic"
               Just _ -> "Update Settings"
@@ -238,7 +238,7 @@ viewSettings linkTo mCachix mAttic = do
       -- Disconnect form outside the main form to avoid nesting
       whenJust mAtticSettings $ \_ ->
         form_ [hxPostSafe_ $ linkTo LinkTo.SettingsDeleteAttic, hxSwapS_ InnerHTML, hxConfirm_ "Are you sure you want to disconnect Attic? This action cannot be undone.", class_ "mt-3"] $ do
-          W.viraButton_ [type_ "submit", class_ "bg-red-600 hover:bg-red-700 focus:ring-red-500"] "Disconnect"
+          W.viraButton_ W.ButtonDestructive [type_ "submit"] "Disconnect"
 
 withFieldName ::
   forall record field a r.

--- a/src/Vira/Page/SettingsPage.hs
+++ b/src/Vira/Page/SettingsPage.hs
@@ -166,9 +166,11 @@ viewSettings linkTo mCachix mAttic = do
             case mCachixSettings of
               Nothing -> "Connect Cachix"
               Just _ -> "Update Settings"
-          whenJust mCachixSettings $ \_ ->
-            form_ [hxPostSafe_ $ linkTo LinkTo.SettingsDeleteCachix, hxSwapS_ InnerHTML, hxConfirm_ "Are you sure you want to disconnect Cachix? This action cannot be undone.", class_ "inline"] $ do
-              W.viraButton_ [type_ "submit", class_ "bg-red-600 hover:bg-red-700 focus:ring-red-500"] "Disconnect"
+
+      -- Disconnect form outside the main form to avoid nesting
+      whenJust mCachixSettings $ \_ ->
+        form_ [hxPostSafe_ $ linkTo LinkTo.SettingsDeleteCachix, hxSwapS_ InnerHTML, hxConfirm_ "Are you sure you want to disconnect Cachix? This action cannot be undone.", class_ "mt-3"] $ do
+          W.viraButton_ [type_ "submit", class_ "bg-red-600 hover:bg-red-700 focus:ring-red-500"] "Disconnect"
 
     atticForm :: Maybe AtticSettings -> Html ()
     atticForm mAtticSettings = do
@@ -232,9 +234,11 @@ viewSettings linkTo mCachix mAttic = do
             case mAtticSettings of
               Nothing -> "Connect Attic"
               Just _ -> "Update Settings"
-          whenJust mAtticSettings $ \_ ->
-            form_ [hxPostSafe_ $ linkTo LinkTo.SettingsDeleteAttic, hxSwapS_ InnerHTML, hxConfirm_ "Are you sure you want to disconnect Attic? This action cannot be undone.", class_ "inline"] $ do
-              W.viraButton_ [type_ "submit", class_ "bg-red-600 hover:bg-red-700 focus:ring-red-500"] "Disconnect"
+
+      -- Disconnect form outside the main form to avoid nesting
+      whenJust mAtticSettings $ \_ ->
+        form_ [hxPostSafe_ $ linkTo LinkTo.SettingsDeleteAttic, hxSwapS_ InnerHTML, hxConfirm_ "Are you sure you want to disconnect Attic? This action cannot be undone.", class_ "mt-3"] $ do
+          W.viraButton_ [type_ "submit", class_ "bg-red-600 hover:bg-red-700 focus:ring-red-500"] "Disconnect"
 
 withFieldName ::
   forall record field a r.

--- a/src/Vira/Page/SettingsPage.hs
+++ b/src/Vira/Page/SettingsPage.hs
@@ -92,7 +92,7 @@ viewSettings linkTo mCachix mAttic = do
       -- Cachix Configuration
       W.viraCard_ [class_ "p-6"] $ do
         div_ [class_ "flex items-center mb-6"] $ do
-          img_ [src_ "https://docs.cachix.org/img/logo.svg", alt_ "Cachix", class_ "h-8 w-8 mr-3"]
+          span_ [class_ "h-8 w-8 mr-3 bg-blue-100 rounded-lg flex items-center justify-center text-blue-600 font-bold"] "C"
           h3_ [class_ "text-xl font-bold text-gray-900"] "Cachix Configuration"
 
         case mCachix of

--- a/src/Vira/Page/SettingsPage.hs
+++ b/src/Vira/Page/SettingsPage.hs
@@ -97,13 +97,13 @@ viewSettings linkTo mCachix mAttic = do
 
         case mCachix of
           Just cachix -> do
-            W.viraAlert_ "success" "bg-green-50 border-green-200" $ do
+            W.viraAlert_ W.AlertSuccess $ do
               p_ [class_ "text-green-800"] $ do
-                "✅ Connected to cache: "
+                "Connected to cache: "
                 strong_ $ toHtml cachix.cachixName
             W.viraDivider_
           Nothing -> do
-            W.viraAlert_ "info" "bg-blue-50 border-blue-200" $ do
+            W.viraAlert_ W.AlertInfo $ do
               p_ [class_ "text-blue-800"] "Configure Cachix to enable build caching"
             W.viraDivider_
 
@@ -117,16 +117,16 @@ viewSettings linkTo mCachix mAttic = do
 
         case mAttic of
           Just attic -> do
-            W.viraAlert_ "success" "bg-green-50 border-green-200" $ do
+            W.viraAlert_ W.AlertSuccess $ do
               p_ [class_ "text-green-800"] $ do
-                "✅ Connected to "
+                "Connected to "
                 strong_ $ toHtml attic.atticServer.serverName
                 " ("
                 toHtml $ toText attic.atticCacheName
                 ")"
             W.viraDivider_
           Nothing -> do
-            W.viraAlert_ "info" "bg-blue-50 border-blue-200" $ do
+            W.viraAlert_ W.AlertInfo $ do
               p_ [class_ "text-blue-800"] "Configure Attic for distributed build caching"
             W.viraDivider_
 

--- a/src/Vira/Page/SettingsPage.hs
+++ b/src/Vira/Page/SettingsPage.hs
@@ -83,79 +83,158 @@ deleteAtticHandler = do
   pure $ addHeader True "Ok"
 
 viewSettings :: (LinkTo.LinkTo -> Link) -> Maybe CachixSettings -> Maybe AtticSettings -> Html ()
-viewSettings linkTo mCachix mAttic =
-  div_ [class_ "space-y-8"] $ do
-    section_ [class_ "bg-white border-2 border-gray-300 rounded-xl shadow-md p-6"] cachixForm
-    section_ [class_ "bg-white border-2 border-gray-300 rounded-xl shadow-md p-6"] atticForm
+viewSettings linkTo mCachix mAttic = do
+  W.viraSection_ [] $ do
+    W.viraPageHeader_ "Settings" $ do
+      p_ [class_ "text-gray-600"] "Configure build cache providers and CI/CD integrations"
+
+    div_ [class_ "grid gap-8 lg:grid-cols-2"] $ do
+      -- Cachix Configuration
+      W.viraCard_ [class_ "p-6"] $ do
+        div_ [class_ "flex items-center mb-6"] $ do
+          img_ [src_ "https://docs.cachix.org/img/logo.svg", alt_ "Cachix", class_ "h-8 w-8 mr-3"]
+          h3_ [class_ "text-xl font-bold text-gray-900"] "Cachix Configuration"
+
+        case mCachix of
+          Just cachix -> do
+            W.viraAlert_ "success" "bg-green-50 border-green-200" $ do
+              p_ [class_ "text-green-800"] $ do
+                "✅ Connected to cache: "
+                strong_ $ toHtml cachix.cachixName
+            W.viraDivider_
+          Nothing -> do
+            W.viraAlert_ "info" "bg-blue-50 border-blue-200" $ do
+              p_ [class_ "text-blue-800"] "Configure Cachix to enable build caching"
+            W.viraDivider_
+
+        cachixForm mCachix
+
+      -- Attic Configuration
+      W.viraCard_ [class_ "p-6"] $ do
+        div_ [class_ "flex items-center mb-6"] $ do
+          span_ [class_ "h-8 w-8 mr-3 bg-purple-100 rounded-lg flex items-center justify-center text-purple-600 font-bold"] "A"
+          h3_ [class_ "text-xl font-bold text-gray-900"] "Attic Configuration"
+
+        case mAttic of
+          Just attic -> do
+            W.viraAlert_ "success" "bg-green-50 border-green-200" $ do
+              p_ [class_ "text-green-800"] $ do
+                "✅ Connected to "
+                strong_ $ toHtml attic.atticServer.serverName
+                " ("
+                toHtml $ toText attic.atticCacheName
+                ")"
+            W.viraDivider_
+          Nothing -> do
+            W.viraAlert_ "info" "bg-blue-50 border-blue-200" $ do
+              p_ [class_ "text-blue-800"] "Configure Attic for distributed build caching"
+            W.viraDivider_
+
+        atticForm mAttic
   where
-    cachixForm :: Html ()
-    cachixForm = do
-      h2_ [class_ "text-2xl font-semibold mb-4 text-gray-800"] "Cachix"
-      form_ [id_ "cachix-update", hxPostSafe_ $ linkTo LinkTo.SettingsUpdateCachix, hxSwapS_ InnerHTML, class_ "space-y-4"] $ do
-        div_ $ do
-          withFieldName @CachixSettings @"cachixName" $ \name -> do
-            W.viraLabel_ [for_ name] "Cache Name"
-            W.viraInput_
-              [ type_ "text"
-              , name_ name
-              , value_ $ maybe "" (.cachixName) mCachix
-              ]
-        div_ $ do
-          withFieldName @CachixSettings @"authToken" $ \name -> do
-            W.viraLabel_ [for_ name] "Auth Token"
-            W.viraInput_ $
-              [ type_ "text"
-              , name_ name
-              ]
-                <> maybe [] (const [placeholder_ "Hidden for security reasons"]) mCachix
+    cachixForm :: Maybe CachixSettings -> Html ()
+    cachixForm mCachixSettings = do
+      form_ [id_ "cachix-update", hxPostSafe_ $ linkTo LinkTo.SettingsUpdateCachix, hxSwapS_ InnerHTML, class_ "space-y-6"] $ do
+        W.viraFormGroup_
+          ( withFieldName @CachixSettings @"cachixName" $ \name ->
+              W.viraLabel_ [for_ name] "Cache Name"
+          )
+          ( withFieldName @CachixSettings @"cachixName" $ \name ->
+              W.viraInput_
+                [ type_ "text"
+                , name_ name
+                , value_ $ maybe "" (.cachixName) mCachixSettings
+                , placeholder_ "my-cache"
+                ]
+          )
 
-      div_ [class_ "flex items-center space-x-2 mt-4"] $ do
-        W.viraButton_ [type_ "submit", form_ "cachix-update"] "Update"
-        whenJust mCachix $ \_ ->
-          form_ [hxPostSafe_ $ linkTo LinkTo.SettingsDeleteCachix, hxSwapS_ InnerHTML, hxConfirm_ "Are you sure you want to delete the Cachix settings? This action cannot be undone."] $ do
-            W.viraButton_ [type_ "submit", class_ "bg-red-600 hover:bg-red-700"] "Delete"
+        W.viraFormGroup_
+          ( withFieldName @CachixSettings @"authToken" $ \name ->
+              W.viraLabel_ [for_ name] "Auth Token"
+          )
+          ( withFieldName @CachixSettings @"authToken" $ \name ->
+              W.viraInput_ $
+                [ type_ "password"
+                , name_ name
+                , placeholder_ $ maybe "Enter your Cachix auth token" (const "••••••••••••") mCachixSettings
+                ]
+                  <> maybe [] (const []) mCachixSettings
+          )
 
-    atticForm :: Html ()
-    atticForm = do
-      h2_ [class_ "text-2xl font-semibold mb-4 text-gray-800"] "Attic"
-      form_ [id_ "attic-update", hxPostSafe_ $ linkTo LinkTo.SettingsUpdateAttic, hxSwapS_ InnerHTML, class_ "space-y-4"] $ do
-        div_ $ do
-          withFieldName @AtticServer @"serverName" $ \name -> do
-            W.viraLabel_ [for_ name] "Server Name"
-            W.viraInput_
-              [ type_ "text"
-              , name_ name
-              , value_ $ maybe "" ((.serverName) . (.atticServer)) mAttic
-              ]
-        div_ $ do
-          withFieldName @AtticServer @"serverUrl" $ \name -> do
-            W.viraLabel_ [for_ name] "Server URL"
-            W.viraInput_
-              [ type_ "url"
-              , name_ name
-              , value_ $ maybe "" ((.serverUrl) . (.atticServer)) mAttic
-              ]
-        div_ $ do
-          withFieldName @AtticSettings @"atticCacheName" $ \name -> do
-            W.viraLabel_ [for_ name] "Cache Name"
-            W.viraInput_
-              [ type_ "text"
-              , name_ name
-              , value_ $ maybe "" (toText . (.atticCacheName)) mAttic
-              ]
-        div_ $ do
-          withFieldName @AtticSettings @"atticToken" $ \name -> do
-            W.viraLabel_ [for_ name] "Token"
-            W.viraInput_ $
-              [ type_ "text"
-              , name_ name
-              ]
-                <> maybe [] (const [placeholder_ "Hidden for security reasons"]) mAttic
-      div_ [class_ "flex items-center space-x-2 mt-4"] $ do
-        W.viraButton_ [type_ "submit", form_ "attic-update"] "Update"
-        whenJust mAttic $ \_ ->
-          form_ [hxPostSafe_ $ linkTo LinkTo.SettingsDeleteAttic, hxSwapS_ InnerHTML, hxConfirm_ "Are you sure you want to delete the Attic settings? This action cannot be undone."] $ do
-            W.viraButton_ [type_ "submit", class_ "bg-red-600 hover:bg-red-700"] "Delete"
+        div_ [class_ "flex items-center gap-3 pt-4"] $ do
+          W.viraButton_ [type_ "submit", form_ "cachix-update", class_ "bg-indigo-600 hover:bg-indigo-700 focus:ring-indigo-500"] $ do
+            case mCachixSettings of
+              Nothing -> "Connect Cachix"
+              Just _ -> "Update Settings"
+          whenJust mCachixSettings $ \_ ->
+            form_ [hxPostSafe_ $ linkTo LinkTo.SettingsDeleteCachix, hxSwapS_ InnerHTML, hxConfirm_ "Are you sure you want to disconnect Cachix? This action cannot be undone.", class_ "inline"] $ do
+              W.viraButton_ [type_ "submit", class_ "bg-red-600 hover:bg-red-700 focus:ring-red-500"] "Disconnect"
+
+    atticForm :: Maybe AtticSettings -> Html ()
+    atticForm mAtticSettings = do
+      form_ [id_ "attic-update", hxPostSafe_ $ linkTo LinkTo.SettingsUpdateAttic, hxSwapS_ InnerHTML, class_ "space-y-6"] $ do
+        div_ [class_ "grid gap-4 lg:grid-cols-2"] $ do
+          W.viraFormGroup_
+            ( withFieldName @AtticServer @"serverName" $ \name ->
+                W.viraLabel_ [for_ name] "Server Name"
+            )
+            ( withFieldName @AtticServer @"serverName" $ \name ->
+                W.viraInput_
+                  [ type_ "text"
+                  , name_ name
+                  , value_ $ maybe "" ((.serverName) . (.atticServer)) mAtticSettings
+                  , placeholder_ "my-attic"
+                  ]
+            )
+
+          W.viraFormGroup_
+            ( withFieldName @AtticServer @"serverUrl" $ \name ->
+                W.viraLabel_ [for_ name] "Server URL"
+            )
+            ( withFieldName @AtticServer @"serverUrl" $ \name ->
+                W.viraInput_
+                  [ type_ "url"
+                  , name_ name
+                  , value_ $ maybe "" ((.serverUrl) . (.atticServer)) mAtticSettings
+                  , placeholder_ "https://attic.example.com"
+                  ]
+            )
+
+        div_ [class_ "grid gap-4 lg:grid-cols-2"] $ do
+          W.viraFormGroup_
+            ( withFieldName @AtticSettings @"atticCacheName" $ \name ->
+                W.viraLabel_ [for_ name] "Cache Name"
+            )
+            ( withFieldName @AtticSettings @"atticCacheName" $ \name ->
+                W.viraInput_
+                  [ type_ "text"
+                  , name_ name
+                  , value_ $ maybe "" (toText . (.atticCacheName)) mAtticSettings
+                  , placeholder_ "cache-name"
+                  ]
+            )
+
+          W.viraFormGroup_
+            ( withFieldName @AtticSettings @"atticToken" $ \name ->
+                W.viraLabel_ [for_ name] "Token"
+            )
+            ( withFieldName @AtticSettings @"atticToken" $ \name ->
+                W.viraInput_ $
+                  [ type_ "password"
+                  , name_ name
+                  , placeholder_ $ maybe "Enter your Attic token" (const "••••••••••••") mAtticSettings
+                  ]
+                    <> maybe [] (const []) mAtticSettings
+            )
+
+        div_ [class_ "flex items-center gap-3 pt-4"] $ do
+          W.viraButton_ [type_ "submit", form_ "attic-update", class_ "bg-indigo-600 hover:bg-indigo-700 focus:ring-indigo-500"] $ do
+            case mAtticSettings of
+              Nothing -> "Connect Attic"
+              Just _ -> "Update Settings"
+          whenJust mAtticSettings $ \_ ->
+            form_ [hxPostSafe_ $ linkTo LinkTo.SettingsDeleteAttic, hxSwapS_ InnerHTML, hxConfirm_ "Are you sure you want to disconnect Attic? This action cannot be undone.", class_ "inline"] $ do
+              W.viraButton_ [type_ "submit", class_ "bg-red-600 hover:bg-red-700 focus:ring-red-500"] "Disconnect"
 
 withFieldName ::
   forall record field a r.

--- a/src/Vira/Widgets.hs
+++ b/src/Vira/Widgets.hs
@@ -57,6 +57,7 @@ module Vira.Widgets (
 
   -- * Type-safe enums
   AlertType (..),
+  ButtonVariant (..),
 ) where
 
 import Lucid
@@ -74,6 +75,18 @@ data AlertType
   | AlertError
   | AlertWarning
   | AlertInfo
+  deriving stock (Eq, Show)
+
+-- | Button variant types for consistent styling
+data ButtonVariant
+  = -- | Indigo - primary actions, forms
+    ButtonPrimary
+  | -- | Red - delete, disconnect, kill actions
+    ButtonDestructive
+  | -- | Green - build, success actions
+    ButtonSuccess
+  | -- | Gray - secondary actions
+    ButtonSecondary
   deriving stock (Eq, Show)
 
 -- | Common HTML layout for all routes.
@@ -164,43 +177,58 @@ breadcrumbs linkTo rs' = do
       span_ [class_ "mx-1 text-white/60"] $ toHtmlRaw ("<svg xmlns='http://www.w3.org/2000/svg' class='h-5 w-5' fill='none' viewBox='0 0 24 24' stroke='currentColor' stroke-width='2'><path stroke-linecap='round' stroke-linejoin='round' d='M9 5l7 7-7 7'/></svg>" :: Text)
 
 {- |
-Enhanced button component with improved styling and hover states.
+Enhanced button component with type-safe styling variants.
 
 This is the primary button component for all user actions. It includes:
+- Type-safe variant system for consistent styling
 - Smooth transitions and micro-interactions
 - Proper focus states for accessibility
 - Disabled state handling
-- Consistent indigo brand colors by default
+- Automatic color coordination
 
 = Usage Examples
 
 @
 -- Primary action (most important action on page)
-W.viraButton_ [class_ "bg-indigo-600 hover:bg-indigo-700 focus:ring-indigo-500"] "Save Changes"
+W.viraButton_ W.ButtonPrimary [type_ "submit"] "Save Changes"
 
 -- Success action
-W.viraButton_ [class_ "bg-green-600 hover:bg-green-700 focus:ring-green-500"] "✅ Build"
+W.viraButton_ W.ButtonSuccess [] "✅ Build"
 
 -- Destructive action
-W.viraButton_ [class_ "bg-red-600 hover:bg-red-700 focus:ring-red-500"] "🗑️ Delete"
+W.viraButton_ W.ButtonDestructive [] "🗑️ Delete"
 
--- Submit button in forms
-W.viraButton_ [type_ "submit", form_ "my-form"] "Submit"
+-- Secondary action
+W.viraButton_ W.ButtonSecondary [] "Cancel"
+
+-- With additional attributes
+W.viraButton_ W.ButtonPrimary [type_ "submit", form_ "my-form"] "Submit"
 @
 
-= Styling Guidelines
+= Variant Guidelines
 
-Override colors using Tailwind classes while maintaining the component structure.
-Always include hover and focus ring colors that match the background color.
+- **ButtonPrimary**: Main actions, form submissions (indigo)
+- **ButtonSuccess**: Positive actions like build, save (green)
+- **ButtonDestructive**: Delete, disconnect, kill actions (red)
+- **ButtonSecondary**: Less important actions, cancel (gray)
+
+= Type Safety
+
+Colors are automatically managed by the variant type, preventing inconsistent styling.
 -}
-viraButton_ :: forall {result}. (Term [Attributes] result) => [Attributes] -> result
-viraButton_ attrs =
-  button_
-    ( [ class_ "inline-flex items-center justify-center px-6 py-3 text-sm font-semibold rounded-lg transition-smooth focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed bg-indigo-600 hover:bg-indigo-700 text-white shadow-md hover:shadow-lg focus:ring-indigo-500"
-      , hyperscript_ "on click add .scale-95 then wait 100ms then remove .scale-95"
-      ]
-        <> attrs
-    )
+viraButton_ :: forall {result}. (Term [Attributes] result) => ButtonVariant -> [Attributes] -> result
+viraButton_ variant attrs =
+  let (colorClasses, focusRing) = case variant of
+        ButtonPrimary -> ("bg-indigo-600 hover:bg-indigo-700 text-white", "focus:ring-indigo-500")
+        ButtonSuccess -> ("bg-green-600 hover:bg-green-700 text-white", "focus:ring-green-500")
+        ButtonDestructive -> ("bg-red-600 hover:bg-red-700 text-white", "focus:ring-red-500")
+        ButtonSecondary -> ("bg-gray-600 hover:bg-gray-700 text-white", "focus:ring-gray-500")
+   in button_
+        ( [ class_ $ "inline-flex items-center justify-center px-6 py-3 text-sm font-semibold rounded-lg transition-smooth focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed shadow-md hover:shadow-lg " <> colorClasses <> " " <> focusRing
+          , hyperscript_ "on click add .scale-95 then wait 100ms then remove .scale-95"
+          ]
+            <> attrs
+        )
 
 {- |
 Icon button variant for secondary actions and toolbar buttons.

--- a/src/Vira/Widgets.hs
+++ b/src/Vira/Widgets.hs
@@ -6,6 +6,15 @@ module Vira.Widgets (
   viraButton_,
   viraInput_,
   viraLabel_,
+  viraCard_,
+  viraSection_,
+  viraPageHeader_,
+  viraStatusBadge_,
+  viraCodeBlock_,
+  viraAlert_,
+  viraFormGroup_,
+  viraIconButton_,
+  viraDivider_,
 ) where
 
 import Lucid
@@ -31,15 +40,31 @@ layout cfg crumbs content = do
             " - "
         toHtml siteTitle
       base_ [href_ cfg.cliSettings.basePath]
+      -- Google Fonts - Inter for modern, clean typography
+      link_ [rel_ "preconnect", href_ "https://fonts.googleapis.com"]
+      link_ [rel_ "preconnect", href_ "https://fonts.gstatic.com", crossorigin_ ""]
+      link_ [href_ "https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap", rel_ "stylesheet"]
       -- favicon
       link_ [rel_ "icon", type_ "image/jpg", href_ "vira-logo.jpg"]
       htmx
       link_ [rel_ "stylesheet", type_ "text/css", href_ "tailwind.css"]
-    body_ [class_ "bg-orange-50"] $ do
-      div_ [class_ "container mx-auto p-4 mt-8 bg-white rounded shadow-lg"] $ do
-        let crumbs' = crumbs <&> \l -> (toHtml $ linkShortTitle l, linkURI $ cfg.linkTo l)
-        breadcrumbs cfg.linkTo crumbs'
-        content
+      -- Custom styles for the new design
+      style_ $
+        unlines
+          [ "body { font-family: 'Inter', ui-sans-serif, system-ui, sans-serif; }"
+          , ".gradient-bg { background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); }"
+          , ".glass-effect { backdrop-filter: blur(10px); background: rgba(255, 255, 255, 0.1); }"
+          , ".shadow-elegant { box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04); }"
+          , ".transition-smooth { transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1); }"
+          ]
+    body_ [class_ "bg-gradient-to-br from-slate-50 to-blue-50 min-h-screen font-inter"] $ do
+      div_ [class_ "min-h-screen"] $ do
+        -- Main container with improved styling
+        div_ [class_ "container mx-auto px-4 py-6 lg:px-8"] $ do
+          div_ [class_ "bg-white/80 backdrop-blur-sm border border-white/20 rounded-2xl shadow-elegant p-6 lg:p-8"] $ do
+            let crumbs' = crumbs <&> \l -> (toHtml $ linkShortTitle l, linkURI $ cfg.linkTo l)
+            breadcrumbs cfg.linkTo crumbs'
+            content
   where
     siteTitle = "Vira (" <> cfg.cliSettings.instanceName <> ")"
     -- Mobile friendly head tags
@@ -59,10 +84,10 @@ layout cfg crumbs content = do
 breadcrumbs :: (LinkTo -> Link) -> [(Html (), URI)] -> Html ()
 breadcrumbs linkTo rs' = do
   let home = URI {uriScheme = "", uriAuthority = Nothing, uriPath = "", uriQuery = [], uriFragment = ""}
-      logo = img_ [src_ "vira-logo.jpg", alt_ "Vira Logo", style_ "height: 32px;"]
+      logo = img_ [src_ "vira-logo.jpg", alt_ "Vira Logo", class_ "h-8 w-8 rounded-lg shadow-sm"]
       rs = (logo, home) :| rs'
-  nav_ [id_ "breadcrumbs", class_ "flex items-center text-sm p-2 mb-4 bg-orange-700 rounded"] $ do
-    ol_ [class_ "flex flex-1 items-center space-x-1 text-xl list-none"] $
+  nav_ [id_ "breadcrumbs", class_ "flex items-center justify-between p-4 mb-6 bg-gradient-to-r from-indigo-600 via-purple-600 to-blue-600 rounded-xl shadow-lg"] $ do
+    ol_ [class_ "flex flex-1 items-center space-x-2 text-lg list-none"] $
       renderCrumbs (toList rs)
     Status.viewStream linkTo
   where
@@ -79,30 +104,104 @@ breadcrumbs linkTo rs' = do
       Just r ->
         a_
           [ href_ (show r)
-          , class_ "text-gray-100 hover:text-white transition-colors px-2 py-1 rounded focus:outline-none focus:ring-2 focus:ring-white"
+          , class_ "text-white/90 hover:text-white transition-smooth px-3 py-2 rounded-lg hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/30 font-medium"
           ]
           $ toHtml s
       Nothing ->
-        span_ [class_ "font-bold text-white px-2 py-1 rounded bg-orange-800"] $ toHtml s
+        span_ [class_ "font-semibold text-white px-3 py-2 rounded-lg bg-white/20 backdrop-blur-sm"] $ toHtml s
     chevronSvg =
-      span_ [class_ "mx-1 text-gray-300"] $ toHtmlRaw ("<svg xmlns='http://www.w3.org/2000/svg' class='h-4 w-4' fill='none' viewBox='0 0 24 24' stroke='currentColor' stroke-width='2'><path stroke-linecap='round' stroke-linejoin='round' d='M9 5l7 7-7 7'/></svg>" :: Text)
+      span_ [class_ "mx-1 text-white/60"] $ toHtmlRaw ("<svg xmlns='http://www.w3.org/2000/svg' class='h-5 w-5' fill='none' viewBox='0 0 24 24' stroke='currentColor' stroke-width='2'><path stroke-linecap='round' stroke-linejoin='round' d='M9 5l7 7-7 7'/></svg>" :: Text)
 
+-- | Enhanced button component with improved styling and variants
 viraButton_ :: forall {result}. (Term [Attributes] result) => [Attributes] -> result
 viraButton_ attrs =
   button_
-    ( [ class_ "inline-flex h-12 items-center justify-center rounded-md bg-blue-950 px-4 my-2 font-medium text-neutral-50 shadow-lg shadow-blue-500/20 transition active:scale-95"
+    ( [ class_ "inline-flex items-center justify-center px-6 py-3 text-sm font-semibold rounded-lg transition-smooth focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed bg-indigo-600 hover:bg-indigo-700 text-white shadow-md hover:shadow-lg focus:ring-indigo-500"
       , type_ "button"
-      , hyperscript_ "on click toggle .bg-green-500 until htmx:afterOnLoad"
+      , hyperscript_ "on click add .scale-95 then wait 100ms then remove .scale-95"
       ]
         <> attrs
     )
+
+-- | Icon button variant for actions
+viraIconButton_ :: forall {result}. (Term [Attributes] result) => [Attributes] -> result
+viraIconButton_ attrs =
+  button_
+    ( [ class_ "inline-flex items-center justify-center p-2 text-sm font-medium rounded-lg transition-smooth focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed bg-white hover:bg-gray-50 text-gray-700 border border-gray-300 shadow-sm hover:shadow-md focus:ring-indigo-500"
+      , type_ "button"
+      ]
+        <> attrs
+    )
+
+-- | Card container component
+viraCard_ :: forall {result}. (Term [Attributes] result) => [Attributes] -> result
+viraCard_ attrs =
+  div_
+    ( [ class_ "bg-white rounded-xl border border-gray-200 shadow-elegant hover:shadow-lg transition-smooth overflow-hidden"
+      ]
+        <> attrs
+    )
+
+-- | Section component for grouping content
+viraSection_ :: forall {result}. (Term [Attributes] result) => [Attributes] -> result
+viraSection_ attrs =
+  section_
+    ( [ class_ "space-y-6"
+      ]
+        <> attrs
+    )
+
+-- | Page header component
+viraPageHeader_ :: Text -> Html () -> Html ()
+viraPageHeader_ title subtitle = do
+  div_ [class_ "border-b border-gray-200 pb-6 mb-8"] $ do
+    h1_ [class_ "text-3xl font-bold text-gray-900 tracking-tight"] $ toHtml title
+    div_ [class_ "mt-2 text-gray-600"] subtitle
+
+-- | Status badge component with color variants
+viraStatusBadge_ :: Text -> Text -> Html ()
+viraStatusBadge_ status colorClass = do
+  span_ [class_ $ "inline-flex items-center px-3 py-1 rounded-full text-sm font-medium " <> colorClass] $
+    toHtml status
+
+-- | Code block component
+viraCodeBlock_ :: Text -> Html ()
+viraCodeBlock_ code = do
+  div_ [class_ "bg-gray-50 border border-gray-200 rounded-lg p-4 overflow-x-auto"] $ do
+    code_ [class_ "text-sm text-gray-800 font-mono break-all"] $ toHtml code
+
+-- | Alert component with variants
+viraAlert_ :: Text -> Text -> Html () -> Html ()
+viraAlert_ alertType colorClass content = do
+  div_ [class_ $ "rounded-lg p-4 border " <> colorClass, role_ "alert"] $ do
+    div_ [class_ "flex items-start"] $ do
+      div_ [class_ "flex-shrink-0"] $ do
+        case alertType of
+          "error" -> span_ [class_ "text-red-500"] "❌"
+          "warning" -> span_ [class_ "text-yellow-500"] "⚠️"
+          "success" -> span_ [class_ "text-green-500"] "✅"
+          "info" -> span_ [class_ "text-blue-500"] "ℹ️"
+          _ -> span_ [class_ "text-gray-500"] "•"
+      div_ [class_ "ml-3 flex-1"] content
+
+-- | Form group component for consistent form layout
+viraFormGroup_ :: Html () -> Html () -> Html ()
+viraFormGroup_ label input = do
+  div_ [class_ "space-y-2"] $ do
+    label
+    input
+
+-- | Divider component
+viraDivider_ :: Html ()
+viraDivider_ = do
+  hr_ [class_ "border-gray-200 my-6"]
 
 -- Form related widgets below
 
 viraInput_ :: forall (m :: Type -> Type). (Monad m) => [Attributes] -> HtmlT m ()
 viraInput_ attrs = do
-  input_ ([class_ "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"] <> attrs)
+  input_ ([class_ "block w-full px-4 py-3 text-sm border border-gray-300 rounded-lg shadow-sm placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition-smooth"] <> attrs)
 
 viraLabel_ :: forall {result}. (Term [Attributes] result) => [Attributes] -> result
 viraLabel_ attrs = do
-  label_ ([class_ "block text-sm font-medium text-gray-700"] <> attrs)
+  label_ ([class_ "block text-sm font-semibold text-gray-700 mb-1"] <> attrs)

--- a/src/Vira/Widgets.hs
+++ b/src/Vira/Widgets.hs
@@ -11,6 +11,7 @@ module Vira.Widgets (
   viraPageHeader_,
   viraStatusBadge_,
   viraCodeBlock_,
+  viraCodeInline_,
   viraAlert_,
   viraFormGroup_,
   viraIconButton_,
@@ -19,9 +20,9 @@ module Vira.Widgets (
 
 import Lucid
 import Servant.Links (Link, URI (..), linkURI)
-import Vira.App (AppState (cliSettings, linkTo), instanceName)
-import Vira.App.CLI (CLISettings (basePath))
+import Vira.App.CLI (CLISettings (basePath), instanceName)
 import Vira.App.LinkTo.Type (LinkTo, linkShortTitle)
+import Vira.App.Stack (AppState (cliSettings, linkTo))
 import Vira.Lib.HTMX
 import Vira.Stream.Status qualified as Status
 
@@ -169,6 +170,11 @@ viraCodeBlock_ :: Text -> Html ()
 viraCodeBlock_ code = do
   div_ [class_ "bg-gray-50 border border-gray-200 rounded-lg p-4 overflow-x-auto"] $ do
     code_ [class_ "text-sm text-gray-800 font-mono break-all"] $ toHtml code
+
+-- | Inline code component for smaller code snippets
+viraCodeInline_ :: Text -> Html ()
+viraCodeInline_ code = do
+  code_ [class_ "px-2 py-1 text-xs bg-gray-100 text-gray-700 rounded font-mono"] $ toHtml code
 
 -- | Alert component with variants
 viraAlert_ :: Text -> Text -> Html () -> Html ()

--- a/src/Vira/Widgets.hs
+++ b/src/Vira/Widgets.hs
@@ -1,6 +1,44 @@
 {-# LANGUAGE OverloadedRecordDot #-}
 
--- | Common Lucid rendering helpers
+{- |
+Vira Design System - Reusable UI Components
+
+This module contains all reusable UI components for the Vira CI/CD application.
+All components follow the Vira Design System guidelines defined in DESIGN.md.
+
+= Component Categories
+
+== Layout Components
+- 'viraSection_' - Page section wrapper with consistent spacing
+- 'viraCard_' - Card container with elegant shadows and rounded corners
+- 'viraPageHeader_' - Standardized page headers with title and subtitle
+- 'viraDivider_' - Visual content separator
+
+== Interactive Components
+- 'viraButton_' - Primary action buttons with hover states
+- 'viraIconButton_' - Icon-only buttons for secondary actions
+- 'viraInput_' - Form input fields with proper focus states
+- 'viraLabel_' - Form labels with consistent typography
+
+== Display Components
+- 'viraStatusBadge_' - Status indicators with semantic colors
+- 'viraCodeBlock_' - Code display with proper formatting
+- 'viraCodeInline_' - Inline code elements
+- 'viraAlert_' - Alert messages (success, error, warning, info)
+- 'viraFormGroup_' - Form field grouping for consistent layouts
+
+= Usage Guidelines
+
+Always use these components instead of raw HTML to maintain design consistency.
+Follow the Vira Design System color palette and spacing guidelines.
+
+= Design Principles
+
+- Modern & Professional: Clean, contemporary design
+- Clarity & Focus: Clear information hierarchy
+- Consistency: Unified visual language
+- Accessibility: Inclusive design with proper focus states
+-}
 module Vira.Widgets (
   layout,
   viraButton_,
@@ -113,28 +151,110 @@ breadcrumbs linkTo rs' = do
     chevronSvg =
       span_ [class_ "mx-1 text-white/60"] $ toHtmlRaw ("<svg xmlns='http://www.w3.org/2000/svg' class='h-5 w-5' fill='none' viewBox='0 0 24 24' stroke='currentColor' stroke-width='2'><path stroke-linecap='round' stroke-linejoin='round' d='M9 5l7 7-7 7'/></svg>" :: Text)
 
--- | Enhanced button component with improved styling and variants
+{- |
+Enhanced button component with improved styling and hover states.
+
+This is the primary button component for all user actions. It includes:
+- Smooth transitions and micro-interactions
+- Proper focus states for accessibility
+- Disabled state handling
+- Consistent indigo brand colors by default
+
+= Usage Examples
+
+@
+-- Primary action (most important action on page)
+W.viraButton_ [class_ "bg-indigo-600 hover:bg-indigo-700 focus:ring-indigo-500"] "Save Changes"
+
+-- Success action
+W.viraButton_ [class_ "bg-green-600 hover:bg-green-700 focus:ring-green-500"] "✅ Build"
+
+-- Destructive action
+W.viraButton_ [class_ "bg-red-600 hover:bg-red-700 focus:ring-red-500"] "🗑️ Delete"
+
+-- Submit button in forms
+W.viraButton_ [type_ "submit", form_ "my-form"] "Submit"
+@
+
+= Styling Guidelines
+
+Override colors using Tailwind classes while maintaining the component structure.
+Always include hover and focus ring colors that match the background color.
+-}
 viraButton_ :: forall {result}. (Term [Attributes] result) => [Attributes] -> result
 viraButton_ attrs =
   button_
     ( [ class_ "inline-flex items-center justify-center px-6 py-3 text-sm font-semibold rounded-lg transition-smooth focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed bg-indigo-600 hover:bg-indigo-700 text-white shadow-md hover:shadow-lg focus:ring-indigo-500"
-      , type_ "button"
       , hyperscript_ "on click add .scale-95 then wait 100ms then remove .scale-95"
       ]
         <> attrs
     )
 
--- | Icon button variant for actions
+{- |
+Icon button variant for secondary actions and toolbar buttons.
+
+Smaller, more subtle button for icon-only actions. Perfect for:
+- Toolbar actions
+- Settings buttons
+- Secondary controls that don't need emphasis
+
+= Usage Examples
+
+@
+-- Settings action
+W.viraIconButton_ [] "⚙️"
+
+-- Edit action
+W.viraIconButton_ [title_ "Edit"] "✏️"
+
+-- Close/cancel action
+W.viraIconButton_ [onclick_ "closeModal()"] "✕"
+@
+
+= Design Notes
+
+Uses neutral colors by default to avoid competing with primary actions.
+Always include a title attribute for accessibility when using icons.
+-}
 viraIconButton_ :: forall {result}. (Term [Attributes] result) => [Attributes] -> result
 viraIconButton_ attrs =
   button_
     ( [ class_ "inline-flex items-center justify-center p-2 text-sm font-medium rounded-lg transition-smooth focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed bg-white hover:bg-gray-50 text-gray-700 border border-gray-300 shadow-sm hover:shadow-md focus:ring-indigo-500"
-      , type_ "button"
       ]
         <> attrs
     )
 
--- | Card container component
+{- |
+Card container component with elegant styling and hover effects.
+
+The primary container for grouping related content. Features:
+- Elegant shadow that lifts on hover
+- Rounded corners and subtle borders
+- Consistent spacing and overflow handling
+- Glass-morphism inspired design
+
+= Usage Examples
+
+@
+-- Basic content card
+W.viraCard_ [class_ "p-6"] $ do
+  h3_ [class_ "text-lg font-semibold mb-4"] "Card Title"
+  p_ [class_ "text-gray-600"] "Card content goes here"
+
+-- Repository card with custom padding
+W.viraCard_ [class_ "p-4 hover:bg-gray-50"] $ do
+  -- Repository details
+
+-- Settings section card
+W.viraCard_ [class_ "p-6 mb-6"] $ do
+  -- Configuration form
+@
+
+= Layout Guidelines
+
+Use consistent padding: p-4 for compact cards, p-6 for standard cards.
+Combine with grid layouts for responsive card grids.
+-}
 viraCard_ :: forall {result}. (Term [Attributes] result) => [Attributes] -> result
 viraCard_ attrs =
   div_
@@ -143,7 +263,32 @@ viraCard_ attrs =
         <> attrs
     )
 
--- | Section component for grouping content
+{- |
+Section component for grouping and spacing page content.
+
+Provides consistent vertical spacing between content sections.
+Use this as the main wrapper for page content areas.
+
+= Usage Examples
+
+@
+-- Main page content
+W.viraSection_ [] $ do
+  W.viraPageHeader_ "Page Title" $ do
+    p_ [class_ "text-gray-600"] "Page description"
+
+  W.viraCard_ [class_ "p-6"] $ do
+    -- Main content
+
+-- Custom spacing
+W.viraSection_ [class_ "space-y-8"] $ do
+  -- Content with larger spacing
+@
+
+= Spacing System
+
+Default spacing is space-y-6 (24px). Override with space-y-* classes as needed.
+-}
 viraSection_ :: forall {result}. (Term [Attributes] result) => [Attributes] -> result
 viraSection_ attrs =
   section_
@@ -152,31 +297,187 @@ viraSection_ attrs =
         <> attrs
     )
 
--- | Page header component
+{- |
+Standardized page header with title and subtitle.
+
+Creates consistent page headers across the application with:
+- Large, bold title typography
+- Subtle subtitle area for descriptions
+- Bottom border for visual separation
+- Proper spacing and hierarchy
+
+= Usage Examples
+
+@
+-- Basic page header
+W.viraPageHeader_ "Settings" $ do
+  p_ [class_ "text-gray-600"] "Configure your CI/CD settings"
+
+-- Header with multiple subtitle elements
+W.viraPageHeader_ "Repository Details" $ do
+  div_ [class_ "flex items-center space-x-4 text-gray-600"] $ do
+    span_ "Last updated: 2 hours ago"
+    W.viraStatusBadge_ "Active" "bg-green-100 text-green-800"
+
+-- Simple header without subtitle
+W.viraPageHeader_ "Build Logs" mempty
+@
+
+= Typography Guidelines
+
+Title uses text-3xl font-bold for strong hierarchy.
+Subtitle area should use text-gray-600 for proper contrast.
+-}
 viraPageHeader_ :: Text -> Html () -> Html ()
 viraPageHeader_ title subtitle = do
   div_ [class_ "border-b border-gray-200 pb-6 mb-8"] $ do
     h1_ [class_ "text-3xl font-bold text-gray-900 tracking-tight"] $ toHtml title
     div_ [class_ "mt-2 text-gray-600"] subtitle
 
--- | Status badge component with color variants
+{- |
+Status badge component with semantic color variants.
+
+Displays status information with appropriate colors and styling.
+Follows the Vira Design System status color guidelines.
+
+= Usage Examples
+
+@
+-- Success status
+W.viraStatusBadge_ "Success" "bg-green-100 text-green-800 border-green-200"
+
+-- Error status
+W.viraStatusBadge_ "Failed" "bg-red-100 text-red-800 border-red-200"
+
+-- Warning/Pending status
+W.viraStatusBadge_ "Pending" "bg-yellow-100 text-yellow-800 border-yellow-200"
+
+-- Info/Running status
+W.viraStatusBadge_ "Running" "bg-blue-100 text-blue-800 border-blue-200"
+
+-- Killed status (darker red for distinction)
+W.viraStatusBadge_ "Killed" "bg-red-200 text-red-900 border-red-300"
+@
+
+= Color Guidelines
+
+Use semantic colors that match the status meaning:
+- Green: Success, connected, healthy states
+- Red: Errors, failures, killed processes
+- Yellow: Warnings, pending states
+- Blue: Information, running processes
+- Gray: Neutral, inactive states
+-}
 viraStatusBadge_ :: Text -> Text -> Html ()
 viraStatusBadge_ status colorClass = do
   span_ [class_ $ "inline-flex items-center px-3 py-1 rounded-full text-sm font-medium " <> colorClass] $
     toHtml status
 
--- | Code block component
+{- |
+Code block component for displaying larger code snippets.
+
+Formatted container for multi-line code with:
+- Monospace font family
+- Subtle background and borders
+- Horizontal scrolling for overflow
+- Proper text selection and copying
+
+= Usage Examples
+
+@
+-- Git commit hash
+W.viraCodeBlock_ "a1b2c3d4e5f6g7h8i9j0"
+
+-- Build command
+W.viraCodeBlock_ "nix build .#default"
+
+-- Error message
+W.viraCodeBlock_ "Error: Package not found in registry"
+@
+
+= When to Use
+
+Use for longer code snippets, commit hashes, commands, or error messages.
+For inline code within text, use 'viraCodeInline_' instead.
+-}
 viraCodeBlock_ :: Text -> Html ()
 viraCodeBlock_ code = do
   div_ [class_ "bg-gray-50 border border-gray-200 rounded-lg p-4 overflow-x-auto"] $ do
     code_ [class_ "text-sm text-gray-800 font-mono break-all"] $ toHtml code
 
--- | Inline code component for smaller code snippets
+{- |
+Inline code component for small code snippets within text.
+
+Compact styling for short code elements that appear inline with text.
+Perfect for commit hashes, variable names, and short commands.
+
+= Usage Examples
+
+@
+-- Commit hash in job listing
+div_ $ do
+  "Commit: "
+  W.viraCodeInline_ "a1b2c3d4"
+
+-- Variable name in documentation
+p_ $ do
+  "Set the "
+  W.viraCodeInline_ "API_KEY"
+  " environment variable"
+
+-- Short command
+span_ $ do
+  "Run "
+  W.viraCodeInline_ "just build"
+@
+
+= Design Guidelines
+
+Uses smaller, more subtle styling than 'viraCodeBlock_'.
+Integrates seamlessly with surrounding text flow.
+-}
 viraCodeInline_ :: Text -> Html ()
 viraCodeInline_ code = do
   code_ [class_ "px-2 py-1 text-xs bg-gray-100 text-gray-700 rounded font-mono"] $ toHtml code
 
--- | Alert component with variants
+{- |
+Alert component for displaying important messages with semantic colors.
+
+Provides user feedback with appropriate visual styling and icons.
+Includes accessibility features with proper ARIA roles.
+
+= Usage Examples
+
+@
+-- Success message
+W.viraAlert_ "success" "bg-green-50 border-green-200" $ do
+  p_ [class_ "text-green-800"] "Repository successfully added!"
+
+-- Error message
+W.viraAlert_ "error" "bg-red-50 border-red-200" $ do
+  p_ [class_ "text-red-800"] "Failed to connect to repository"
+
+-- Warning message
+W.viraAlert_ "warning" "bg-yellow-50 border-yellow-200" $ do
+  p_ [class_ "text-yellow-800"] "This action cannot be undone"
+
+-- Info message
+W.viraAlert_ "info" "bg-blue-50 border-blue-200" $ do
+  p_ [class_ "text-blue-800"] "Configure Cachix to enable build caching"
+@
+
+= Icons
+
+Automatically includes appropriate emoji icons:
+- ✅ for success alerts
+- ❌ for error alerts
+- ⚠️ for warning alerts
+- ℹ️ for info alerts
+
+= Accessibility
+
+Includes role="alert" for screen readers.
+-}
 viraAlert_ :: Text -> Text -> Html () -> Html ()
 viraAlert_ alertType colorClass content = do
   div_ [class_ $ "rounded-lg p-4 border " <> colorClass, role_ "alert"] $ do
@@ -190,24 +491,139 @@ viraAlert_ alertType colorClass content = do
           _ -> span_ [class_ "text-gray-500"] "•"
       div_ [class_ "ml-3 flex-1"] content
 
--- | Form group component for consistent form layout
+{- |
+Form group component for consistent form field layout.
+
+Groups labels and inputs with proper spacing for professional forms.
+Ensures consistent spacing and alignment across all form fields.
+
+= Usage Examples
+
+@
+-- Basic form field
+W.viraFormGroup_
+  (W.viraLabel_ [for_ "username"] "Username")
+  (W.viraInput_ [type_ "text", name_ "username", id_ "username"])
+
+-- With validation state
+W.viraFormGroup_
+  (W.viraLabel_ [for_ "email"] "Email Address")
+  (div_ $ do
+    W.viraInput_ [type_ "email", name_ "email", id_ "email"]
+    W.viraAlert_ "error" "bg-red-50" $ do
+      p_ [class_ "text-red-600 text-sm"] "Please enter a valid email")
+@
+
+= Layout Guidelines
+
+Use this for all form fields to maintain consistent spacing.
+Pairs perfectly with 'viraLabel_' and 'viraInput_' components.
+-}
 viraFormGroup_ :: Html () -> Html () -> Html ()
 viraFormGroup_ label input = do
   div_ [class_ "space-y-2"] $ do
     label
     input
 
--- | Divider component
+{- |
+Visual divider component for separating content sections.
+
+Creates a subtle horizontal line to separate content areas.
+Includes consistent spacing above and below.
+
+= Usage Examples
+
+@
+-- Between content sections
+div_ $ do
+  -- First section content
+  W.viraDivider_
+  -- Second section content
+
+-- In cards between different areas
+W.viraCard_ [class_ "p-6"] $ do
+  h3_ "Connected Services"
+  W.viraAlert_ "success" "..." $ do
+    -- Success message
+  W.viraDivider_
+  -- Configuration form
+@
+
+= Spacing Guidelines
+
+Includes my-6 (24px) vertical margin for proper content separation.
+-}
 viraDivider_ :: Html ()
 viraDivider_ = do
   hr_ [class_ "border-gray-200 my-6"]
 
 -- Form related widgets below
 
+{- |
+Form input component with consistent styling and focus states.
+
+Provides standardized input fields across the application with:
+- Consistent padding, borders, and border radius
+- Proper focus states with indigo accent colors
+- Background and transition styling
+- Accessibility features
+
+= Usage Examples
+
+@
+-- Basic text input
+W.viraInput_ [type_ "text", name_ "username", placeholder_ "Enter username"]
+
+-- Email input with validation
+W.viraInput_ [type_ "email", name_ "email", required_ "", placeholder_ "user@example.com"]
+
+-- Password input
+W.viraInput_ [type_ "password", name_ "password", placeholder_ "Enter password"]
+
+-- With initial value
+W.viraInput_ [type_ "text", name_ "repo", value_ existingValue]
+@
+
+= Styling Guidelines
+
+Inherits full width (w-full) by default.
+Override styling with additional classes as needed.
+Focus ring uses indigo-500 to match brand colors.
+-}
 viraInput_ :: forall (m :: Type -> Type). (Monad m) => [Attributes] -> HtmlT m ()
 viraInput_ attrs = do
   input_ ([class_ "block w-full px-4 py-3 text-sm border border-gray-300 rounded-lg shadow-sm placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 bg-white transition-colors duration-200"] <> attrs)
 
+{- |
+Form label component with consistent typography and spacing.
+
+Provides standardized labels for form fields with:
+- Consistent font weight and size
+- Proper text color for readability
+- Bottom margin for spacing from input
+
+= Usage Examples
+
+@
+-- Basic label
+W.viraLabel_ [for_ "username"] "Username"
+
+-- Required field indicator
+W.viraLabel_ [for_ "email"] $ do
+  "Email Address"
+  span_ [class_ "text-red-500"] " *"
+
+-- With help text
+div_ $ do
+  W.viraLabel_ [for_ "api-key"] "API Key"
+  p_ [class_ "text-xs text-gray-500"] "Found in your account settings"
+@
+
+= Accessibility Guidelines
+
+Always include for_ attribute that matches the input's id.
+This ensures proper label-input association for screen readers.
+-}
 viraLabel_ :: forall {result}. (Term [Attributes] result) => [Attributes] -> result
 viraLabel_ attrs = do
   label_ ([class_ "block text-sm font-semibold text-gray-700 mb-1"] <> attrs)

--- a/src/Vira/Widgets.hs
+++ b/src/Vira/Widgets.hs
@@ -206,7 +206,7 @@ viraDivider_ = do
 
 viraInput_ :: forall (m :: Type -> Type). (Monad m) => [Attributes] -> HtmlT m ()
 viraInput_ attrs = do
-  input_ ([class_ "block w-full px-4 py-3 text-sm border border-gray-300 rounded-lg shadow-sm placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition-smooth"] <> attrs)
+  input_ ([class_ "block w-full px-4 py-3 text-sm border border-gray-300 rounded-lg shadow-sm placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 bg-white transition-colors duration-200"] <> attrs)
 
 viraLabel_ :: forall {result}. (Term [Attributes] result) => [Attributes] -> result
 viraLabel_ attrs = do

--- a/static/tailwind.css
+++ b/static/tailwind.css
@@ -10,10 +10,12 @@
     --color-red-50: oklch(97.1% 0.013 17.38);
     --color-red-100: oklch(93.6% 0.032 17.717);
     --color-red-200: oklch(88.5% 0.062 18.334);
+    --color-red-300: oklch(80.8% 0.114 19.571);
     --color-red-500: oklch(63.7% 0.237 25.331);
     --color-red-600: oklch(57.7% 0.245 27.325);
     --color-red-700: oklch(50.5% 0.213 27.518);
     --color-red-800: oklch(44.4% 0.177 26.899);
+    --color-red-900: oklch(39.6% 0.141 25.723);
     --color-orange-100: oklch(95.4% 0.038 75.164);
     --color-orange-300: oklch(83.7% 0.128 66.29);
     --color-yellow-100: oklch(97.3% 0.071 103.193);
@@ -528,6 +530,9 @@
   .border-red-200 {
     border-color: var(--color-red-200);
   }
+  .border-red-300 {
+    border-color: var(--color-red-300);
+  }
   .border-white\/20 {
     border-color: color-mix(in srgb, #fff 20%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
@@ -575,6 +580,9 @@
   }
   .bg-red-100 {
     background-color: var(--color-red-100);
+  }
+  .bg-red-200 {
+    background-color: var(--color-red-200);
   }
   .bg-red-600 {
     background-color: var(--color-red-600);
@@ -784,6 +792,9 @@
   }
   .text-red-800 {
     color: var(--color-red-800);
+  }
+  .text-red-900 {
+    color: var(--color-red-900);
   }
   .text-white {
     color: var(--color-white);

--- a/static/tailwind.css
+++ b/static/tailwind.css
@@ -8,24 +8,42 @@
     --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
     monospace;
     --color-red-50: oklch(97.1% 0.013 17.38);
+    --color-red-100: oklch(93.6% 0.032 17.717);
     --color-red-200: oklch(88.5% 0.062 18.334);
+    --color-red-500: oklch(63.7% 0.237 25.331);
     --color-red-600: oklch(57.7% 0.245 27.325);
     --color-red-700: oklch(50.5% 0.213 27.518);
-    --color-orange-50: oklch(98% 0.016 73.684);
+    --color-red-800: oklch(44.4% 0.177 26.899);
     --color-orange-100: oklch(95.4% 0.038 75.164);
     --color-orange-300: oklch(83.7% 0.128 66.29);
-    --color-orange-700: oklch(55.3% 0.195 38.402);
-    --color-orange-800: oklch(47% 0.157 37.304);
-    --color-yellow-700: oklch(55.4% 0.135 66.442);
+    --color-yellow-100: oklch(97.3% 0.071 103.193);
+    --color-yellow-200: oklch(94.5% 0.129 101.54);
+    --color-yellow-500: oklch(79.5% 0.184 86.047);
+    --color-yellow-800: oklch(47.6% 0.114 61.907);
+    --color-green-50: oklch(98.2% 0.018 155.826);
+    --color-green-100: oklch(96.2% 0.044 156.743);
+    --color-green-200: oklch(92.5% 0.084 155.995);
     --color-green-500: oklch(72.3% 0.219 149.579);
+    --color-green-600: oklch(62.7% 0.194 149.214);
     --color-green-700: oklch(52.7% 0.154 150.069);
+    --color-green-800: oklch(44.8% 0.119 151.328);
+    --color-blue-50: oklch(97% 0.014 254.604);
     --color-blue-100: oklch(93.2% 0.032 255.585);
-    --color-blue-400: oklch(70.7% 0.165 254.624);
+    --color-blue-200: oklch(88.2% 0.059 254.128);
+    --color-blue-300: oklch(80.9% 0.105 251.813);
     --color-blue-500: oklch(62.3% 0.214 259.815);
     --color-blue-600: oklch(54.6% 0.245 262.881);
     --color-blue-700: oklch(48.8% 0.243 264.376);
     --color-blue-800: oklch(42.4% 0.199 265.638);
-    --color-blue-950: oklch(28.2% 0.091 267.935);
+    --color-indigo-50: oklch(96.2% 0.018 272.314);
+    --color-indigo-200: oklch(87% 0.065 274.039);
+    --color-indigo-500: oklch(58.5% 0.233 277.117);
+    --color-indigo-600: oklch(51.1% 0.262 276.966);
+    --color-indigo-700: oklch(45.7% 0.24 277.023);
+    --color-indigo-800: oklch(39.8% 0.195 277.366);
+    --color-purple-100: oklch(94.6% 0.033 307.174);
+    --color-purple-600: oklch(55.8% 0.288 302.321);
+    --color-slate-50: oklch(98.4% 0.003 247.858);
     --color-gray-50: oklch(98.5% 0.002 247.839);
     --color-gray-100: oklch(96.7% 0.003 264.542);
     --color-gray-200: oklch(92.8% 0.006 264.531);
@@ -36,12 +54,9 @@
     --color-gray-700: oklch(37.3% 0.034 259.733);
     --color-gray-800: oklch(27.8% 0.033 256.848);
     --color-gray-900: oklch(21% 0.034 264.665);
-    --color-neutral-50: oklch(98.5% 0 0);
     --color-black: #000;
     --color-white: #fff;
     --spacing: 0.25rem;
-    --container-md: 28rem;
-    --container-4xl: 56rem;
     --text-xs: 0.75rem;
     --text-xs--line-height: calc(1 / 0.75);
     --text-sm: 0.875rem;
@@ -52,13 +67,20 @@
     --text-xl--line-height: calc(1.75 / 1.25);
     --text-2xl: 1.5rem;
     --text-2xl--line-height: calc(2 / 1.5);
+    --text-3xl: 1.875rem;
+    --text-3xl--line-height: calc(2.25 / 1.875);
+    --text-6xl: 3.75rem;
+    --text-6xl--line-height: 1;
     --font-weight-medium: 500;
     --font-weight-semibold: 600;
     --font-weight-bold: 700;
+    --tracking-tight: -0.025em;
     --radius-md: 0.375rem;
     --radius-lg: 0.5rem;
     --radius-xl: 0.75rem;
+    --radius-2xl: 1rem;
     --animate-ping: ping 1s cubic-bezier(0, 0, 0.2, 1) infinite;
+    --blur-sm: 8px;
     --default-transition-duration: 150ms;
     --default-transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
     --default-font-family: var(--font-sans);
@@ -244,23 +266,26 @@
   .my-2 {
     margin-block: calc(var(--spacing) * 2);
   }
-  .my-4 {
-    margin-block: calc(var(--spacing) * 4);
-  }
   .my-6 {
     margin-block: calc(var(--spacing) * 6);
   }
-  .mt-1 {
-    margin-top: calc(var(--spacing) * 1);
+  .mt-2 {
+    margin-top: calc(var(--spacing) * 2);
   }
-  .mt-4 {
-    margin-top: calc(var(--spacing) * 4);
+  .mt-6 {
+    margin-top: calc(var(--spacing) * 6);
   }
-  .mt-8 {
-    margin-top: calc(var(--spacing) * 8);
+  .mr-2 {
+    margin-right: calc(var(--spacing) * 2);
   }
-  .mb-3 {
-    margin-bottom: calc(var(--spacing) * 3);
+  .mr-3 {
+    margin-right: calc(var(--spacing) * 3);
+  }
+  .mb-1 {
+    margin-bottom: calc(var(--spacing) * 1);
+  }
+  .mb-2 {
+    margin-bottom: calc(var(--spacing) * 2);
   }
   .mb-4 {
     margin-bottom: calc(var(--spacing) * 4);
@@ -271,8 +296,14 @@
   .mb-8 {
     margin-bottom: calc(var(--spacing) * 8);
   }
-  .ml-4 {
-    margin-left: calc(var(--spacing) * 4);
+  .ml-2 {
+    margin-left: calc(var(--spacing) * 2);
+  }
+  .ml-3 {
+    margin-left: calc(var(--spacing) * 3);
+  }
+  .ml-6 {
+    margin-left: calc(var(--spacing) * 6);
   }
   .block {
     display: block;
@@ -286,44 +317,62 @@
   .hidden {
     display: none;
   }
+  .inline {
+    display: inline;
+  }
   .inline-flex {
     display: inline-flex;
   }
   .h-4 {
     height: calc(var(--spacing) * 4);
   }
-  .h-12 {
-    height: calc(var(--spacing) * 12);
+  .h-5 {
+    height: calc(var(--spacing) * 5);
+  }
+  .h-8 {
+    height: calc(var(--spacing) * 8);
+  }
+  .min-h-screen {
+    min-height: 100vh;
   }
   .w-4 {
     width: calc(var(--spacing) * 4);
   }
-  .w-24 {
-    width: calc(var(--spacing) * 24);
+  .w-5 {
+    width: calc(var(--spacing) * 5);
+  }
+  .w-8 {
+    width: calc(var(--spacing) * 8);
   }
   .w-full {
     width: 100%;
   }
-  .max-w-4xl {
-    max-width: var(--container-4xl);
-  }
-  .max-w-md {
-    max-width: var(--container-md);
-  }
   .flex-1 {
     flex: 1;
   }
+  .flex-shrink-0 {
+    flex-shrink: 0;
+  }
+  .scale-95 {
+    --tw-scale-x: 95%;
+    --tw-scale-y: 95%;
+    --tw-scale-z: 95%;
+    scale: var(--tw-scale-x) var(--tw-scale-y);
+  }
+  .transform {
+    transform: var(--tw-rotate-x,) var(--tw-rotate-y,) var(--tw-rotate-z,) var(--tw-skew-x,) var(--tw-skew-y,);
+  }
   .animate-ping {
     animation: var(--animate-ping);
+  }
+  .cursor-pointer {
+    cursor: pointer;
   }
   .list-none {
     list-style-type: none;
   }
   .grid-cols-1 {
     grid-template-columns: repeat(1, minmax(0, 1fr));
-  }
-  .flex-col {
-    flex-direction: column;
   }
   .items-center {
     align-items: center;
@@ -340,14 +389,17 @@
   .justify-end {
     justify-content: flex-end;
   }
-  .justify-start {
-    justify-content: flex-start;
-  }
-  .gap-2 {
-    gap: calc(var(--spacing) * 2);
+  .gap-3 {
+    gap: calc(var(--spacing) * 3);
   }
   .gap-4 {
     gap: calc(var(--spacing) * 4);
+  }
+  .gap-6 {
+    gap: calc(var(--spacing) * 6);
+  }
+  .gap-8 {
+    gap: calc(var(--spacing) * 8);
   }
   .space-y-2 {
     :where(& > :not(:last-child)) {
@@ -356,11 +408,11 @@
       margin-block-end: calc(calc(var(--spacing) * 2) * calc(1 - var(--tw-space-y-reverse)));
     }
   }
-  .space-y-4 {
+  .space-y-3 {
     :where(& > :not(:last-child)) {
       --tw-space-y-reverse: 0;
-      margin-block-start: calc(calc(var(--spacing) * 4) * var(--tw-space-y-reverse));
-      margin-block-end: calc(calc(var(--spacing) * 4) * calc(1 - var(--tw-space-y-reverse)));
+      margin-block-start: calc(calc(var(--spacing) * 3) * var(--tw-space-y-reverse));
+      margin-block-end: calc(calc(var(--spacing) * 3) * calc(1 - var(--tw-space-y-reverse)));
     }
   }
   .space-y-6 {
@@ -368,20 +420,6 @@
       --tw-space-y-reverse: 0;
       margin-block-start: calc(calc(var(--spacing) * 6) * var(--tw-space-y-reverse));
       margin-block-end: calc(calc(var(--spacing) * 6) * calc(1 - var(--tw-space-y-reverse)));
-    }
-  }
-  .space-y-8 {
-    :where(& > :not(:last-child)) {
-      --tw-space-y-reverse: 0;
-      margin-block-start: calc(calc(var(--spacing) * 8) * var(--tw-space-y-reverse));
-      margin-block-end: calc(calc(var(--spacing) * 8) * calc(1 - var(--tw-space-y-reverse)));
-    }
-  }
-  .space-x-1 {
-    :where(& > :not(:last-child)) {
-      --tw-space-x-reverse: 0;
-      margin-inline-start: calc(calc(var(--spacing) * 1) * var(--tw-space-x-reverse));
-      margin-inline-end: calc(calc(var(--spacing) * 1) * calc(1 - var(--tw-space-x-reverse)));
     }
   }
   .space-x-2 {
@@ -405,13 +443,14 @@
       margin-inline-end: calc(calc(var(--spacing) * 4) * calc(1 - var(--tw-space-x-reverse)));
     }
   }
-  .truncate {
+  .overflow-hidden {
     overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
   }
-  .rounded {
-    border-radius: 0.25rem;
+  .overflow-x-auto {
+    overflow-x: auto;
+  }
+  .rounded-2xl {
+    border-radius: var(--radius-2xl);
   }
   .rounded-full {
     border-radius: calc(infinity * 1px);
@@ -429,34 +468,31 @@
     border-style: var(--tw-border-style);
     border-width: 1px;
   }
-  .border-2 {
-    border-style: var(--tw-border-style);
-    border-width: 2px;
-  }
   .border-4 {
     border-style: var(--tw-border-style);
     border-width: 4px;
   }
-  .border-t {
-    border-top-style: var(--tw-border-style);
-    border-top-width: 1px;
-  }
-  .border-b-2 {
+  .border-b {
     border-bottom-style: var(--tw-border-style);
-    border-bottom-width: 2px;
+    border-bottom-width: 1px;
   }
-  .border-l-4 {
-    border-left-style: var(--tw-border-style);
-    border-left-width: 4px;
+  .border-blue-200 {
+    border-color: var(--color-blue-200);
   }
-  .border-blue-100 {
-    border-color: var(--color-blue-100);
+  .border-gray-100 {
+    border-color: var(--color-gray-100);
   }
   .border-gray-200 {
     border-color: var(--color-gray-200);
   }
   .border-gray-300 {
     border-color: var(--color-gray-300);
+  }
+  .border-green-200 {
+    border-color: var(--color-green-200);
+  }
+  .border-indigo-200 {
+    border-color: var(--color-indigo-200);
   }
   .border-orange-100 {
     border-color: var(--color-orange-100);
@@ -467,38 +503,107 @@
   .border-red-200 {
     border-color: var(--color-red-200);
   }
+  .border-white\/20 {
+    border-color: color-mix(in srgb, #fff 20%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      border-color: color-mix(in oklab, var(--color-white) 20%, transparent);
+    }
+  }
+  .border-yellow-200 {
+    border-color: var(--color-yellow-200);
+  }
   .bg-black {
     background-color: var(--color-black);
+  }
+  .bg-blue-50 {
+    background-color: var(--color-blue-50);
+  }
+  .bg-blue-100 {
+    background-color: var(--color-blue-100);
   }
   .bg-blue-600 {
     background-color: var(--color-blue-600);
   }
-  .bg-blue-950 {
-    background-color: var(--color-blue-950);
-  }
   .bg-gray-50 {
     background-color: var(--color-gray-50);
   }
-  .bg-green-500 {
-    background-color: var(--color-green-500);
+  .bg-gray-100 {
+    background-color: var(--color-gray-100);
   }
-  .bg-orange-50 {
-    background-color: var(--color-orange-50);
+  .bg-green-50 {
+    background-color: var(--color-green-50);
   }
-  .bg-orange-700 {
-    background-color: var(--color-orange-700);
+  .bg-green-100 {
+    background-color: var(--color-green-100);
   }
-  .bg-orange-800 {
-    background-color: var(--color-orange-800);
+  .bg-green-600 {
+    background-color: var(--color-green-600);
+  }
+  .bg-indigo-600 {
+    background-color: var(--color-indigo-600);
+  }
+  .bg-purple-100 {
+    background-color: var(--color-purple-100);
   }
   .bg-red-50 {
     background-color: var(--color-red-50);
+  }
+  .bg-red-100 {
+    background-color: var(--color-red-100);
   }
   .bg-red-600 {
     background-color: var(--color-red-600);
   }
   .bg-white {
     background-color: var(--color-white);
+  }
+  .bg-white\/20 {
+    background-color: color-mix(in srgb, #fff 20%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-white) 20%, transparent);
+    }
+  }
+  .bg-white\/80 {
+    background-color: color-mix(in srgb, #fff 80%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-white) 80%, transparent);
+    }
+  }
+  .bg-yellow-100 {
+    background-color: var(--color-yellow-100);
+  }
+  .bg-gradient-to-br {
+    --tw-gradient-position: to bottom right in oklab;
+    background-image: linear-gradient(var(--tw-gradient-stops));
+  }
+  .bg-gradient-to-r {
+    --tw-gradient-position: to right in oklab;
+    background-image: linear-gradient(var(--tw-gradient-stops));
+  }
+  .from-indigo-50 {
+    --tw-gradient-from: var(--color-indigo-50);
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+  }
+  .from-indigo-600 {
+    --tw-gradient-from: var(--color-indigo-600);
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+  }
+  .from-slate-50 {
+    --tw-gradient-from: var(--color-slate-50);
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+  }
+  .via-purple-600 {
+    --tw-gradient-via: var(--color-purple-600);
+    --tw-gradient-via-stops: var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-via) var(--tw-gradient-via-position), var(--tw-gradient-to) var(--tw-gradient-to-position);
+    --tw-gradient-stops: var(--tw-gradient-via-stops);
+  }
+  .to-blue-50 {
+    --tw-gradient-to: var(--color-blue-50);
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+  }
+  .to-blue-600 {
+    --tw-gradient-to: var(--color-blue-600);
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
   }
   .p-2 {
     padding: calc(var(--spacing) * 2);
@@ -512,8 +617,8 @@
   .p-6 {
     padding: calc(var(--spacing) * 6);
   }
-  .px-2 {
-    padding-inline: calc(var(--spacing) * 2);
+  .p-12 {
+    padding: calc(var(--spacing) * 12);
   }
   .px-3 {
     padding-inline: calc(var(--spacing) * 3);
@@ -521,26 +626,35 @@
   .px-4 {
     padding-inline: calc(var(--spacing) * 4);
   }
+  .px-6 {
+    padding-inline: calc(var(--spacing) * 6);
+  }
+  .px-8 {
+    padding-inline: calc(var(--spacing) * 8);
+  }
   .py-1 {
     padding-block: calc(var(--spacing) * 1);
   }
   .py-2 {
     padding-block: calc(var(--spacing) * 2);
   }
-  .py-8 {
-    padding-block: calc(var(--spacing) * 8);
+  .py-3 {
+    padding-block: calc(var(--spacing) * 3);
   }
-  .pt-6 {
-    padding-top: calc(var(--spacing) * 6);
+  .py-6 {
+    padding-block: calc(var(--spacing) * 6);
   }
-  .pb-2 {
-    padding-bottom: calc(var(--spacing) * 2);
+  .py-12 {
+    padding-block: calc(var(--spacing) * 12);
+  }
+  .pt-4 {
+    padding-top: calc(var(--spacing) * 4);
+  }
+  .pb-6 {
+    padding-bottom: calc(var(--spacing) * 6);
   }
   .text-center {
     text-align: center;
-  }
-  .text-right {
-    text-align: right;
   }
   .font-mono {
     font-family: var(--font-mono);
@@ -548,6 +662,14 @@
   .text-2xl {
     font-size: var(--text-2xl);
     line-height: var(--tw-leading, var(--text-2xl--line-height));
+  }
+  .text-3xl {
+    font-size: var(--text-3xl);
+    line-height: var(--tw-leading, var(--text-3xl--line-height));
+  }
+  .text-6xl {
+    font-size: var(--text-6xl);
+    line-height: var(--tw-leading, var(--text-6xl--line-height));
   }
   .text-lg {
     font-size: var(--text-lg);
@@ -577,20 +699,21 @@
     --tw-font-weight: var(--font-weight-semibold);
     font-weight: var(--font-weight-semibold);
   }
+  .tracking-tight {
+    --tw-tracking: var(--tracking-tight);
+    letter-spacing: var(--tracking-tight);
+  }
+  .break-all {
+    word-break: break-all;
+  }
   .text-blue-500 {
     color: var(--color-blue-500);
-  }
-  .text-blue-600 {
-    color: var(--color-blue-600);
   }
   .text-blue-700 {
     color: var(--color-blue-700);
   }
-  .text-gray-100 {
-    color: var(--color-gray-100);
-  }
-  .text-gray-300 {
-    color: var(--color-gray-300);
+  .text-blue-800 {
+    color: var(--color-blue-800);
   }
   .text-gray-400 {
     color: var(--color-gray-400);
@@ -610,23 +733,52 @@
   .text-gray-900 {
     color: var(--color-gray-900);
   }
-  .text-green-700 {
-    color: var(--color-green-700);
+  .text-green-500 {
+    color: var(--color-green-500);
   }
-  .text-neutral-50 {
-    color: var(--color-neutral-50);
+  .text-green-800 {
+    color: var(--color-green-800);
   }
-  .text-red-700 {
-    color: var(--color-red-700);
+  .text-indigo-600 {
+    color: var(--color-indigo-600);
+  }
+  .text-purple-600 {
+    color: var(--color-purple-600);
+  }
+  .text-red-500 {
+    color: var(--color-red-500);
+  }
+  .text-red-800 {
+    color: var(--color-red-800);
   }
   .text-white {
     color: var(--color-white);
   }
-  .text-yellow-700 {
-    color: var(--color-yellow-700);
+  .text-white\/60 {
+    color: color-mix(in srgb, #fff 60%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      color: color-mix(in oklab, var(--color-white) 60%, transparent);
+    }
+  }
+  .text-white\/90 {
+    color: color-mix(in srgb, #fff 90%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      color: color-mix(in oklab, var(--color-white) 90%, transparent);
+    }
+  }
+  .text-yellow-500 {
+    color: var(--color-yellow-500);
+  }
+  .text-yellow-800 {
+    color: var(--color-yellow-800);
   }
   .underline {
     text-decoration-line: underline;
+  }
+  .placeholder-gray-500 {
+    &::placeholder {
+      color: var(--color-gray-500);
+    }
   }
   .shadow-lg {
     --tw-shadow: 0 10px 15px -3px var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 4px 6px -4px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
@@ -640,14 +792,17 @@
     --tw-shadow: 0 1px 3px 0 var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 1px 2px -1px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
     box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
   }
-  .shadow-blue-500\/20 {
-    --tw-shadow-color: color-mix(in srgb, oklch(62.3% 0.214 259.815) 20%, transparent);
-    @supports (color: color-mix(in lab, red, red)) {
-      --tw-shadow-color: color-mix(in oklab, color-mix(in oklab, var(--color-blue-500) 20%, transparent) var(--tw-shadow-alpha), transparent);
-    }
-  }
   .filter {
     filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
+  }
+  .backdrop-blur-sm {
+    --tw-backdrop-blur: blur(var(--blur-sm));
+    -webkit-backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
+    backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
+  }
+  .backdrop-filter {
+    -webkit-backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
+    backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
   }
   .transition {
     transition-property: color, background-color, border-color, outline-color, text-decoration-color, fill, stroke, --tw-gradient-from, --tw-gradient-via, --tw-gradient-to, opacity, box-shadow, transform, translate, scale, rotate, filter, -webkit-backdrop-filter, backdrop-filter, display, visibility, content-visibility, overlay, pointer-events;
@@ -664,28 +819,52 @@
     transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
     transition-duration: var(--tw-duration, var(--default-transition-duration));
   }
+  .transition-transform {
+    transition-property: transform, translate, scale, rotate;
+    transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
+    transition-duration: var(--tw-duration, var(--default-transition-duration));
+  }
+  .duration-200 {
+    --tw-duration: 200ms;
+    transition-duration: 200ms;
+  }
   .duration-300 {
     --tw-duration: 300ms;
     transition-duration: 300ms;
   }
-  .hover\:border-blue-400 {
-    &:hover {
+  .group-hover\:translate-x-1 {
+    &:is(:where(.group):hover *) {
       @media (hover: hover) {
-        border-color: var(--color-blue-400);
+        --tw-translate-x: calc(var(--spacing) * 1);
+        translate: var(--tw-translate-x) var(--tw-translate-y);
       }
     }
   }
-  .hover\:border-gray-300 {
-    &:hover {
+  .group-hover\:text-indigo-500 {
+    &:is(:where(.group):hover *) {
       @media (hover: hover) {
-        border-color: var(--color-gray-300);
+        color: var(--color-indigo-500);
       }
     }
   }
-  .hover\:bg-blue-100 {
+  .group-hover\:text-indigo-600 {
+    &:is(:where(.group):hover *) {
+      @media (hover: hover) {
+        color: var(--color-indigo-600);
+      }
+    }
+  }
+  .hover\:border-blue-300 {
     &:hover {
       @media (hover: hover) {
-        background-color: var(--color-blue-100);
+        border-color: var(--color-blue-300);
+      }
+    }
+  }
+  .hover\:bg-blue-50 {
+    &:hover {
+      @media (hover: hover) {
+        background-color: var(--color-blue-50);
       }
     }
   }
@@ -710,6 +889,20 @@
       }
     }
   }
+  .hover\:bg-green-700 {
+    &:hover {
+      @media (hover: hover) {
+        background-color: var(--color-green-700);
+      }
+    }
+  }
+  .hover\:bg-indigo-700 {
+    &:hover {
+      @media (hover: hover) {
+        background-color: var(--color-indigo-700);
+      }
+    }
+  }
   .hover\:bg-red-700 {
     &:hover {
       @media (hover: hover) {
@@ -717,24 +910,20 @@
       }
     }
   }
-  .hover\:text-black {
+  .hover\:bg-white\/10 {
     &:hover {
       @media (hover: hover) {
-        color: var(--color-black);
+        background-color: color-mix(in srgb, #fff 10%, transparent);
+        @supports (color: color-mix(in lab, red, red)) {
+          background-color: color-mix(in oklab, var(--color-white) 10%, transparent);
+        }
       }
     }
   }
-  .hover\:text-blue-600 {
+  .hover\:text-indigo-800 {
     &:hover {
       @media (hover: hover) {
-        color: var(--color-blue-600);
-      }
-    }
-  }
-  .hover\:text-blue-800 {
-    &:hover {
-      @media (hover: hover) {
-        color: var(--color-blue-800);
+        color: var(--color-indigo-800);
       }
     }
   }
@@ -760,9 +949,25 @@
       }
     }
   }
-  .focus\:border-blue-500 {
+  .hover\:shadow-md {
+    &:hover {
+      @media (hover: hover) {
+        --tw-shadow: 0 4px 6px -1px var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 2px 4px -2px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
+        box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+      }
+    }
+  }
+  .hover\:shadow-xl {
+    &:hover {
+      @media (hover: hover) {
+        --tw-shadow: 0 20px 25px -5px var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 8px 10px -6px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
+        box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+      }
+    }
+  }
+  .focus\:border-indigo-500 {
     &:focus {
-      border-color: var(--color-blue-500);
+      border-color: var(--color-indigo-500);
     }
   }
   .focus\:ring-2 {
@@ -776,9 +981,33 @@
       --tw-ring-color: var(--color-blue-500);
     }
   }
-  .focus\:ring-white {
+  .focus\:ring-green-500 {
     &:focus {
-      --tw-ring-color: var(--color-white);
+      --tw-ring-color: var(--color-green-500);
+    }
+  }
+  .focus\:ring-indigo-500 {
+    &:focus {
+      --tw-ring-color: var(--color-indigo-500);
+    }
+  }
+  .focus\:ring-red-500 {
+    &:focus {
+      --tw-ring-color: var(--color-red-500);
+    }
+  }
+  .focus\:ring-white\/30 {
+    &:focus {
+      --tw-ring-color: color-mix(in srgb, #fff 30%, transparent);
+      @supports (color: color-mix(in lab, red, red)) {
+        --tw-ring-color: color-mix(in oklab, var(--color-white) 30%, transparent);
+      }
+    }
+  }
+  .focus\:ring-offset-2 {
+    &:focus {
+      --tw-ring-offset-width: 2px;
+      --tw-ring-offset-shadow: var(--tw-ring-inset,) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
     }
   }
   .focus\:outline-none {
@@ -787,12 +1016,14 @@
       outline-style: none;
     }
   }
-  .active\:scale-95 {
-    &:active {
-      --tw-scale-x: 95%;
-      --tw-scale-y: 95%;
-      --tw-scale-z: 95%;
-      scale: var(--tw-scale-x) var(--tw-scale-y);
+  .disabled\:cursor-not-allowed {
+    &:disabled {
+      cursor: not-allowed;
+    }
+  }
+  .disabled\:opacity-50 {
+    &:disabled {
+      opacity: 50%;
     }
   }
   .md\:grid-cols-2 {
@@ -800,6 +1031,61 @@
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }
   }
+  .lg\:grid-cols-2 {
+    @media (width >= 64rem) {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+  .lg\:grid-cols-3 {
+    @media (width >= 64rem) {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+  }
+  .lg\:p-8 {
+    @media (width >= 64rem) {
+      padding: calc(var(--spacing) * 8);
+    }
+  }
+  .lg\:px-8 {
+    @media (width >= 64rem) {
+      padding-inline: calc(var(--spacing) * 8);
+    }
+  }
+}
+@property --tw-scale-x {
+  syntax: "*";
+  inherits: false;
+  initial-value: 1;
+}
+@property --tw-scale-y {
+  syntax: "*";
+  inherits: false;
+  initial-value: 1;
+}
+@property --tw-scale-z {
+  syntax: "*";
+  inherits: false;
+  initial-value: 1;
+}
+@property --tw-rotate-x {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-rotate-y {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-rotate-z {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-skew-x {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-skew-y {
+  syntax: "*";
+  inherits: false;
 }
 @property --tw-space-y-reverse {
   syntax: "*";
@@ -816,7 +1102,53 @@
   inherits: false;
   initial-value: solid;
 }
+@property --tw-gradient-position {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-gradient-from {
+  syntax: "<color>";
+  inherits: false;
+  initial-value: #0000;
+}
+@property --tw-gradient-via {
+  syntax: "<color>";
+  inherits: false;
+  initial-value: #0000;
+}
+@property --tw-gradient-to {
+  syntax: "<color>";
+  inherits: false;
+  initial-value: #0000;
+}
+@property --tw-gradient-stops {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-gradient-via-stops {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-gradient-from-position {
+  syntax: "<length-percentage>";
+  inherits: false;
+  initial-value: 0%;
+}
+@property --tw-gradient-via-position {
+  syntax: "<length-percentage>";
+  inherits: false;
+  initial-value: 50%;
+}
+@property --tw-gradient-to-position {
+  syntax: "<length-percentage>";
+  inherits: false;
+  initial-value: 100%;
+}
 @property --tw-font-weight {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-tracking {
   syntax: "*";
   inherits: false;
 }
@@ -938,24 +1270,60 @@
   syntax: "*";
   inherits: false;
 }
+@property --tw-backdrop-blur {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-backdrop-brightness {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-backdrop-contrast {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-backdrop-grayscale {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-backdrop-hue-rotate {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-backdrop-invert {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-backdrop-opacity {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-backdrop-saturate {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-backdrop-sepia {
+  syntax: "*";
+  inherits: false;
+}
 @property --tw-duration {
   syntax: "*";
   inherits: false;
 }
-@property --tw-scale-x {
+@property --tw-translate-x {
   syntax: "*";
   inherits: false;
-  initial-value: 1;
+  initial-value: 0;
 }
-@property --tw-scale-y {
+@property --tw-translate-y {
   syntax: "*";
   inherits: false;
-  initial-value: 1;
+  initial-value: 0;
 }
-@property --tw-scale-z {
+@property --tw-translate-z {
   syntax: "*";
   inherits: false;
-  initial-value: 1;
+  initial-value: 0;
 }
 @keyframes ping {
   75%, 100% {
@@ -966,10 +1334,28 @@
 @layer properties {
   @supports ((-webkit-hyphens: none) and (not (margin-trim: inline))) or ((-moz-orient: inline) and (not (color:rgb(from red r g b)))) {
     *, ::before, ::after, ::backdrop {
+      --tw-scale-x: 1;
+      --tw-scale-y: 1;
+      --tw-scale-z: 1;
+      --tw-rotate-x: initial;
+      --tw-rotate-y: initial;
+      --tw-rotate-z: initial;
+      --tw-skew-x: initial;
+      --tw-skew-y: initial;
       --tw-space-y-reverse: 0;
       --tw-space-x-reverse: 0;
       --tw-border-style: solid;
+      --tw-gradient-position: initial;
+      --tw-gradient-from: #0000;
+      --tw-gradient-via: #0000;
+      --tw-gradient-to: #0000;
+      --tw-gradient-stops: initial;
+      --tw-gradient-via-stops: initial;
+      --tw-gradient-from-position: 0%;
+      --tw-gradient-via-position: 50%;
+      --tw-gradient-to-position: 100%;
       --tw-font-weight: initial;
+      --tw-tracking: initial;
       --tw-shadow: 0 0 #0000;
       --tw-shadow-color: initial;
       --tw-shadow-alpha: 100%;
@@ -997,10 +1383,19 @@
       --tw-drop-shadow-color: initial;
       --tw-drop-shadow-alpha: 100%;
       --tw-drop-shadow-size: initial;
+      --tw-backdrop-blur: initial;
+      --tw-backdrop-brightness: initial;
+      --tw-backdrop-contrast: initial;
+      --tw-backdrop-grayscale: initial;
+      --tw-backdrop-hue-rotate: initial;
+      --tw-backdrop-invert: initial;
+      --tw-backdrop-opacity: initial;
+      --tw-backdrop-saturate: initial;
+      --tw-backdrop-sepia: initial;
       --tw-duration: initial;
-      --tw-scale-x: 1;
-      --tw-scale-y: 1;
-      --tw-scale-z: 1;
+      --tw-translate-x: 0;
+      --tw-translate-y: 0;
+      --tw-translate-z: 0;
     }
   }
 }

--- a/static/tailwind.css
+++ b/static/tailwind.css
@@ -552,14 +552,14 @@
   .bg-blue-100 {
     background-color: var(--color-blue-100);
   }
-  .bg-blue-600 {
-    background-color: var(--color-blue-600);
-  }
   .bg-gray-50 {
     background-color: var(--color-gray-50);
   }
   .bg-gray-100 {
     background-color: var(--color-gray-100);
+  }
+  .bg-gray-600 {
+    background-color: var(--color-gray-600);
   }
   .bg-green-50 {
     background-color: var(--color-green-50);
@@ -914,13 +914,6 @@
       }
     }
   }
-  .hover\:bg-blue-700 {
-    &:hover {
-      @media (hover: hover) {
-        background-color: var(--color-blue-700);
-      }
-    }
-  }
   .hover\:bg-gray-50 {
     &:hover {
       @media (hover: hover) {
@@ -932,6 +925,13 @@
     &:hover {
       @media (hover: hover) {
         background-color: var(--color-gray-100);
+      }
+    }
+  }
+  .hover\:bg-gray-700 {
+    &:hover {
+      @media (hover: hover) {
+        background-color: var(--color-gray-700);
       }
     }
   }
@@ -1022,9 +1022,9 @@
       box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
     }
   }
-  .focus\:ring-blue-500 {
+  .focus\:ring-gray-500 {
     &:focus {
-      --tw-ring-color: var(--color-blue-500);
+      --tw-ring-color: var(--color-gray-500);
     }
   }
   .focus\:ring-green-500 {

--- a/static/tailwind.css
+++ b/static/tailwind.css
@@ -287,6 +287,9 @@
   .mb-2 {
     margin-bottom: calc(var(--spacing) * 2);
   }
+  .mb-3 {
+    margin-bottom: calc(var(--spacing) * 3);
+  }
   .mb-4 {
     margin-bottom: calc(var(--spacing) * 4);
   }
@@ -443,11 +446,33 @@
       margin-inline-end: calc(calc(var(--spacing) * 4) * calc(1 - var(--tw-space-x-reverse)));
     }
   }
+  .divide-y {
+    :where(& > :not(:last-child)) {
+      --tw-divide-y-reverse: 0;
+      border-bottom-style: var(--tw-border-style);
+      border-top-style: var(--tw-border-style);
+      border-top-width: calc(1px * var(--tw-divide-y-reverse));
+      border-bottom-width: calc(1px * calc(1 - var(--tw-divide-y-reverse)));
+    }
+  }
+  .divide-gray-200 {
+    :where(& > :not(:last-child)) {
+      border-color: var(--color-gray-200);
+    }
+  }
+  .truncate {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
   .overflow-hidden {
     overflow: hidden;
   }
   .overflow-x-auto {
     overflow-x: auto;
+  }
+  .rounded {
+    border-radius: 0.25rem;
   }
   .rounded-2xl {
     border-radius: var(--radius-2xl);
@@ -620,6 +645,9 @@
   .p-12 {
     padding: calc(var(--spacing) * 12);
   }
+  .px-2 {
+    padding-inline: calc(var(--spacing) * 2);
+  }
   .px-3 {
     padding-inline: calc(var(--spacing) * 3);
   }
@@ -640,6 +668,9 @@
   }
   .py-3 {
     padding-block: calc(var(--spacing) * 3);
+  }
+  .py-4 {
+    padding-block: calc(var(--spacing) * 4);
   }
   .py-6 {
     padding-block: calc(var(--spacing) * 6);
@@ -708,6 +739,9 @@
   }
   .text-blue-500 {
     color: var(--color-blue-500);
+  }
+  .text-blue-600 {
+    color: var(--color-blue-600);
   }
   .text-blue-700 {
     color: var(--color-blue-700);
@@ -823,6 +857,10 @@
     transition-property: transform, translate, scale, rotate;
     transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
     transition-duration: var(--tw-duration, var(--default-transition-duration));
+  }
+  .duration-150 {
+    --tw-duration: 150ms;
+    transition-duration: 150ms;
   }
   .duration-200 {
     --tw-duration: 200ms;
@@ -1097,6 +1135,11 @@
   inherits: false;
   initial-value: 0;
 }
+@property --tw-divide-y-reverse {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0;
+}
 @property --tw-border-style {
   syntax: "*";
   inherits: false;
@@ -1344,6 +1387,7 @@
       --tw-skew-y: initial;
       --tw-space-y-reverse: 0;
       --tw-space-x-reverse: 0;
+      --tw-divide-y-reverse: 0;
       --tw-border-style: solid;
       --tw-gradient-position: initial;
       --tw-gradient-from: #0000;

--- a/static/tailwind.css
+++ b/static/tailwind.css
@@ -18,6 +18,7 @@
     --color-red-900: oklch(39.6% 0.141 25.723);
     --color-orange-100: oklch(95.4% 0.038 75.164);
     --color-orange-300: oklch(83.7% 0.128 66.29);
+    --color-yellow-50: oklch(98.7% 0.026 102.212);
     --color-yellow-100: oklch(97.3% 0.071 103.193);
     --color-yellow-200: oklch(94.5% 0.129 101.54);
     --color-yellow-500: oklch(79.5% 0.184 86.047);
@@ -32,7 +33,6 @@
     --color-blue-50: oklch(97% 0.014 254.604);
     --color-blue-100: oklch(93.2% 0.032 255.585);
     --color-blue-200: oklch(88.2% 0.059 254.128);
-    --color-blue-300: oklch(80.9% 0.105 251.813);
     --color-blue-500: oklch(62.3% 0.214 259.815);
     --color-blue-600: oklch(54.6% 0.245 262.881);
     --color-blue-700: oklch(48.8% 0.243 264.376);
@@ -67,8 +67,6 @@
     --text-lg--line-height: calc(1.75 / 1.125);
     --text-xl: 1.25rem;
     --text-xl--line-height: calc(1.75 / 1.25);
-    --text-2xl: 1.5rem;
-    --text-2xl--line-height: calc(2 / 1.5);
     --text-3xl: 1.875rem;
     --text-3xl--line-height: calc(2.25 / 1.875);
     --text-6xl: 3.75rem;
@@ -416,18 +414,18 @@
       margin-block-end: calc(calc(var(--spacing) * 2) * calc(1 - var(--tw-space-y-reverse)));
     }
   }
-  .space-y-3 {
-    :where(& > :not(:last-child)) {
-      --tw-space-y-reverse: 0;
-      margin-block-start: calc(calc(var(--spacing) * 3) * var(--tw-space-y-reverse));
-      margin-block-end: calc(calc(var(--spacing) * 3) * calc(1 - var(--tw-space-y-reverse)));
-    }
-  }
   .space-y-6 {
     :where(& > :not(:last-child)) {
       --tw-space-y-reverse: 0;
       margin-block-start: calc(calc(var(--spacing) * 6) * var(--tw-space-y-reverse));
       margin-block-end: calc(calc(var(--spacing) * 6) * calc(1 - var(--tw-space-y-reverse)));
+    }
+  }
+  .space-y-8 {
+    :where(& > :not(:last-child)) {
+      --tw-space-y-reverse: 0;
+      margin-block-start: calc(calc(var(--spacing) * 8) * var(--tw-space-y-reverse));
+      margin-block-end: calc(calc(var(--spacing) * 8) * calc(1 - var(--tw-space-y-reverse)));
     }
   }
   .space-x-2 {
@@ -605,6 +603,9 @@
       background-color: color-mix(in oklab, var(--color-white) 80%, transparent);
     }
   }
+  .bg-yellow-50 {
+    background-color: var(--color-yellow-50);
+  }
   .bg-yellow-100 {
     background-color: var(--color-yellow-100);
   }
@@ -701,10 +702,6 @@
   .font-mono {
     font-family: var(--font-mono);
   }
-  .text-2xl {
-    font-size: var(--text-2xl);
-    line-height: var(--tw-leading, var(--text-2xl--line-height));
-  }
   .text-3xl {
     font-size: var(--text-3xl);
     line-height: var(--tw-leading, var(--text-3xl--line-height));
@@ -793,6 +790,9 @@
   .text-red-500 {
     color: var(--color-red-500);
   }
+  .text-red-600 {
+    color: var(--color-red-600);
+  }
   .text-red-800 {
     color: var(--color-red-800);
   }
@@ -828,6 +828,10 @@
       color: var(--color-gray-500);
     }
   }
+  .shadow {
+    --tw-shadow: 0 1px 3px 0 var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 1px 2px -1px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
   .shadow-lg {
     --tw-shadow: 0 10px 15px -3px var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 4px 6px -4px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
     box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
@@ -838,6 +842,10 @@
   }
   .shadow-sm {
     --tw-shadow: 0 1px 3px 0 var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 1px 2px -1px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+  .ring {
+    --tw-ring-shadow: var(--tw-ring-inset,) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentcolor);
     box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
   }
   .filter {
@@ -903,20 +911,6 @@
     &:is(:where(.group):hover *) {
       @media (hover: hover) {
         color: var(--color-indigo-600);
-      }
-    }
-  }
-  .hover\:border-blue-300 {
-    &:hover {
-      @media (hover: hover) {
-        border-color: var(--color-blue-300);
-      }
-    }
-  }
-  .hover\:bg-blue-50 {
-    &:hover {
-      @media (hover: hover) {
-        background-color: var(--color-blue-50);
       }
     }
   }

--- a/static/tailwind.css
+++ b/static/tailwind.css
@@ -274,6 +274,9 @@
   .mt-2 {
     margin-top: calc(var(--spacing) * 2);
   }
+  .mt-3 {
+    margin-top: calc(var(--spacing) * 3);
+  }
   .mt-6 {
     margin-top: calc(var(--spacing) * 6);
   }


### PR DESCRIPTION
Use GitHub Copilot Pro (in VSCode) to redesign all pages for a consistent theme. Thereon, create `DESIGN.md` capturing the styling principles so that future work (either by AI or humans) can follow consistent set of styling. The `Widgets.hs` module contains Vira's UI component library; each component has a detailed Haddock comment explaining how to use it.

## Repos

<img width="1410" height="1257" alt="image" src="https://github.com/user-attachments/assets/8a5970f5-5366-4e9b-aa5c-f08c69901de0" />


## Jobs

<img width="1410" height="1257" alt="image" src="https://github.com/user-attachments/assets/4d4d9865-79a9-4ad2-a08b-c831ec60f291" />


## Settings

<img width="1410" height="1257" alt="image" src="https://github.com/user-attachments/assets/91e44fc1-1a80-4af0-b736-73fda4560a1a" />

