### PR TITLE
Use hpack

### DIFF
--- a/hpack-common.yaml
+++ b/hpack-common.yaml
@@ -1,0 +1,48 @@
+language: GHC2021
+
+ghc-options:
+  - -Wall
+  - -Wincomplete-record-updates
+  - -Wincomplete-uni-patterns
+  - -Wmissing-deriving-strategies
+  - -Wunused-foralls
+  - -fprint-explicit-foralls
+  - -fprint-explicit-kinds
+
+default-extensions:
+  - DataKinds
+  - DeriveDataTypeable
+  - DeriveGeneric
+  - DeriveTraversable
+  - DerivingStrategies
+  - DerivingVia
+  - ExplicitForAll
+  - FlexibleContexts
+  - FlexibleInstances
+  - GeneralizedNewtypeDeriving
+  - ImportQualifiedPost
+  - LambdaCase
+  - MultiParamTypeClasses
+  - MultiWayIf
+  - NamedFieldPuns
+  - NoStarIsType
+  - NumericUnderscores
+  - OverloadedStrings
+  - ScopedTypeVariables
+  - StrictData
+  - TypeApplications
+  - TypeFamilies
+  - TypeOperators
+  - TypeSynonymInstances
+  - ViewPatterns
+
+dependencies:
+  - name: base
+    version: ">= 4 && < 5"
+    mixin:
+      - hiding (Prelude)
+  - name: relude
+    version: ">= 1.0"
+    mixin:
+      - (Relude as Prelude, Relude.Container.One)
+      - ""

--- a/nix/modules/flake-parts/pre-commit.nix
+++ b/nix/modules/flake-parts/pre-commit.nix
@@ -8,12 +8,12 @@
     pre-commit.settings = {
       hooks = {
         nixpkgs-fmt.enable = true;
-        cabal-fmt.enable = true;
         fourmolu = {
           enable = true;
           package = config.fourmolu.wrapper;
         };
         hlint.enable = true;
+        hpack.enable = true;
         typos = {
           enable = true;
           settings.config.files.extend-exclude = [

--- a/packages/htmx-lucid-contrib/htmx-lucid-contrib.cabal
+++ b/packages/htmx-lucid-contrib/htmx-lucid-contrib.cabal
@@ -1,52 +1,67 @@
-cabal-version: 2.4
+cabal-version: 2.0
+
+-- This file has been generated from package.yaml by hpack version 0.37.0.
+--
+-- see: https://github.com/sol/hpack
+
 name:          htmx-lucid-contrib
 version:       0.1.0.0
-license:       MIT
-copyright:     2024 Juspay
-maintainer:    srid@srid.ca
-author:        Sridhar Ratnakumar
-category:      Web
 synopsis:      Additional HTMX utilities for Lucid (upstream candidates)
-description:
-  Additional utilities for working with HTMX and Lucid that are candidates for upstreaming to htmx-lucid
-
-common shared
-  default-language:   GHC2021
-  ghc-options:
-    -Wall -Wincomplete-record-updates -Wincomplete-uni-patterns
-    -Wmissing-deriving-strategies -Wunused-foralls -Wunused-foralls
-    -fprint-explicit-foralls -fprint-explicit-kinds
-
-  mixins:
-    base hiding (Prelude),
-    relude (Relude as Prelude, Relude.Container.One),
-    relude
-
-  default-extensions:
-    DataKinds
-    DeriveTraversable
-    DerivingStrategies
-    DerivingVia
-    ImportQualifiedPost
-    LambdaCase
-    MultiWayIf
-    NoStarIsType
-    OverloadedStrings
-    StrictData
-    TypeFamilies
-    ViewPatterns
+description:   Additional utilities for working with HTMX and Lucid that are candidates for upstreaming to htmx-lucid
+category:      Web
+author:        Sridhar Ratnakumar
+maintainer:    srid@srid.ca
+copyright:     2024 Juspay
+license:       MIT
+build-type:    Simple
 
 library
-  import:          shared
-  hs-source-dirs:  src
+  exposed-modules:
+      Lucid.Htmx.Contrib
+  other-modules:
+      Paths_htmx_lucid_contrib
+  autogen-modules:
+      Paths_htmx_lucid_contrib
+  hs-source-dirs:
+      src
+  default-extensions:
+      DataKinds
+      DeriveDataTypeable
+      DeriveGeneric
+      DeriveTraversable
+      DerivingStrategies
+      DerivingVia
+      ExplicitForAll
+      FlexibleContexts
+      FlexibleInstances
+      GeneralizedNewtypeDeriving
+      ImportQualifiedPost
+      LambdaCase
+      MultiParamTypeClasses
+      MultiWayIf
+      NamedFieldPuns
+      NoStarIsType
+      NumericUnderscores
+      OverloadedStrings
+      ScopedTypeVariables
+      StrictData
+      TypeApplications
+      TypeFamilies
+      TypeOperators
+      TypeSynonymInstances
+      ViewPatterns
+  ghc-options: -Wall -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-deriving-strategies -Wunused-foralls -fprint-explicit-foralls -fprint-explicit-kinds
   build-depends:
-    , base            >=4   && <5
+      base ==4.*
     , htmx
     , htmx-lucid
     , lucid2
-    , relude          >=1.0
+    , relude >=1.0
     , servant
     , servant-server
     , text
-
-  exposed-modules: Lucid.Htmx.Contrib
+  mixins:
+      base hiding (Prelude)
+    , relude (Relude as Prelude, Relude.Container.One)
+    , relude 
+  default-language: GHC2021

--- a/packages/htmx-lucid-contrib/package.yaml
+++ b/packages/htmx-lucid-contrib/package.yaml
@@ -21,5 +21,3 @@ dependencies:
 
 library:
   source-dirs: src
-  exposed-modules:
-    - Lucid.Htmx.Contrib

--- a/packages/htmx-lucid-contrib/package.yaml
+++ b/packages/htmx-lucid-contrib/package.yaml
@@ -1,0 +1,25 @@
+defaults:
+  local: ../../hpack-common.yaml
+
+name: htmx-lucid-contrib
+version: 0.1.0.0
+license: MIT
+copyright: 2024 Juspay
+maintainer: srid@srid.ca
+author: Sridhar Ratnakumar
+category: Web
+synopsis: Additional HTMX utilities for Lucid (upstream candidates)
+description: Additional utilities for working with HTMX and Lucid that are candidates for upstreaming to htmx-lucid
+
+dependencies:
+  - htmx
+  - htmx-lucid
+  - lucid2
+  - servant
+  - servant-server
+  - text
+
+library:
+  source-dirs: src
+  exposed-modules:
+    - Lucid.Htmx.Contrib

--- a/packages/vira/package.yaml
+++ b/packages/vira/package.yaml
@@ -21,11 +21,6 @@ data-files:
   - tailwind.css
   - vira-logo.jpg
 
-flags:
-  ghcid:
-    default: false
-    manual: true
-
 ghc-options:
   - -fplugin=Effectful.Plugin
 

--- a/packages/vira/package.yaml
+++ b/packages/vira/package.yaml
@@ -78,13 +78,11 @@ dependencies:
 
 library:
   source-dirs: src
-  generated-other-modules: Paths_vira
 
 executables:
   vira:
     main: Main.hs
     source-dirs: app
-    generated-other-modules: Paths_vira
     ghc-options:
       - -threaded
       - -rtsopts
@@ -95,6 +93,5 @@ executables:
   vira-tests:
     main: Test.hs
     source-dirs: test
-    generated-other-modules: Paths_vira
     dependencies:
       - vira

--- a/packages/vira/package.yaml
+++ b/packages/vira/package.yaml
@@ -78,50 +78,13 @@ dependencies:
 
 library:
   source-dirs: src
-  other-modules: Paths_vira
-  exposed-modules:
-    - Vira.App
-    - Vira.App.AcidState
-    - Vira.App.CLI
-    - Vira.App.LinkTo.Resolve
-    - Vira.App.LinkTo.Type
-    - Vira.App.Logging
-    - Vira.App.Run
-    - Vira.App.Servant
-    - Vira.App.Server
-    - Vira.App.Stack
-    - Vira.Lib.Attic
-    - Vira.Lib.Cachix
-    - Vira.Lib.Git
-    - Vira.Lib.Omnix
-    - Vira.Lib.Process
-    - Vira.Lib.Process.TailF
-    - Vira.Page.IndexPage
-    - Vira.Page.JobLog
-    - Vira.Page.JobPage
-    - Vira.Page.RegistryPage
-    - Vira.Page.RepoPage
-    - Vira.Page.SettingsPage
-    - Vira.State.Acid
-    - Vira.State.Core
-    - Vira.State.Type
-    - Vira.Stream.Log
-    - Vira.Stream.Status
-    - Vira.Supervisor.Core
-    - Vira.Supervisor.Task
-    - Vira.Supervisor.Type
-    - Vira.Widgets.Alert
-    - Vira.Widgets.Button
-    - Vira.Widgets.Card
-    - Vira.Widgets.Code
-    - Vira.Widgets.Form
-    - Vira.Widgets.Layout
-    - Vira.Widgets.Status
+  generated-other-modules: Paths_vira
 
 executables:
   vira:
     main: Main.hs
     source-dirs: app
+    generated-other-modules: Paths_vira
     ghc-options:
       - -threaded
       - -rtsopts
@@ -132,5 +95,6 @@ executables:
   vira-tests:
     main: Test.hs
     source-dirs: test
+    generated-other-modules: Paths_vira
     dependencies:
       - vira

--- a/packages/vira/package.yaml
+++ b/packages/vira/package.yaml
@@ -1,0 +1,141 @@
+defaults:
+  local: ../../hpack-common.yaml
+
+name: vira
+version: 0.1.0.0
+license: AGPL-3.0-or-later
+copyright: 2024 Juspay
+maintainer: srid@srid.ca
+author: Sridhar Ratnakumar
+category: Web
+homepage: https://github.com/juspay/vira
+synopsis: Nix CI & Cache
+description: vira - Nix CI & Cache
+
+data-dir: static
+data-files:
+  - js/htmx-ext-debug.js
+  - js/htmx-extensions/src/sse/sse.js
+  - js/htmx.min.js
+  - js/hyperscript.min.js
+  - tailwind.css
+  - vira-logo.jpg
+
+flags:
+  ghcid:
+    default: false
+    manual: true
+
+ghc-options:
+  - -fplugin=Effectful.Plugin
+
+dependencies:
+  - acid-state
+  - aeson
+  - async
+  - bytestring
+  - co-log
+  - co-log-core
+  - co-log-effectful
+  - dani-servant-lucid2
+  - data-default
+  - deriving-aeson
+  - directory
+  - effectful
+  - effectful-core
+  - effectful-plugin
+  - effectful-th
+  - envparse
+  - filepath
+  - gitlib
+  - hostname
+  - hspec
+  - hspec-discover
+  - htmx
+  - htmx-lucid
+  - htmx-lucid-contrib
+  - htmx-servant
+  - http-api-data
+  - ixset-typed
+  - lucid2
+  - mtl
+  - optics-core
+  - optparse-applicative
+  - process
+  - profunctors
+  - QuickCheck
+  - safecopy
+  - servant
+  - servant-event-stream
+  - servant-server
+  - shower
+  - sqlite-simple
+  - stm
+  - streaming
+  - time
+  - wai
+  - wai-extra
+  - wai-middleware-static
+  - warp
+  - warp-tls-simple
+  - which
+  - with-utf8
+
+library:
+  source-dirs: src
+  other-modules: Paths_vira
+  exposed-modules:
+    - Vira.App
+    - Vira.App.AcidState
+    - Vira.App.CLI
+    - Vira.App.LinkTo.Resolve
+    - Vira.App.LinkTo.Type
+    - Vira.App.Logging
+    - Vira.App.Run
+    - Vira.App.Servant
+    - Vira.App.Server
+    - Vira.App.Stack
+    - Vira.Lib.Attic
+    - Vira.Lib.Cachix
+    - Vira.Lib.Git
+    - Vira.Lib.Omnix
+    - Vira.Lib.Process
+    - Vira.Lib.Process.TailF
+    - Vira.Page.IndexPage
+    - Vira.Page.JobLog
+    - Vira.Page.JobPage
+    - Vira.Page.RegistryPage
+    - Vira.Page.RepoPage
+    - Vira.Page.SettingsPage
+    - Vira.State.Acid
+    - Vira.State.Core
+    - Vira.State.Type
+    - Vira.Stream.Log
+    - Vira.Stream.Status
+    - Vira.Supervisor.Core
+    - Vira.Supervisor.Task
+    - Vira.Supervisor.Type
+    - Vira.Widgets.Alert
+    - Vira.Widgets.Button
+    - Vira.Widgets.Card
+    - Vira.Widgets.Code
+    - Vira.Widgets.Form
+    - Vira.Widgets.Layout
+    - Vira.Widgets.Status
+
+executables:
+  vira:
+    main: Main.hs
+    source-dirs: app
+    ghc-options:
+      - -threaded
+      - -rtsopts
+      - -with-rtsopts=-N
+    dependencies:
+      - vira
+
+  vira-tests:
+    main: Test.hs
+    source-dirs: test
+    dependencies:
+      - vira

--- a/packages/vira/vira.cabal
+++ b/packages/vira/vira.cabal
@@ -25,10 +25,6 @@ data-files:
     vira-logo.jpg
 data-dir:      static
 
-flag ghcid
-  manual: True
-  default: False
-
 library
   exposed-modules:
       Vira.App

--- a/packages/vira/vira.cabal
+++ b/packages/vira/vira.cabal
@@ -1,61 +1,112 @@
-cabal-version: 2.4
+cabal-version: 2.2
+
+-- This file has been generated from package.yaml by hpack version 0.37.0.
+--
+-- see: https://github.com/sol/hpack
+
 name:          vira
 version:       0.1.0.0
-license:       AGPL-3.0-or-later
-copyright:     2024 Juspay
-maintainer:    srid@srid.ca
-author:        Sridhar Ratnakumar
-category:      Web
-homepage:      https://github.com/juspay/vira
 synopsis:      Nix CI & Cache
 description:   vira - Nix CI & Cache
-data-dir:      static
+category:      Web
+homepage:      https://github.com/juspay/vira
+author:        Sridhar Ratnakumar
+maintainer:    srid@srid.ca
+copyright:     2024 Juspay
+license:       AGPL-3.0-or-later
+license-file:  LICENSE
+build-type:    Simple
 data-files:
-  js/htmx-ext-debug.js
-  js/htmx-extensions/src/sse/sse.js
-  js/htmx.min.js
-  js/hyperscript.min.js
-  tailwind.css
-  vira-logo.jpg
+    js/htmx-ext-debug.js
+    js/htmx-extensions/src/sse/sse.js
+    js/htmx.min.js
+    js/hyperscript.min.js
+    tailwind.css
+    vira-logo.jpg
+data-dir:      static
 
 flag ghcid
+  manual: True
   default: False
-  manual:  True
 
-common shared
-  default-language:   GHC2021
-  ghc-options:
-    -Wall -Wincomplete-record-updates -Wincomplete-uni-patterns
-    -Wmissing-deriving-strategies -Wunused-foralls -Wunused-foralls
-    -fprint-explicit-foralls -fprint-explicit-kinds
-    -fplugin=Effectful.Plugin
-
-  mixins:
-    base hiding (Prelude),
-    relude (Relude as Prelude, Relude.Container.One),
-    relude
-
+library
+  exposed-modules:
+      Vira.App
+      Vira.App.AcidState
+      Vira.App.CLI
+      Vira.App.LinkTo.Resolve
+      Vira.App.LinkTo.Type
+      Vira.App.Logging
+      Vira.App.Run
+      Vira.App.Servant
+      Vira.App.Server
+      Vira.App.Stack
+      Vira.Lib.Attic
+      Vira.Lib.Cachix
+      Vira.Lib.Git
+      Vira.Lib.Omnix
+      Vira.Lib.Process
+      Vira.Lib.Process.TailF
+      Vira.Page.IndexPage
+      Vira.Page.JobLog
+      Vira.Page.JobPage
+      Vira.Page.RegistryPage
+      Vira.Page.RepoPage
+      Vira.Page.SettingsPage
+      Vira.State.Acid
+      Vira.State.Core
+      Vira.State.Type
+      Vira.Stream.Log
+      Vira.Stream.Status
+      Vira.Supervisor.Core
+      Vira.Supervisor.Task
+      Vira.Supervisor.Type
+      Vira.Widgets.Alert
+      Vira.Widgets.Button
+      Vira.Widgets.Card
+      Vira.Widgets.Code
+      Vira.Widgets.Form
+      Vira.Widgets.Layout
+      Vira.Widgets.Status
+  other-modules:
+      Paths_vira
+  autogen-modules:
+      Paths_vira
+  hs-source-dirs:
+      src
   default-extensions:
-    DataKinds
-    DeriveTraversable
-    DerivingStrategies
-    DerivingVia
-    ImportQualifiedPost
-    LambdaCase
-    MultiWayIf
-    NoStarIsType
-    OverloadedStrings
-    StrictData
-    TypeFamilies
-    ViewPatterns
-
-common library-shared
-  import:        shared
+      DataKinds
+      DeriveDataTypeable
+      DeriveGeneric
+      DeriveTraversable
+      DerivingStrategies
+      DerivingVia
+      ExplicitForAll
+      FlexibleContexts
+      FlexibleInstances
+      GeneralizedNewtypeDeriving
+      ImportQualifiedPost
+      LambdaCase
+      MultiParamTypeClasses
+      MultiWayIf
+      NamedFieldPuns
+      NoStarIsType
+      NumericUnderscores
+      OverloadedStrings
+      ScopedTypeVariables
+      StrictData
+      TypeApplications
+      TypeFamilies
+      TypeOperators
+      TypeSynonymInstances
+      ViewPatterns
+  ghc-options: -Wall -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-deriving-strategies -Wunused-foralls -fprint-explicit-foralls -fprint-explicit-kinds -fplugin=Effectful.Plugin
   build-depends:
+      QuickCheck
     , acid-state
     , aeson
     , async
-    , base                   >=4   && <5
+    , base ==4.*
     , bytestring
     , co-log
     , co-log-core
@@ -86,8 +137,7 @@ common library-shared
     , optparse-applicative
     , process
     , profunctors
-    , QuickCheck
-    , relude                 >=1.0
+    , relude >=1.0
     , safecopy
     , servant
     , servant-event-stream
@@ -104,60 +154,198 @@ common library-shared
     , warp-tls-simple
     , which
     , with-utf8
-
-library
-  import:          library-shared
-  hs-source-dirs:  src
-  autogen-modules: Paths_vira
-  other-modules:   Paths_vira
-  exposed-modules:
-    Vira.App
-    Vira.App.AcidState
-    Vira.App.CLI
-    Vira.App.LinkTo.Resolve
-    Vira.App.LinkTo.Type
-    Vira.App.Logging
-    Vira.App.Run
-    Vira.App.Servant
-    Vira.App.Server
-    Vira.App.Stack
-    Vira.Lib.Attic
-    Vira.Lib.Cachix
-    Vira.Lib.Git
-    Vira.Lib.Omnix
-    Vira.Lib.Process
-    Vira.Lib.Process.TailF
-    Vira.Page.IndexPage
-    Vira.Page.JobLog
-    Vira.Page.JobPage
-    Vira.Page.RegistryPage
-    Vira.Page.RepoPage
-    Vira.Page.SettingsPage
-    Vira.State.Acid
-    Vira.State.Core
-    Vira.State.Type
-    Vira.Stream.Log
-    Vira.Stream.Status
-    Vira.Supervisor.Core
-    Vira.Supervisor.Task
-    Vira.Supervisor.Type
-    Vira.Widgets.Alert
-    Vira.Widgets.Button
-    Vira.Widgets.Card
-    Vira.Widgets.Code
-    Vira.Widgets.Form
-    Vira.Widgets.Layout
-    Vira.Widgets.Status
+  mixins:
+      base hiding (Prelude)
+    , relude (Relude as Prelude, Relude.Container.One)
+    , relude 
+  default-language: GHC2021
 
 executable vira
-  import:         library-shared
-  main-is:        Main.hs
-  ghc-options:    -threaded -rtsopts -with-rtsopts=-N
-  hs-source-dirs: app
-  build-depends:  vira
+  main-is: Main.hs
+  other-modules:
+      Paths_vira
+  autogen-modules:
+      Paths_vira
+  hs-source-dirs:
+      app
+  default-extensions:
+      DataKinds
+      DeriveDataTypeable
+      DeriveGeneric
+      DeriveTraversable
+      DerivingStrategies
+      DerivingVia
+      ExplicitForAll
+      FlexibleContexts
+      FlexibleInstances
+      GeneralizedNewtypeDeriving
+      ImportQualifiedPost
+      LambdaCase
+      MultiParamTypeClasses
+      MultiWayIf
+      NamedFieldPuns
+      NoStarIsType
+      NumericUnderscores
+      OverloadedStrings
+      ScopedTypeVariables
+      StrictData
+      TypeApplications
+      TypeFamilies
+      TypeOperators
+      TypeSynonymInstances
+      ViewPatterns
+  ghc-options: -Wall -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-deriving-strategies -Wunused-foralls -fprint-explicit-foralls -fprint-explicit-kinds -fplugin=Effectful.Plugin -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+      QuickCheck
+    , acid-state
+    , aeson
+    , async
+    , base ==4.*
+    , bytestring
+    , co-log
+    , co-log-core
+    , co-log-effectful
+    , dani-servant-lucid2
+    , data-default
+    , deriving-aeson
+    , directory
+    , effectful
+    , effectful-core
+    , effectful-plugin
+    , effectful-th
+    , envparse
+    , filepath
+    , gitlib
+    , hostname
+    , hspec
+    , hspec-discover
+    , htmx
+    , htmx-lucid
+    , htmx-lucid-contrib
+    , htmx-servant
+    , http-api-data
+    , ixset-typed
+    , lucid2
+    , mtl
+    , optics-core
+    , optparse-applicative
+    , process
+    , profunctors
+    , relude >=1.0
+    , safecopy
+    , servant
+    , servant-event-stream
+    , servant-server
+    , shower
+    , sqlite-simple
+    , stm
+    , streaming
+    , time
+    , vira
+    , wai
+    , wai-extra
+    , wai-middleware-static
+    , warp
+    , warp-tls-simple
+    , which
+    , with-utf8
+  mixins:
+      base hiding (Prelude)
+    , relude (Relude as Prelude, Relude.Container.One)
+    , relude 
+  default-language: GHC2021
 
 executable vira-tests
-  import:         library-shared
-  main-is:        Test.hs
-  hs-source-dirs: test
-  build-depends:  vira
+  main-is: Test.hs
+  other-modules:
+      Paths_vira
+  autogen-modules:
+      Paths_vira
+  hs-source-dirs:
+      test
+  default-extensions:
+      DataKinds
+      DeriveDataTypeable
+      DeriveGeneric
+      DeriveTraversable
+      DerivingStrategies
+      DerivingVia
+      ExplicitForAll
+      FlexibleContexts
+      FlexibleInstances
+      GeneralizedNewtypeDeriving
+      ImportQualifiedPost
+      LambdaCase
+      MultiParamTypeClasses
+      MultiWayIf
+      NamedFieldPuns
+      NoStarIsType
+      NumericUnderscores
+      OverloadedStrings
+      ScopedTypeVariables
+      StrictData
+      TypeApplications
+      TypeFamilies
+      TypeOperators
+      TypeSynonymInstances
+      ViewPatterns
+  ghc-options: -Wall -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-deriving-strategies -Wunused-foralls -fprint-explicit-foralls -fprint-explicit-kinds -fplugin=Effectful.Plugin
+  build-depends:
+      QuickCheck
+    , acid-state
+    , aeson
+    , async
+    , base ==4.*
+    , bytestring
+    , co-log
+    , co-log-core
+    , co-log-effectful
+    , dani-servant-lucid2
+    , data-default
+    , deriving-aeson
+    , directory
+    , effectful
+    , effectful-core
+    , effectful-plugin
+    , effectful-th
+    , envparse
+    , filepath
+    , gitlib
+    , hostname
+    , hspec
+    , hspec-discover
+    , htmx
+    , htmx-lucid
+    , htmx-lucid-contrib
+    , htmx-servant
+    , http-api-data
+    , ixset-typed
+    , lucid2
+    , mtl
+    , optics-core
+    , optparse-applicative
+    , process
+    , profunctors
+    , relude >=1.0
+    , safecopy
+    , servant
+    , servant-event-stream
+    , servant-server
+    , shower
+    , sqlite-simple
+    , stm
+    , streaming
+    , time
+    , vira
+    , wai
+    , wai-extra
+    , wai-middleware-static
+    , warp
+    , warp-tls-simple
+    , which
+    , with-utf8
+  mixins:
+      base hiding (Prelude)
+    , relude (Relude as Prelude, Relude.Container.One)
+    , relude 
+  default-language: GHC2021

--- a/packages/warp-tls-simple/package.yaml
+++ b/packages/warp-tls-simple/package.yaml
@@ -1,0 +1,27 @@
+defaults:
+  local: ../../hpack-common.yaml
+
+name: warp-tls-simple
+version: 0.1.0.0
+license: MIT
+copyright: 2024 Juspay
+maintainer: srid@srid.ca
+author: Sridhar Ratnakumar
+category: Web
+synopsis: Simple TLS configuration for Warp
+description: Simplified TLS setup and certificate generation for Warp servers
+
+dependencies:
+  - directory
+  - optparse-applicative
+  - process
+  - text
+  - wai
+  - warp
+  - warp-tls
+  - which
+
+library:
+  source-dirs: src
+  exposed-modules:
+    - Network.Wai.Handler.WarpTLS.Simple

--- a/packages/warp-tls-simple/package.yaml
+++ b/packages/warp-tls-simple/package.yaml
@@ -4,7 +4,7 @@ defaults:
 name: warp-tls-simple
 version: 0.1.0.0
 license: MIT
-copyright: 2024 Juspay
+copyright: 2025 Juspay
 maintainer: srid@srid.ca
 author: Sridhar Ratnakumar
 category: Web
@@ -23,5 +23,3 @@ dependencies:
 
 library:
   source-dirs: src
-  exposed-modules:
-    - Network.Wai.Handler.WarpTLS.Simple

--- a/packages/warp-tls-simple/warp-tls-simple.cabal
+++ b/packages/warp-tls-simple/warp-tls-simple.cabal
@@ -11,7 +11,7 @@ description:   Simplified TLS setup and certificate generation for Warp servers
 category:      Web
 author:        Sridhar Ratnakumar
 maintainer:    srid@srid.ca
-copyright:     2024 Juspay
+copyright:     2025 Juspay
 license:       MIT
 build-type:    Simple
 

--- a/packages/warp-tls-simple/warp-tls-simple.cabal
+++ b/packages/warp-tls-simple/warp-tls-simple.cabal
@@ -1,54 +1,69 @@
-cabal-version: 2.4
+cabal-version: 2.0
+
+-- This file has been generated from package.yaml by hpack version 0.37.0.
+--
+-- see: https://github.com/sol/hpack
+
 name:          warp-tls-simple
 version:       0.1.0.0
-license:       MIT
-copyright:     2024 Juspay
-maintainer:    srid@srid.ca
-author:        Sridhar Ratnakumar
-category:      Web
 synopsis:      Simple TLS configuration for Warp
-description:
-  Simplified TLS setup and certificate generation for Warp servers
-
-common shared
-  default-language:   GHC2021
-  ghc-options:
-    -Wall -Wincomplete-record-updates -Wincomplete-uni-patterns
-    -Wmissing-deriving-strategies -Wunused-foralls -Wunused-foralls
-    -fprint-explicit-foralls -fprint-explicit-kinds
-
-  mixins:
-    base hiding (Prelude),
-    relude (Relude as Prelude, Relude.Container.One),
-    relude
-
-  default-extensions:
-    DataKinds
-    DeriveTraversable
-    DerivingStrategies
-    DerivingVia
-    ImportQualifiedPost
-    LambdaCase
-    MultiWayIf
-    NoStarIsType
-    OverloadedStrings
-    StrictData
-    TypeFamilies
-    ViewPatterns
+description:   Simplified TLS setup and certificate generation for Warp servers
+category:      Web
+author:        Sridhar Ratnakumar
+maintainer:    srid@srid.ca
+copyright:     2024 Juspay
+license:       MIT
+build-type:    Simple
 
 library
-  import:          shared
-  hs-source-dirs:  src
+  exposed-modules:
+      Network.Wai.Handler.WarpTLS.Simple
+  other-modules:
+      Paths_warp_tls_simple
+  autogen-modules:
+      Paths_warp_tls_simple
+  hs-source-dirs:
+      src
+  default-extensions:
+      DataKinds
+      DeriveDataTypeable
+      DeriveGeneric
+      DeriveTraversable
+      DerivingStrategies
+      DerivingVia
+      ExplicitForAll
+      FlexibleContexts
+      FlexibleInstances
+      GeneralizedNewtypeDeriving
+      ImportQualifiedPost
+      LambdaCase
+      MultiParamTypeClasses
+      MultiWayIf
+      NamedFieldPuns
+      NoStarIsType
+      NumericUnderscores
+      OverloadedStrings
+      ScopedTypeVariables
+      StrictData
+      TypeApplications
+      TypeFamilies
+      TypeOperators
+      TypeSynonymInstances
+      ViewPatterns
+  ghc-options: -Wall -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-deriving-strategies -Wunused-foralls -fprint-explicit-foralls -fprint-explicit-kinds
   build-depends:
-    , base                  >=4   && <5
+      base ==4.*
     , directory
     , optparse-applicative
     , process
-    , relude                >=1.0
+    , relude >=1.0
     , text
     , wai
     , warp
     , warp-tls
     , which
-
-  exposed-modules: Network.Wai.Handler.WarpTLS.Simple
+  mixins:
+      base hiding (Prelude)
+    , relude (Relude as Prelude, Relude.Container.One)
+    , relude 
+  default-language: GHC2021


### PR DESCRIPTION
It is a pain to manage `.cabal` on a multi package repo. Plus, with hpack we get to DRY it up by creating [common](https://github.com/sol/hpack?tab=readme-ov-file#defaults) configuration (`hpack-common.yaml`) in this PR.