### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: "CI"
 on:
   # Run only when pushing to master branch, and making PRs


### PR DESCRIPTION
Potential fix for [https://github.com/juspay/vira/security/code-scanning/1](https://github.com/juspay/vira/security/code-scanning/1)

To fix this issue, the workflow should explicitly specify a `permissions` block with the minimum privileges necessary for the job to run. In this case, unless there are steps that require write access to the repository (which from the snippet, there are not), setting `permissions: contents: read` at the workflow root is appropriate. This covers all jobs unless they are otherwise overridden and aligns with security best practices. The new top-level entry should be inserted after the `name` key and before the `on` block in `.github/workflows/ci.yaml`.

No additional YAML libraries, imports, or other dependencies are required for this change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
