### PR TITLE
refactor: Move logging to Vira.Lib

### DIFF
--- a/packages/vira/src/Vira/App.hs
+++ b/packages/vira/src/Vira/App.hs
@@ -9,6 +9,6 @@ where
 
 import Vira.App.AcidState as X
 import Vira.App.CLI as X
-import Vira.App.Logging as X (log)
 import Vira.App.Servant as X
 import Vira.App.Stack as X
+import Vira.Lib.Logging as X (log)

--- a/packages/vira/src/Vira/App/Server.hs
+++ b/packages/vira/src/Vira/App/Server.hs
@@ -4,7 +4,9 @@ module Vira.App.Server (
   runServer,
 ) where
 
+import Colog (Message, Severity (..))
 import Effectful (Eff, IOE, (:>))
+import Effectful.Colog (Log)
 import Effectful.FileSystem (FileSystem, doesDirectoryExist)
 import Effectful.Reader.Dynamic qualified as Reader
 import Network.Wai.Handler.Warp qualified as Warp
@@ -18,7 +20,7 @@ import Network.Wai.Middleware.Static (
 import Paths_vira qualified
 import Servant.Server.Generic (genericServe)
 import Vira.App (AppStack, CLISettings (..))
-import Vira.App.Logging
+import Vira.Lib.Logging
 import Vira.Page.IndexPage qualified as IndexPage
 
 -- | Run the Vira server with the given CLI settings

--- a/packages/vira/src/Vira/App/Stack.hs
+++ b/packages/vira/src/Vira/App/Stack.hs
@@ -1,8 +1,10 @@
 -- | Effectful stack for our app.
 module Vira.App.Stack where
 
+import Colog (Message)
 import Data.Acid (AcidState)
-import Effectful (Eff, IOE)
+import Effectful (Eff, IOE, runEff)
+import Effectful.Colog (Log)
 import Effectful.Concurrent.Async (Concurrent, runConcurrent)
 import Effectful.Error.Static (Error, runErrorNoCallStack)
 import Effectful.FileSystem (FileSystem, runFileSystem)
@@ -12,7 +14,7 @@ import Servant (Handler (Handler), ServerError)
 import Servant.Links (Link)
 import Vira.App.CLI (CLISettings)
 import Vira.App.LinkTo.Type (LinkTo)
-import Vira.App.Logging (Log, Message, runViraLog)
+import Vira.Lib.Logging (runLogActionStdout)
 import Vira.State.Core (ViraState)
 import Vira.Supervisor.Type (TaskSupervisor)
 import Prelude hiding (Reader, ask, asks, runReader)
@@ -32,7 +34,8 @@ type AppServantStack = (Error ServerError : AppStack)
 runApp :: AppState -> Eff AppStack a -> IO a
 runApp cfg =
   do
-    runViraLog
+    runEff
+    . runLogActionStdout
     . runFileSystem
     . runProcess
     . runConcurrent

--- a/packages/vira/src/Vira/Lib/Logging.hs
+++ b/packages/vira/src/Vira/Lib/Logging.hs
@@ -2,33 +2,19 @@
 
 {- | To use logging, import this module unqualified.
 
->>> import Vira.App.Logging
-
-You do not need to import any other module to use logging, since this one re-exports all the necessary types and functions.
+>>> import Vira.Lib.Logging
 -}
-module Vira.App.Logging (
+module Vira.Lib.Logging (
   -- * Logging
   log,
-
-  -- * Re-exports from co-log
-  Severity (..),
-  Message,
-  Log,
-
-  -- * For logging in IO monads
-  runViraLog,
+  runLogActionStdout,
 )
 where
 
 import Colog.Core (Severity (..))
 import Colog.Message (Message, Msg (..), fmtMessage)
-import Effectful (Eff, IOE, runEff, (:>))
+import Effectful (Eff, IOE, (:>))
 import Effectful.Colog (Log, LogAction (LogAction), logMsg, runLogAction)
-
--- | Like `runLogActionStdout` but useful in `IO` monads.
-runViraLog :: Eff '[Log Message, IOE] a -> IO a
-runViraLog =
-  runEff . runLogActionStdout
 
 -- | Like `runLogAction` but works with `Message` and writes to `Stdout` (the common use-case)
 runLogActionStdout :: Eff '[Log Message, IOE] a -> Eff '[IOE] a
@@ -40,7 +26,9 @@ runLogActionStdout =
 
 {- | Log a message with the given severity.
 
->>> import Vira.App.Logging (log, Severity(Info))
+Ref: https://github.com/eldritch-cookie/co-log-effectful/issues/1
+
+>>> import Vira.Lib.Logging (log, Severity(Info))
 >>> log Info "Hello, world!"
 -}
 log :: forall es. (HasCallStack, Log Message :> es) => Severity -> Text -> Eff es ()

--- a/packages/vira/src/Vira/Page/JobPage.hs
+++ b/packages/vira/src/Vira/Page/JobPage.hs
@@ -2,6 +2,7 @@
 
 module Vira.Page.JobPage where
 
+import Colog (Severity (..))
 import Data.Text qualified as T
 import Effectful (Eff)
 import Effectful.Error.Static (throwError)
@@ -18,11 +19,11 @@ import Servant.API.ContentTypes.Lucid (HTML)
 import Servant.Server.Generic (AsServer)
 import Vira.App qualified as App
 import Vira.App.LinkTo.Type qualified as LinkTo
-import Vira.App.Logging
 import Vira.Lib.Attic
 import Vira.Lib.Cachix
 import Vira.Lib.Git (BranchName)
 import Vira.Lib.Git qualified as Git
+import Vira.Lib.Logging
 import Vira.Lib.Omnix qualified as Omnix
 import Vira.Page.JobLog qualified as JobLog
 import Vira.State.Acid qualified as St

--- a/packages/vira/src/Vira/Page/RegistryPage.hs
+++ b/packages/vira/src/Vira/Page/RegistryPage.hs
@@ -3,6 +3,7 @@
 
 module Vira.Page.RegistryPage where
 
+import Colog (Severity (..))
 import Effectful (Eff)
 import Effectful.Reader.Dynamic (ask)
 import GHC.Records (HasField)
@@ -17,7 +18,7 @@ import Servant.API.ContentTypes.Lucid (HTML)
 import Servant.Server.Generic (AsServer)
 import Vira.App qualified as App
 import Vira.App.LinkTo.Type qualified as LinkTo
-import Vira.App.Logging
+import Vira.Lib.Logging
 import Vira.Page.RepoPage qualified as RepoPage
 import Vira.State.Acid qualified as St
 import Vira.State.Core qualified as St

--- a/packages/vira/src/Vira/Page/SettingsPage.hs
+++ b/packages/vira/src/Vira/Page/SettingsPage.hs
@@ -8,6 +8,7 @@ module Vira.Page.SettingsPage (
 )
 where
 
+import Colog (Severity (..))
 import Effectful (Eff)
 import Effectful.Reader.Dynamic (ask)
 import GHC.Records (HasField)
@@ -22,8 +23,8 @@ import Servant.API.ContentTypes.Lucid (HTML)
 import Servant.Server.Generic (AsServer)
 import Vira.App qualified as App
 import Vira.App.LinkTo.Type qualified as LinkTo
-import Vira.App.Logging
 import Vira.Lib.Attic (AtticServer (..))
+import Vira.Lib.Logging
 import Vira.State.Acid qualified as St
 import Vira.State.Type (AtticSettings (..), CachixSettings (..))
 import Vira.Widgets.Alert qualified as W

--- a/packages/vira/src/Vira/Stream/Log.hs
+++ b/packages/vira/src/Vira/Stream/Log.hs
@@ -11,6 +11,7 @@ module Vira.Stream.Log (
   logViewerWidget,
 ) where
 
+import Colog (Severity (..))
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.STM.CircularBuffer (CircularBuffer)
 import Control.Concurrent.STM.CircularBuffer qualified as CB
@@ -25,7 +26,6 @@ import Servant.Types.SourceT qualified as S
 import System.Tail qualified as Tail
 import Vira.App qualified as App
 import Vira.App.LinkTo.Type qualified as LinkTo
-import Vira.App.Logging (Severity (Error, Info))
 import Vira.State.Acid qualified as St
 import Vira.State.Type (Job, JobId)
 import Vira.State.Type qualified as St

--- a/packages/vira/src/Vira/Supervisor/Task.hs
+++ b/packages/vira/src/Vira/Supervisor/Task.hs
@@ -6,8 +6,10 @@ module Vira.Supervisor.Task (
   killTask,
 ) where
 
+import Colog (Message, Severity (..))
 import Data.Map.Strict qualified as Map
 import Effectful (Eff, IOE, (:>))
+import Effectful.Colog (Log)
 import Effectful.Concurrent.Async
 import Effectful.Concurrent.MVar (modifyMVar, modifyMVar_, readMVar)
 import Effectful.Exception (catch, finally, mask)
@@ -17,7 +19,7 @@ import Effectful.Process (CreateProcess (cmdspec, create_group), Pid, Process, c
 import System.Exit (ExitCode (ExitSuccess))
 import System.FilePath ((</>))
 import System.Tail qualified as Tail
-import Vira.App.Logging
+import Vira.Lib.Logging (log)
 import Vira.Lib.Process qualified as Process
 import Vira.Supervisor.Type
 import Prelude hiding (readMVar)

--- a/packages/vira/vira.cabal
+++ b/packages/vira/vira.cabal
@@ -32,7 +32,6 @@ library
       Vira.App.CLI
       Vira.App.LinkTo.Resolve
       Vira.App.LinkTo.Type
-      Vira.App.Logging
       Vira.App.Run
       Vira.App.Servant
       Vira.App.Server
@@ -40,6 +39,7 @@ library
       Vira.Lib.Attic
       Vira.Lib.Cachix
       Vira.Lib.Git
+      Vira.Lib.Logging
       Vira.Lib.Omnix
       Vira.Lib.Process
       Vira.Page.IndexPage


### PR DESCRIPTION
The logging part doesn't require application domain, so it shouldn't be in Vira.App.

Incidentally, this makes Vira.Supervisor independent of the rest of the app (only dependent on Vira.Lib.*)

Thus, we could potentially make the supervisor its own package (in `./packages`) but I will not do that while #83 is in flight.