### PR TITLE
Leverage `HtmlT` (lucid2) and `SourceT`(servant)

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -7,3 +7,4 @@ packages:
 multi-repl: true
 tests: True
 benchmarks: True
+optimization: False

--- a/justfile
+++ b/justfile
@@ -17,6 +17,10 @@ run:
 test COMPONENT='vira-tests':
     ghcid --warnings -T Main.main -c "./cabal-repl {{ COMPONENT }}"
 
+[group('2. haskell')]
+ghcid COMPONENT='vira':
+    ghcid --warnings -c "./cabal-repl {{ COMPONENT }}"
+
 # Delete and recreate vira.db
 [group('1. vira')]
 resetdb:

--- a/packages/vira/package.yaml
+++ b/packages/vira/package.yaml
@@ -35,13 +35,13 @@ dependencies:
   - co-log-core
   - co-log-effectful
   - containers
-  - dani-servant-lucid2
   - data-default
   - deriving-aeson
   - directory
   - effectful
   - effectful-core
   - effectful-plugin
+  - http-media
   - effectful-th
   - envparse
   - filepath
@@ -71,6 +71,7 @@ dependencies:
   - stm
   - streaming
   - tail
+  - text
   - time
   - wai
   - wai-extra

--- a/packages/vira/package.yaml
+++ b/packages/vira/package.yaml
@@ -35,6 +35,7 @@ dependencies:
   - co-log-core
   - co-log-effectful
   - containers
+  - dani-servant-lucid2
   - data-default
   - deriving-aeson
   - directory

--- a/packages/vira/package.yaml
+++ b/packages/vira/package.yaml
@@ -79,6 +79,7 @@ dependencies:
   - warp-tls-simple
   - which
   - with-utf8
+  - binary
 
 library:
   source-dirs: src

--- a/packages/vira/src/Vira/App.hs
+++ b/packages/vira/src/Vira/App.hs
@@ -9,7 +9,7 @@ where
 
 import Vira.App.AcidState as X
 import Vira.App.CLI as X
+import Vira.App.Lucid as X
 import Vira.App.Servant as X
 import Vira.App.Stack as X
-import Vira.App.VHtml as X
 import Vira.Lib.Logging as X (log)

--- a/packages/vira/src/Vira/App.hs
+++ b/packages/vira/src/Vira/App.hs
@@ -11,4 +11,5 @@ import Vira.App.AcidState as X
 import Vira.App.CLI as X
 import Vira.App.Servant as X
 import Vira.App.Stack as X
+import Vira.App.VHtml as X
 import Vira.Lib.Logging as X (log)

--- a/packages/vira/src/Vira/App/Lucid.hs
+++ b/packages/vira/src/Vira/App/Lucid.hs
@@ -1,5 +1,5 @@
 -- | VHtml types and utilities for Lucid HTML with effectful capabilities
-module Vira.App.VHtml where
+module Vira.App.Lucid where
 
 import Data.Binary.Builder (toLazyByteString)
 import Effectful (Eff, type (:>))
@@ -7,10 +7,7 @@ import Effectful.Reader.Dynamic (ask, asks)
 import Effectful.Reader.Dynamic qualified as Reader
 import Lucid.Base (Html, HtmlT, ToHtml (toHtmlRaw))
 import Lucid.Base qualified as Lucid
-import Servant.API.Stream (SourceIO)
 import Servant.Links (Link, linkURI)
-import Servant.Types.SourceT (SourceT)
-import Servant.Types.SourceT qualified as S
 import Vira.App.LinkTo.Type (LinkTo)
 import Vira.App.Stack (AppServantStack, AppStack, AppState (linkTo), runApp)
 import Prelude hiding (ask, asks)
@@ -20,12 +17,6 @@ import Prelude hiding (ask, asks)
 Use `lift` to perform effects.
 -}
 type VHtml = HtmlT (Eff AppStack)
-
-{- | Like `SourceIO` but can do application effects
-
-Use `lift` to perform effects.
--}
-type VSource a = SourceT (Eff AppStack) a
 
 -- | Convert VHtml to Html in the Servant effect stack
 runVHtml :: VHtml () -> Eff AppServantStack (Html ())
@@ -49,19 +40,3 @@ getLinkUrl :: (Reader.Reader AppState :> es) => LinkTo -> Eff es Text
 getLinkUrl linkToValue = do
   uri <- linkURI <$> getLink linkToValue
   pure $ show @Text $ uri
-
--- | Convert VSource to SourceIO by running effects in IO
-runVSourceIO :: AppState -> VSource a -> SourceIO a
-runVSourceIO cfg vsource = S.fromStepT go
-  where
-    go = S.Effect $ do
-      step <- runApp cfg $ S.unSourceT vsource pure
-      pure $ transformStep step
-    transformStep = \case
-      S.Stop -> S.Stop
-      S.Error e -> S.Error e
-      S.Skip next -> S.Skip (transformStep next)
-      S.Yield a next -> S.Yield a (transformStep next)
-      S.Effect eff -> S.Effect $ do
-        nextStep <- runApp cfg eff
-        pure $ transformStep nextStep

--- a/packages/vira/src/Vira/App/Lucid.hs
+++ b/packages/vira/src/Vira/App/Lucid.hs
@@ -1,4 +1,4 @@
--- | VHtml types and utilities for Lucid HTML with effectful capabilities
+-- | AppHtml types and utilities for Lucid HTML with effectful capabilities
 module Vira.App.Lucid where
 
 import Effectful (Eff, type (:>))
@@ -16,16 +16,20 @@ import Prelude hiding (ask, asks)
 
 Use `lift` to perform effects.
 -}
-type VHtml = HtmlT (Eff AppServantStack)
+type AppHtml = HtmlT (Eff AppServantStack)
 
--- | Convert VHtml to Html in the Servant effect stack
-runVHtml :: VHtml () -> Eff AppServantStack (Html ())
-runVHtml htmlT = do
+-- | Convert AppHtml to Html in the Servant effect stack
+runAppHtml :: AppHtml () -> Eff AppServantStack (Html ())
+runAppHtml htmlT = do
   toHtmlRaw <$> Lucid.renderBST htmlT
 
-runVHtmlHandlingError :: VHtml () -> Eff AppStack (Html ())
-runVHtmlHandlingError w = do
-  res <- runVHtml w & runErrorNoCallStack
+{- | Like `runAppHtml` but runs in a less restrictive stack
+
+To do this, it catches servant errors and renders a HTML div in place.
+-}
+runAppHtmlHandlingError :: AppHtml () -> Eff AppStack (Html ())
+runAppHtmlHandlingError w = do
+  res <- runAppHtml w & runErrorNoCallStack
   case res of
     Left err ->
       pure $ Lucid.toHtml $ "Error rendering HTML: " <> show @Text err

--- a/packages/vira/src/Vira/App/Lucid.hs
+++ b/packages/vira/src/Vira/App/Lucid.hs
@@ -1,7 +1,6 @@
 -- | VHtml types and utilities for Lucid HTML with effectful capabilities
 module Vira.App.Lucid where
 
-import Data.Binary.Builder (toLazyByteString)
 import Effectful (Eff, type (:>))
 import Effectful.Reader.Dynamic (ask, asks)
 import Effectful.Reader.Dynamic qualified as Reader
@@ -26,8 +25,7 @@ runVHtml vhtml = do
 
 runVHtml' :: VHtml () -> Eff AppStack (Html ())
 runVHtml' htmlT = do
-  (builder, _) <- Lucid.runHtmlT htmlT
-  pure $ toHtmlRaw $ toLazyByteString builder
+  toHtmlRaw <$> Lucid.renderBST htmlT
 
 -- | Get a `Link` to a part of the application
 getLink :: (Reader.Reader AppState :> es) => LinkTo -> Eff es Link

--- a/packages/vira/src/Vira/App/Lucid.hs
+++ b/packages/vira/src/Vira/App/Lucid.hs
@@ -2,30 +2,35 @@
 module Vira.App.Lucid where
 
 import Effectful (Eff, type (:>))
-import Effectful.Reader.Dynamic (ask, asks)
+import Effectful.Error.Static (runErrorNoCallStack)
+import Effectful.Reader.Dynamic (asks)
 import Effectful.Reader.Dynamic qualified as Reader
 import Lucid.Base (Html, HtmlT, ToHtml (toHtmlRaw))
 import Lucid.Base qualified as Lucid
 import Servant.Links (Link, linkURI)
 import Vira.App.LinkTo.Type (LinkTo)
-import Vira.App.Stack (AppServantStack, AppStack, AppState (linkTo), runApp)
+import Vira.App.Stack (AppServantStack, AppStack, AppState (linkTo))
 import Prelude hiding (ask, asks)
 
 {- | Like `Html` but can do application effects
 
 Use `lift` to perform effects.
 -}
-type VHtml = HtmlT (Eff AppStack)
+type VHtml = HtmlT (Eff AppServantStack)
 
 -- | Convert VHtml to Html in the Servant effect stack
 runVHtml :: VHtml () -> Eff AppServantStack (Html ())
-runVHtml vhtml = do
-  cfg <- ask @AppState
-  liftIO $ runApp cfg $ runVHtml' vhtml
-
-runVHtml' :: VHtml () -> Eff AppStack (Html ())
-runVHtml' htmlT = do
+runVHtml htmlT = do
   toHtmlRaw <$> Lucid.renderBST htmlT
+
+runVHtmlHandlingError :: VHtml () -> Eff AppStack (Html ())
+runVHtmlHandlingError w = do
+  res <- runVHtml w & runErrorNoCallStack
+  case res of
+    Left err ->
+      pure $ Lucid.toHtml $ "Error rendering HTML: " <> show @Text err
+    Right v ->
+      pure v
 
 -- | Get a `Link` to a part of the application
 getLink :: (Reader.Reader AppState :> es) => LinkTo -> Eff es Link

--- a/packages/vira/src/Vira/App/Servant.hs
+++ b/packages/vira/src/Vira/App/Servant.hs
@@ -1,6 +1,11 @@
 -- | Utilities for working with haskell-servant
 module Vira.App.Servant where
 
+import Effectful (Eff)
+import Servant.API.Stream (SourceIO)
+import Servant.Types.SourceT (SourceT)
+import Servant.Types.SourceT qualified as S
+import Vira.App.Stack (AppStack, AppState, runApp)
 import Prelude hiding (Reader, ask, runReader)
 
 {- | Handy operator to compose nested routes
@@ -20,3 +25,25 @@ Useful when working with `fieldLink`
 (/:) = flip
 
 infixl 2 /:
+
+{- | Like `SourceIO` but can do application effects
+
+Use `lift` to perform effects.
+-}
+type VSource a = SourceT (Eff AppStack) a
+
+-- | Convert VSource to SourceIO by running effects in IO
+runVSourceIO :: AppState -> VSource a -> SourceIO a
+runVSourceIO cfg vsource = S.fromStepT go
+  where
+    go = S.Effect $ do
+      step <- runApp cfg $ S.unSourceT vsource pure
+      pure $ transformStep step
+    transformStep = \case
+      S.Stop -> S.Stop
+      S.Error e -> S.Error e
+      S.Skip next -> S.Skip (transformStep next)
+      S.Yield a next -> S.Yield a (transformStep next)
+      S.Effect eff -> S.Effect $ do
+        nextStep <- runApp cfg eff
+        pure $ transformStep nextStep

--- a/packages/vira/src/Vira/App/Servant.hs
+++ b/packages/vira/src/Vira/App/Servant.hs
@@ -1,9 +1,6 @@
 -- | Utilities for working with haskell-servant
 module Vira.App.Servant where
 
-import Lucid (Html, renderBST)
-import Network.HTTP.Media qualified as M
-import Servant.API.ContentTypes (Accept (contentTypes), MimeRender (mimeRender))
 import Servant.Types.SourceT (SourceT)
 import Servant.Types.SourceT qualified as S
 import Prelude hiding (Reader, ask, runReader)
@@ -25,22 +22,6 @@ Useful when working with `fieldLink`
 (/:) = flip
 
 infixl 2 /:
-
-data HTML deriving stock (Typeable)
-
--- | @text/html;charset=utf-8@
-instance Accept HTML where
-  contentTypes _ =
-    "text"
-      M.// "html"
-      M./: ("charset", "utf-8")
-      :| ["text" M.// "html"]
-
-instance MimeRender HTML (Html ()) where
-  mimeRender _ = runIdentity . renderBST
-
-instance MimeRender HTML Text where
-  mimeRender _ = fromStrict . encodeUtf8
 
 {- | Transform the monad of a SourceT
 

--- a/packages/vira/src/Vira/App/Servant.hs
+++ b/packages/vira/src/Vira/App/Servant.hs
@@ -1,6 +1,9 @@
 -- | Utilities for working with haskell-servant
 module Vira.App.Servant where
 
+import Lucid (Html, renderBST)
+import Network.HTTP.Media qualified as M
+import Servant.API.ContentTypes (Accept (contentTypes), MimeRender (mimeRender))
 import Servant.Types.SourceT (SourceT)
 import Servant.Types.SourceT qualified as S
 import Prelude hiding (Reader, ask, runReader)
@@ -22,6 +25,22 @@ Useful when working with `fieldLink`
 (/:) = flip
 
 infixl 2 /:
+
+data HTML deriving stock (Typeable)
+
+-- | @text/html;charset=utf-8@
+instance Accept HTML where
+  contentTypes _ =
+    "text"
+      M.// "html"
+      M./: ("charset", "utf-8")
+      :| ["text" M.// "html"]
+
+instance MimeRender HTML (Html ()) where
+  mimeRender _ = runIdentity . renderBST
+
+instance MimeRender HTML Text where
+  mimeRender _ = fromStrict . encodeUtf8
 
 {- | Transform the monad of a SourceT
 

--- a/packages/vira/src/Vira/App/Servant.hs
+++ b/packages/vira/src/Vira/App/Servant.hs
@@ -1,11 +1,8 @@
 -- | Utilities for working with haskell-servant
 module Vira.App.Servant where
 
-import Effectful (Eff)
-import Servant.API.Stream (SourceIO)
 import Servant.Types.SourceT (SourceT)
 import Servant.Types.SourceT qualified as S
-import Vira.App.Stack (AppStack, AppState, runApp)
 import Prelude hiding (Reader, ask, runReader)
 
 {- | Handy operator to compose nested routes
@@ -26,18 +23,15 @@ Useful when working with `fieldLink`
 
 infixl 2 /:
 
-{- | Like `SourceIO` but can do application effects
+{- | Transform the monad of a SourceT
 
-Use `lift` to perform effects.
+XXX: Why is this not in upstream?
 -}
-type VSource a = SourceT (Eff AppStack) a
-
--- | Convert VSource to SourceIO by running effects in IO
-runVSourceIO :: AppState -> VSource a -> SourceIO a
-runVSourceIO cfg vsource = S.fromStepT go
+mapSourceT :: (Monad m, Monad n) => (forall x. m x -> n x) -> SourceT m a -> SourceT n a
+mapSourceT f source = S.fromStepT go
   where
     go = S.Effect $ do
-      step <- runApp cfg $ S.unSourceT vsource pure
+      step <- f $ S.unSourceT source pure
       pure $ transformStep step
     transformStep = \case
       S.Stop -> S.Stop
@@ -45,5 +39,5 @@ runVSourceIO cfg vsource = S.fromStepT go
       S.Skip next -> S.Skip (transformStep next)
       S.Yield a next -> S.Yield a (transformStep next)
       S.Effect eff -> S.Effect $ do
-        nextStep <- runApp cfg eff
+        nextStep <- f eff
         pure $ transformStep nextStep

--- a/packages/vira/src/Vira/App/Stack.hs
+++ b/packages/vira/src/Vira/App/Stack.hs
@@ -42,13 +42,9 @@ runApp cfg =
     . runReader cfg
 
 -- | Like `runApp`, but for Servant 'Handler'.
-runAppInServant :: AppState -> Eff (Error ServerError : AppStack) a -> Handler a
+runAppInServant :: AppState -> Eff AppServantStack a -> Handler a
 runAppInServant cfg =
   Handler . ExceptT . runApp cfg . runErrorNoCallStack
-
-runAppInServant' :: AppState -> Eff AppStack a -> Handler a
-runAppInServant' cfg =
-  Handler . ExceptT . fmap Right . runApp cfg
 
 -- | Application-wide state available in Effectful stack
 data AppState = AppState

--- a/packages/vira/src/Vira/App/Stack.hs
+++ b/packages/vira/src/Vira/App/Stack.hs
@@ -63,7 +63,14 @@ data AppState = AppState
     linkTo :: LinkTo -> Link
   }
 
-runHtmlT :: HtmlT (Eff AppStack) () -> Eff AppStack (Html ())
-runHtmlT htmlT = do
+{- | Like `Html` but can do application effects
+
+Use `lift` to perform effects.
+-}
+type VHtml = HtmlT (Eff AppServantStack)
+
+-- | Convert a `VHtml` to a Lucid `Html`
+runVHtml :: VHtml () -> Eff AppServantStack (Html ())
+runVHtml htmlT = do
   (builder, _) <- Lucid.runHtmlT htmlT
   pure $ toHtmlRaw $ toLazyByteString builder

--- a/packages/vira/src/Vira/App/Stack.hs
+++ b/packages/vira/src/Vira/App/Stack.hs
@@ -46,6 +46,10 @@ runAppInServant :: AppState -> Eff (Error ServerError : AppStack) a -> Handler a
 runAppInServant cfg =
   Handler . ExceptT . runApp cfg . runErrorNoCallStack
 
+runAppInServant' :: AppState -> Eff AppStack a -> Handler a
+runAppInServant' cfg =
+  Handler . ExceptT . fmap Right . runApp cfg
+
 -- | Application-wide state available in Effectful stack
 data AppState = AppState
   { -- CLI args passed by the user

--- a/packages/vira/src/Vira/App/Stack.hs
+++ b/packages/vira/src/Vira/App/Stack.hs
@@ -3,6 +3,7 @@ module Vira.App.Stack where
 
 import Colog (Message)
 import Data.Acid (AcidState)
+import Data.Binary.Builder (toLazyByteString)
 import Effectful (Eff, IOE, runEff)
 import Effectful.Colog (Log)
 import Effectful.Concurrent.Async (Concurrent, runConcurrent)
@@ -10,6 +11,8 @@ import Effectful.Error.Static (Error, runErrorNoCallStack)
 import Effectful.FileSystem (FileSystem, runFileSystem)
 import Effectful.Process (Process, runProcess)
 import Effectful.Reader.Dynamic (Reader, runReader)
+import Lucid.Base (Html, HtmlT, ToHtml (toHtmlRaw))
+import Lucid.Base qualified as Lucid
 import Servant (Handler (Handler), ServerError)
 import Servant.Links (Link)
 import Vira.App.CLI (CLISettings)
@@ -59,3 +62,8 @@ data AppState = AppState
     -- This is decoupled from servant types deliberately to avoid cyclic imports.
     linkTo :: LinkTo -> Link
   }
+
+runHtmlT :: HtmlT (Eff AppStack) () -> Eff AppStack (Html ())
+runHtmlT htmlT = do
+  (builder, _) <- Lucid.runHtmlT htmlT
+  pure $ toHtmlRaw $ toLazyByteString builder

--- a/packages/vira/src/Vira/App/Stack.hs
+++ b/packages/vira/src/Vira/App/Stack.hs
@@ -67,13 +67,19 @@ data AppState = AppState
 
 Use `lift` to perform effects.
 -}
-type VHtml = HtmlT (Eff AppServantStack)
+type VHtml = HtmlT (Eff AppStack)
 
 -- | Convert a `VHtml` to a Lucid `Html`
-runVHtml :: VHtml () -> Eff AppServantStack (Html ())
+runVHtml :: VHtml () -> Eff AppStack (Html ())
 runVHtml htmlT = do
   (builder, _) <- Lucid.runHtmlT htmlT
   pure $ toHtmlRaw $ toLazyByteString builder
+
+-- | Convert VHtml to Html in the Servant effect stack
+runVHtmlInServant :: VHtml () -> Eff AppServantStack (Html ())
+runVHtmlInServant vhtml = do
+  cfg <- ask @AppState
+  liftIO $ runApp cfg $ runVHtml vhtml
 
 hoistVHtml :: Html () -> VHtml ()
 hoistVHtml = Lucid.hoistHtmlT (pure . runIdentity)

--- a/packages/vira/src/Vira/App/Stack.hs
+++ b/packages/vira/src/Vira/App/Stack.hs
@@ -14,7 +14,7 @@ import Effectful.Reader.Dynamic (Reader, ask, runReader)
 import Lucid.Base (Html, HtmlT, ToHtml (toHtmlRaw))
 import Lucid.Base qualified as Lucid
 import Servant (Handler (Handler), ServerError)
-import Servant.Links (Link, linkURI)
+import Servant.Links (Link, URI, linkURI)
 import Vira.App.CLI (CLISettings)
 import Vira.App.LinkTo.Type (LinkTo)
 import Vira.Lib.Logging (runLogActionStdout)
@@ -78,9 +78,20 @@ runVHtml htmlT = do
 hoistVHtml :: Html () -> VHtml ()
 hoistVHtml = Lucid.hoistHtmlT (pure . runIdentity)
 
--- | Helper to get a URL string for a LinkTo
+-- | Helper to get a Link for a LinkTo (for hxPostSafe_ and similar)
+linkToLink :: LinkTo -> VHtml Link
+linkToLink linkToValue = do
+  cfg <- lift $ ask @AppState
+  pure $ linkTo cfg linkToValue
+
+-- | Helper to get a URI for a LinkTo
+linkToUri :: LinkTo -> VHtml URI
+linkToUri linkToValue = do
+  link <- linkToLink linkToValue
+  pure $ linkURI link
+
+-- | Helper to get a URL string for a LinkTo (for href attributes)
 linkToUrl :: LinkTo -> VHtml Text
 linkToUrl linkToValue = do
-  cfg <- lift $ ask @AppState
-  let link = linkTo cfg linkToValue
-  pure $ toText $ show @String $ linkURI link
+  uri <- linkToUri linkToValue
+  pure $ toText $ show @String $ uri

--- a/packages/vira/src/Vira/App/VHtml.hs
+++ b/packages/vira/src/Vira/App/VHtml.hs
@@ -7,7 +7,7 @@ import Effectful.Reader.Dynamic (ask, asks)
 import Effectful.Reader.Dynamic qualified as Reader
 import Lucid.Base (Html, HtmlT, ToHtml (toHtmlRaw))
 import Lucid.Base qualified as Lucid
-import Servant.Links (Link, URI, linkURI)
+import Servant.Links (Link, linkURI)
 import Vira.App.LinkTo.Type (LinkTo)
 import Vira.App.Stack (AppServantStack, AppStack, AppState (linkTo), runApp)
 import Prelude hiding (ask, asks)
@@ -30,20 +30,14 @@ runVHtmlInServant vhtml = do
   cfg <- ask @AppState
   liftIO $ runApp cfg $ runVHtml vhtml
 
--- | Helper to get a Link for a LinkTo (for hxPostSafe_ and similar)
-linkToLink :: (Reader.Reader AppState :> es) => LinkTo -> Eff es Link
-linkToLink linkToValue = do
+-- | Get a `Link` to a part of the application
+getLink :: (Reader.Reader AppState :> es) => LinkTo -> Eff es Link
+getLink linkToValue = do
   linkToFn <- asks @AppState linkTo
   pure $ linkToFn linkToValue
 
--- | Helper to get a URI for a LinkTo
-linkToUri :: (Reader.Reader AppState :> es) => LinkTo -> Eff es URI
-linkToUri linkToValue = do
-  link <- linkToLink linkToValue
-  pure $ linkURI link
-
--- | Helper to get a URL string for a LinkTo (for href attributes)
-linkToUrl :: (Reader.Reader AppState :> es) => LinkTo -> Eff es Text
-linkToUrl linkToValue = do
-  uri <- linkToUri linkToValue
-  pure $ toText $ show @String $ uri
+-- | Link `getLink` but as URL text.
+getLinkUrl :: (Reader.Reader AppState :> es) => LinkTo -> Eff es Text
+getLinkUrl linkToValue = do
+  uri <- linkURI <$> getLink linkToValue
+  pure $ show @Text $ uri

--- a/packages/vira/src/Vira/App/VHtml.hs
+++ b/packages/vira/src/Vira/App/VHtml.hs
@@ -30,9 +30,6 @@ runVHtmlInServant vhtml = do
   cfg <- ask @AppState
   liftIO $ runApp cfg $ runVHtml vhtml
 
-hoistVHtml :: Html () -> VHtml ()
-hoistVHtml = Lucid.hoistHtmlT (pure . runIdentity)
-
 -- | Helper to get a Link for a LinkTo (for hxPostSafe_ and similar)
 linkToLink :: (Reader.Reader AppState :> es) => LinkTo -> Eff es Link
 linkToLink linkToValue = do

--- a/packages/vira/src/Vira/App/VHtml.hs
+++ b/packages/vira/src/Vira/App/VHtml.hs
@@ -1,0 +1,51 @@
+-- | VHtml types and utilities for Lucid HTML with effectful capabilities
+module Vira.App.VHtml where
+
+import Data.Binary.Builder (toLazyByteString)
+import Effectful (Eff)
+import Effectful.Reader.Dynamic (ask)
+import Lucid.Base (Html, HtmlT, ToHtml (toHtmlRaw))
+import Lucid.Base qualified as Lucid
+import Servant.Links (Link, URI, linkURI)
+import Vira.App.LinkTo.Type (LinkTo)
+import Vira.App.Stack (AppServantStack, AppStack, AppState (linkTo), runApp)
+import Prelude hiding (ask)
+
+{- | Like `Html` but can do application effects
+
+Use `lift` to perform effects.
+-}
+type VHtml = HtmlT (Eff AppStack)
+
+-- | Convert a `VHtml` to a Lucid `Html`
+runVHtml :: VHtml () -> Eff AppStack (Html ())
+runVHtml htmlT = do
+  (builder, _) <- Lucid.runHtmlT htmlT
+  pure $ toHtmlRaw $ toLazyByteString builder
+
+-- | Convert VHtml to Html in the Servant effect stack
+runVHtmlInServant :: VHtml () -> Eff AppServantStack (Html ())
+runVHtmlInServant vhtml = do
+  cfg <- ask @AppState
+  liftIO $ runApp cfg $ runVHtml vhtml
+
+hoistVHtml :: Html () -> VHtml ()
+hoistVHtml = Lucid.hoistHtmlT (pure . runIdentity)
+
+-- | Helper to get a Link for a LinkTo (for hxPostSafe_ and similar)
+linkToLink :: LinkTo -> VHtml Link
+linkToLink linkToValue = do
+  cfg <- lift $ ask @AppState
+  pure $ linkTo cfg linkToValue
+
+-- | Helper to get a URI for a LinkTo
+linkToUri :: LinkTo -> VHtml URI
+linkToUri linkToValue = do
+  link <- linkToLink linkToValue
+  pure $ linkURI link
+
+-- | Helper to get a URL string for a LinkTo (for href attributes)
+linkToUrl :: LinkTo -> VHtml Text
+linkToUrl linkToValue = do
+  uri <- linkToUri linkToValue
+  pure $ toText $ show @String $ uri

--- a/packages/vira/src/Vira/App/VHtml.hs
+++ b/packages/vira/src/Vira/App/VHtml.hs
@@ -7,7 +7,10 @@ import Effectful.Reader.Dynamic (ask, asks)
 import Effectful.Reader.Dynamic qualified as Reader
 import Lucid.Base (Html, HtmlT, ToHtml (toHtmlRaw))
 import Lucid.Base qualified as Lucid
+import Servant.API.Stream (SourceIO)
 import Servant.Links (Link, linkURI)
+import Servant.Types.SourceT (SourceT)
+import Servant.Types.SourceT qualified as S
 import Vira.App.LinkTo.Type (LinkTo)
 import Vira.App.Stack (AppServantStack, AppStack, AppState (linkTo), runApp)
 import Prelude hiding (ask, asks)
@@ -18,19 +21,22 @@ Use `lift` to perform effects.
 -}
 type VHtml = HtmlT (Eff AppStack)
 
+{- | Like `SourceIO` but can do application effects
+
+Use `lift` to perform effects.
+-}
+type VSource a = SourceT (Eff AppStack) a
+
 -- | Convert VHtml to Html in the Servant effect stack
 runVHtml :: VHtml () -> Eff AppServantStack (Html ())
 runVHtml vhtml = do
   cfg <- ask @AppState
-  liftIO $ runVHtmlIO cfg vhtml
+  liftIO $ runApp cfg $ runVHtml' vhtml
 
-runVHtmlIO :: AppState -> VHtml () -> IO (Html ())
-runVHtmlIO cfg = runApp cfg . runVHtml'
-  where
-    runVHtml' :: VHtml () -> Eff AppStack (Html ())
-    runVHtml' htmlT = do
-      (builder, _) <- Lucid.runHtmlT htmlT
-      pure $ toHtmlRaw $ toLazyByteString builder
+runVHtml' :: VHtml () -> Eff AppStack (Html ())
+runVHtml' htmlT = do
+  (builder, _) <- Lucid.runHtmlT htmlT
+  pure $ toHtmlRaw $ toLazyByteString builder
 
 -- | Get a `Link` to a part of the application
 getLink :: (Reader.Reader AppState :> es) => LinkTo -> Eff es Link
@@ -43,3 +49,19 @@ getLinkUrl :: (Reader.Reader AppState :> es) => LinkTo -> Eff es Text
 getLinkUrl linkToValue = do
   uri <- linkURI <$> getLink linkToValue
   pure $ show @Text $ uri
+
+-- | Convert VSource to SourceIO by running effects in IO
+runVSourceIO :: AppState -> VSource a -> SourceIO a
+runVSourceIO cfg vsource = S.fromStepT go
+  where
+    go = S.Effect $ do
+      step <- runApp cfg $ S.unSourceT vsource pure
+      pure $ transformStep step
+    transformStep = \case
+      S.Stop -> S.Stop
+      S.Error e -> S.Error e
+      S.Skip next -> S.Skip (transformStep next)
+      S.Yield a next -> S.Yield a (transformStep next)
+      S.Effect eff -> S.Effect $ do
+        nextStep <- runApp cfg eff
+        pure $ transformStep nextStep

--- a/packages/vira/src/Vira/Page/IndexPage.hs
+++ b/packages/vira/src/Vira/Page/IndexPage.hs
@@ -10,7 +10,7 @@ import Servant.Links (fieldLink, linkURI)
 import Servant.Server.Generic (AsServer)
 import Vira.App ((//))
 import Vira.App qualified as App
-import Vira.App.VHtml (runVSourceIO)
+import Vira.App.Servant (runVSourceIO)
 import Vira.Page.JobPage qualified as JobPage
 import Vira.Page.RegistryPage qualified as RegistryPage
 import Vira.Page.SettingsPage qualified as SettingsPage

--- a/packages/vira/src/Vira/Page/IndexPage.hs
+++ b/packages/vira/src/Vira/Page/IndexPage.hs
@@ -32,7 +32,7 @@ handlers :: App.AppState -> Routes AsServer
 handlers cfg =
   Routes
     { _home = App.runAppInServant cfg $ do
-        App.runVHtml $
+        App.runVHtmlInServant $
           W.layout cfg [] $
             heroWelcome menu
     , _repos = RegistryPage.handlers cfg

--- a/packages/vira/src/Vira/Page/IndexPage.hs
+++ b/packages/vira/src/Vira/Page/IndexPage.hs
@@ -34,7 +34,7 @@ handlers cfg =
     { _home =
         App.runAppInServant cfg $
           App.runVHtmlInServant $
-            W.layout cfg [] $
+            W.layout mempty $
               heroWelcome menu
     , _repos = RegistryPage.handlers cfg
     , _jobs = JobPage.handlers cfg

--- a/packages/vira/src/Vira/Page/IndexPage.hs
+++ b/packages/vira/src/Vira/Page/IndexPage.hs
@@ -10,7 +10,8 @@ import Servant.Links (fieldLink, linkURI)
 import Servant.Server.Generic (AsServer)
 import Vira.App ((//))
 import Vira.App qualified as App
-import Vira.App.Servant (runVSourceIO)
+import Vira.App.Servant (mapSourceT)
+import Vira.App.Stack (runApp)
 import Vira.Page.JobPage qualified as JobPage
 import Vira.Page.RegistryPage qualified as RegistryPage
 import Vira.Page.SettingsPage qualified as SettingsPage
@@ -40,7 +41,7 @@ handlers cfg =
     , _repos = RegistryPage.handlers cfg
     , _jobs = JobPage.handlers cfg
     , _settings = SettingsPage.handlers cfg
-    , _status = pure $ recommendedEventSourceHeaders $ runVSourceIO cfg Status.streamRouteHandler
+    , _status = pure $ recommendedEventSourceHeaders $ mapSourceT (runApp cfg) Status.streamRouteHandler
     }
   where
     linkText = show . linkURI

--- a/packages/vira/src/Vira/Page/IndexPage.hs
+++ b/packages/vira/src/Vira/Page/IndexPage.hs
@@ -10,6 +10,7 @@ import Servant.Links (fieldLink, linkURI)
 import Servant.Server.Generic (AsServer)
 import Vira.App ((//))
 import Vira.App qualified as App
+import Vira.App.VHtml (runVSourceIO)
 import Vira.Page.JobPage qualified as JobPage
 import Vira.Page.RegistryPage qualified as RegistryPage
 import Vira.Page.SettingsPage qualified as SettingsPage
@@ -39,7 +40,7 @@ handlers cfg =
     , _repos = RegistryPage.handlers cfg
     , _jobs = JobPage.handlers cfg
     , _settings = SettingsPage.handlers cfg
-    , _status = pure $ recommendedEventSourceHeaders $ Status.streamRouteHandler cfg
+    , _status = pure $ recommendedEventSourceHeaders $ runVSourceIO cfg Status.streamRouteHandler
     }
   where
     linkText = show . linkURI

--- a/packages/vira/src/Vira/Page/IndexPage.hs
+++ b/packages/vira/src/Vira/Page/IndexPage.hs
@@ -31,10 +31,11 @@ data Routes mode = Routes
 handlers :: App.AppState -> Routes AsServer
 handlers cfg =
   Routes
-    { _home = App.runAppInServant cfg $ do
-        App.runVHtmlInServant $
-          W.layout cfg [] $
-            heroWelcome menu
+    { _home =
+        App.runAppInServant cfg $
+          App.runVHtmlInServant $
+            W.layout cfg [] $
+              heroWelcome menu
     , _repos = RegistryPage.handlers cfg
     , _jobs = JobPage.handlers cfg
     , _settings = SettingsPage.handlers cfg

--- a/packages/vira/src/Vira/Page/IndexPage.hs
+++ b/packages/vira/src/Vira/Page/IndexPage.hs
@@ -9,7 +9,7 @@ import Servant.Links (fieldLink, linkURI)
 import Servant.Server.Generic (AsServer)
 import Vira.App ((//))
 import Vira.App qualified as App
-import Vira.App.Lucid (runVHtml)
+import Vira.App.Lucid (runAppHtml)
 import Vira.App.Servant (HTML, mapSourceT)
 import Vira.Page.JobPage qualified as JobPage
 import Vira.Page.RegistryPage qualified as RegistryPage
@@ -34,7 +34,7 @@ handlers cfg =
   Routes
     { _home =
         App.runAppInServant cfg $
-          runVHtml $
+          runAppHtml $
             W.layout mempty $
               heroWelcome menu
     , _repos = RegistryPage.handlers cfg

--- a/packages/vira/src/Vira/Page/IndexPage.hs
+++ b/packages/vira/src/Vira/Page/IndexPage.hs
@@ -3,6 +3,7 @@ module Vira.Page.IndexPage where
 
 import Lucid
 import Servant.API (Get, NamedRoutes, (:>))
+import Servant.API.ContentTypes.Lucid (HTML)
 import Servant.API.EventStream (recommendedEventSourceHeaders)
 import Servant.API.Generic (GenericMode (type (:-)))
 import Servant.Links (fieldLink, linkURI)
@@ -10,7 +11,7 @@ import Servant.Server.Generic (AsServer)
 import Vira.App ((//))
 import Vira.App qualified as App
 import Vira.App.Lucid (runAppHtml)
-import Vira.App.Servant (HTML, mapSourceT)
+import Vira.App.Servant (mapSourceT)
 import Vira.Page.JobPage qualified as JobPage
 import Vira.Page.RegistryPage qualified as RegistryPage
 import Vira.Page.SettingsPage qualified as SettingsPage

--- a/packages/vira/src/Vira/Page/IndexPage.hs
+++ b/packages/vira/src/Vira/Page/IndexPage.hs
@@ -9,9 +9,8 @@ import Servant.Links (fieldLink, linkURI)
 import Servant.Server.Generic (AsServer)
 import Vira.App ((//))
 import Vira.App qualified as App
-import Vira.App.Lucid (runVHtml')
+import Vira.App.Lucid (runVHtml)
 import Vira.App.Servant (HTML, mapSourceT)
-import Vira.App.Stack (runApp)
 import Vira.Page.JobPage qualified as JobPage
 import Vira.Page.RegistryPage qualified as RegistryPage
 import Vira.Page.SettingsPage qualified as SettingsPage
@@ -34,14 +33,14 @@ handlers :: App.AppState -> Routes AsServer
 handlers cfg =
   Routes
     { _home =
-        App.runAppInServant' cfg $
-          runVHtml' $
+        App.runAppInServant cfg $
+          runVHtml $
             W.layout mempty $
               heroWelcome menu
     , _repos = RegistryPage.handlers cfg
     , _jobs = JobPage.handlers cfg
     , _settings = SettingsPage.handlers cfg
-    , _status = pure $ recommendedEventSourceHeaders $ mapSourceT (runApp cfg) Status.streamRouteHandler
+    , _status = pure $ recommendedEventSourceHeaders $ mapSourceT (App.runApp cfg) Status.streamRouteHandler
     }
   where
     linkText = show . linkURI

--- a/packages/vira/src/Vira/Page/IndexPage.hs
+++ b/packages/vira/src/Vira/Page/IndexPage.hs
@@ -3,14 +3,14 @@ module Vira.Page.IndexPage where
 
 import Lucid
 import Servant.API (Get, NamedRoutes, (:>))
-import Servant.API.ContentTypes.Lucid (HTML)
 import Servant.API.EventStream (recommendedEventSourceHeaders)
 import Servant.API.Generic (GenericMode (type (:-)))
 import Servant.Links (fieldLink, linkURI)
 import Servant.Server.Generic (AsServer)
 import Vira.App ((//))
 import Vira.App qualified as App
-import Vira.App.Servant (mapSourceT)
+import Vira.App.Lucid (runVHtml')
+import Vira.App.Servant (HTML, mapSourceT)
 import Vira.App.Stack (runApp)
 import Vira.Page.JobPage qualified as JobPage
 import Vira.Page.RegistryPage qualified as RegistryPage
@@ -34,8 +34,8 @@ handlers :: App.AppState -> Routes AsServer
 handlers cfg =
   Routes
     { _home =
-        App.runAppInServant cfg $
-          App.runVHtml $
+        App.runAppInServant' cfg $
+          runVHtml' $
             W.layout mempty $
               heroWelcome menu
     , _repos = RegistryPage.handlers cfg

--- a/packages/vira/src/Vira/Page/IndexPage.hs
+++ b/packages/vira/src/Vira/Page/IndexPage.hs
@@ -13,7 +13,6 @@ import Vira.App qualified as App
 import Vira.Page.JobPage qualified as JobPage
 import Vira.Page.RegistryPage qualified as RegistryPage
 import Vira.Page.SettingsPage qualified as SettingsPage
-import Vira.State.Acid qualified as St
 import Vira.Stream.Status qualified as Status
 import Vira.Widgets.Card qualified as W
 import Vira.Widgets.Layout qualified as W
@@ -33,8 +32,9 @@ handlers :: App.AppState -> Routes AsServer
 handlers cfg =
   Routes
     { _home = App.runAppInServant cfg $ do
-        App.runVHtml $ W.layout cfg [] $ do
-          heroWelcome menu
+        App.runVHtml $
+          W.layout cfg [] $
+            heroWelcome menu
     , _repos = RegistryPage.handlers cfg
     , _jobs = JobPage.handlers cfg
     , _settings = SettingsPage.handlers cfg
@@ -48,9 +48,8 @@ handlers cfg =
       , ("Settings", linkText $ fieldLink _settings // SettingsPage._view)
       ]
 
-heroWelcome :: [(App.VHtml (), Text)] -> App.VHtml ()
+heroWelcome :: (Monad m) => [(HtmlT m (), Text)] -> HtmlT m ()
 heroWelcome menu = do
-  _repos <- lift $ App.query St.GetAllReposA
   div_ [class_ "bg-indigo-50 border-2 border-t-0 border-indigo-200 rounded-b-xl p-12 mb-8 text-center"] $ do
     h1_ [class_ "text-5xl font-bold text-indigo-900 tracking-tight mb-4"] $ do
       "Welcome to "

--- a/packages/vira/src/Vira/Page/IndexPage.hs
+++ b/packages/vira/src/Vira/Page/IndexPage.hs
@@ -33,19 +33,7 @@ handlers cfg =
   Routes
     { _home = App.runAppInServant cfg $ do
         pure $ W.layout cfg [] $ do
-          -- Hero welcome section that connects to breadcrumb
-          div_ [class_ "bg-indigo-50 border-2 border-t-0 border-indigo-200 rounded-b-xl p-12 mb-8 text-center"] $ do
-            h1_ [class_ "text-5xl font-bold text-indigo-900 tracking-tight mb-4"] $ do
-              "Welcome to "
-              a_ [href_ "http://github.com/juspay/vira", class_ "underline hover:no-underline", target_ "_blank"] "Vira"
-            p_ [class_ "text-xl text-indigo-700 mb-8"] $ do
-              "No-frills CI/CD for teams using "
-              a_ [href_ "https://nixos.asia/en/nix-first", class_ "underline hover:no-underline", target_ "blank"] "Nix"
-
-          -- Navigation cards
-          div_ [class_ "grid gap-6 md:grid-cols-2 lg:grid-cols-3"] $ do
-            forM_ menu $ \(name, url) -> do
-              W.viraNavigationCard_ url name
+          heroWelcome menu
     , _repos = RegistryPage.handlers cfg
     , _jobs = JobPage.handlers cfg
     , _settings = SettingsPage.handlers cfg
@@ -58,3 +46,18 @@ handlers cfg =
       [ ("Repositories", linkText $ fieldLink _repos // RegistryPage._listing)
       , ("Settings", linkText $ fieldLink _settings // SettingsPage._view)
       ]
+
+heroWelcome :: (Monad m) => [(HtmlT m (), Text)] -> HtmlT m ()
+heroWelcome menu = do
+  div_ [class_ "bg-indigo-50 border-2 border-t-0 border-indigo-200 rounded-b-xl p-12 mb-8 text-center"] $ do
+    h1_ [class_ "text-5xl font-bold text-indigo-900 tracking-tight mb-4"] $ do
+      "Welcome to "
+      a_ [href_ "http://github.com/juspay/vira", class_ "underline hover:no-underline", target_ "_blank"] "Vira"
+    p_ [class_ "text-xl text-indigo-700 mb-8"] $ do
+      "No-frills CI/CD for teams using "
+      a_ [href_ "https://nixos.asia/en/nix-first", class_ "underline hover:no-underline", target_ "blank"] "Nix"
+
+  -- Navigation cards
+  div_ [class_ "grid gap-6 md:grid-cols-2 lg:grid-cols-3"] $ do
+    forM_ menu $ \(name, url) -> do
+      W.viraNavigationCard_ url name

--- a/packages/vira/src/Vira/Page/IndexPage.hs
+++ b/packages/vira/src/Vira/Page/IndexPage.hs
@@ -33,7 +33,7 @@ handlers cfg =
   Routes
     { _home =
         App.runAppInServant cfg $
-          App.runVHtmlInServant $
+          App.runVHtml $
             W.layout mempty $
               heroWelcome menu
     , _repos = RegistryPage.handlers cfg

--- a/packages/vira/src/Vira/Page/IndexPage.hs
+++ b/packages/vira/src/Vira/Page/IndexPage.hs
@@ -13,6 +13,7 @@ import Vira.App qualified as App
 import Vira.Page.JobPage qualified as JobPage
 import Vira.Page.RegistryPage qualified as RegistryPage
 import Vira.Page.SettingsPage qualified as SettingsPage
+import Vira.State.Acid qualified as St
 import Vira.Stream.Status qualified as Status
 import Vira.Widgets.Card qualified as W
 import Vira.Widgets.Layout qualified as W
@@ -32,7 +33,7 @@ handlers :: App.AppState -> Routes AsServer
 handlers cfg =
   Routes
     { _home = App.runAppInServant cfg $ do
-        pure $ W.layout cfg [] $ do
+        App.runVHtml $ W.layout cfg [] $ do
           heroWelcome menu
     , _repos = RegistryPage.handlers cfg
     , _jobs = JobPage.handlers cfg
@@ -41,14 +42,15 @@ handlers cfg =
     }
   where
     linkText = show . linkURI
-    menu :: [(Html (), Text)]
+    menu :: (Monad m) => [(HtmlT m (), Text)]
     menu =
       [ ("Repositories", linkText $ fieldLink _repos // RegistryPage._listing)
       , ("Settings", linkText $ fieldLink _settings // SettingsPage._view)
       ]
 
-heroWelcome :: (Monad m) => [(HtmlT m (), Text)] -> HtmlT m ()
+heroWelcome :: [(App.VHtml (), Text)] -> App.VHtml ()
 heroWelcome menu = do
+  _repos <- lift $ App.query St.GetAllReposA
   div_ [class_ "bg-indigo-50 border-2 border-t-0 border-indigo-200 rounded-b-xl p-12 mb-8 text-center"] $ do
     h1_ [class_ "text-5xl font-bold text-indigo-900 tracking-tight mb-4"] $ do
       "Welcome to "

--- a/packages/vira/src/Vira/Page/JobLog.hs
+++ b/packages/vira/src/Vira/Page/JobLog.hs
@@ -10,7 +10,7 @@ import Servant.API.EventStream (recommendedEventSourceHeaders)
 import Servant.Server.Generic (AsServer)
 import System.FilePath ((</>))
 import Vira.App qualified as App
-import Vira.App.VHtml (VHtml)
+import Vira.App.VHtml (VHtml, runVSourceIO)
 import Vira.State.Acid qualified as St
 import Vira.State.Type (Job, JobId, jobWorkingDir)
 import Vira.State.Type qualified as St
@@ -29,7 +29,7 @@ handlers :: App.AppState -> JobId -> Routes AsServer
 handlers cfg jobId = do
   Routes
     { _rawLog = App.runAppInServant cfg $ rawLogHandler jobId
-    , _streamLog = pure $ recommendedEventSourceHeaders $ Log.streamRouteHandler cfg jobId
+    , _streamLog = pure $ recommendedEventSourceHeaders $ runVSourceIO cfg $ Log.streamRouteHandler jobId
     }
 
 rawLogHandler :: JobId -> Eff App.AppServantStack Text

--- a/packages/vira/src/Vira/Page/JobLog.hs
+++ b/packages/vira/src/Vira/Page/JobLog.hs
@@ -10,7 +10,7 @@ import Servant.API.EventStream (recommendedEventSourceHeaders)
 import Servant.Server.Generic (AsServer)
 import System.FilePath ((</>))
 import Vira.App qualified as App
-import Vira.App.Stack (VHtml)
+import Vira.App.VHtml (VHtml)
 import Vira.State.Acid qualified as St
 import Vira.State.Type (Job, JobId, jobWorkingDir)
 import Vira.State.Type qualified as St

--- a/packages/vira/src/Vira/Page/JobLog.hs
+++ b/packages/vira/src/Vira/Page/JobLog.hs
@@ -10,7 +10,8 @@ import Servant.API.EventStream (recommendedEventSourceHeaders)
 import Servant.Server.Generic (AsServer)
 import System.FilePath ((</>))
 import Vira.App qualified as App
-import Vira.App.VHtml (VHtml, runVSourceIO)
+import Vira.App.Lucid (VHtml)
+import Vira.App.Servant (runVSourceIO)
 import Vira.State.Acid qualified as St
 import Vira.State.Type (Job, JobId, jobWorkingDir)
 import Vira.State.Type qualified as St

--- a/packages/vira/src/Vira/Page/JobLog.hs
+++ b/packages/vira/src/Vira/Page/JobLog.hs
@@ -10,7 +10,7 @@ import Servant.API.EventStream (recommendedEventSourceHeaders)
 import Servant.Server.Generic (AsServer)
 import System.FilePath ((</>))
 import Vira.App qualified as App
-import Vira.App.LinkTo.Type (LinkTo)
+import Vira.App.Stack (VHtml)
 import Vira.State.Acid qualified as St
 import Vira.State.Type (Job, JobId, jobWorkingDir)
 import Vira.State.Type qualified as St
@@ -39,17 +39,17 @@ rawLogHandler jobId = do
     liftIO $ readFileBS $ job.jobWorkingDir </> "output.log"
   pure $ decodeUtf8 logText
 
-view :: (LinkTo -> Link) -> Job -> Eff App.AppServantStack (Html ())
-view linkTo job = do
+view :: Job -> VHtml ()
+view job = do
   let jobActive = job.jobStatus == St.JobRunning || job.jobStatus == St.JobPending
   if jobActive
-    then pure $ Log.viewStream linkTo job
-    else viewStaticLog linkTo job
+    then Log.viewStream job
+    else viewStaticLog job
 
-viewStaticLog :: (LinkTo -> Link) -> Job -> Eff App.AppServantStack (Html ())
-viewStaticLog linkTo job = do
+viewStaticLog :: Job -> VHtml ()
+viewStaticLog job = do
   logText <- readJobLogFull job
-  pure $ Log.logViewerWidget linkTo job $ do
+  Log.logViewerWidget job $ do
     toHtml logText
 
 readJobLogFull :: (MonadIO m) => Job -> m Text

--- a/packages/vira/src/Vira/Page/JobLog.hs
+++ b/packages/vira/src/Vira/Page/JobLog.hs
@@ -11,7 +11,8 @@ import Servant.Server.Generic (AsServer)
 import System.FilePath ((</>))
 import Vira.App qualified as App
 import Vira.App.Lucid (VHtml)
-import Vira.App.Servant (runVSourceIO)
+import Vira.App.Servant (mapSourceT)
+import Vira.App.Stack (runApp)
 import Vira.State.Acid qualified as St
 import Vira.State.Type (Job, JobId, jobWorkingDir)
 import Vira.State.Type qualified as St
@@ -30,7 +31,7 @@ handlers :: App.AppState -> JobId -> Routes AsServer
 handlers cfg jobId = do
   Routes
     { _rawLog = App.runAppInServant cfg $ rawLogHandler jobId
-    , _streamLog = pure $ recommendedEventSourceHeaders $ runVSourceIO cfg $ Log.streamRouteHandler jobId
+    , _streamLog = pure $ recommendedEventSourceHeaders $ mapSourceT (runApp cfg) $ Log.streamRouteHandler jobId
     }
 
 rawLogHandler :: JobId -> Eff App.AppServantStack Text

--- a/packages/vira/src/Vira/Page/JobLog.hs
+++ b/packages/vira/src/Vira/Page/JobLog.hs
@@ -10,7 +10,7 @@ import Servant.API.EventStream (recommendedEventSourceHeaders)
 import Servant.Server.Generic (AsServer)
 import System.FilePath ((</>))
 import Vira.App qualified as App
-import Vira.App.Lucid (VHtml)
+import Vira.App.Lucid (AppHtml)
 import Vira.App.Servant (mapSourceT)
 import Vira.App.Stack (runApp)
 import Vira.State.Acid qualified as St
@@ -41,14 +41,14 @@ rawLogHandler jobId = do
     liftIO $ readFileBS $ job.jobWorkingDir </> "output.log"
   pure $ decodeUtf8 logText
 
-view :: Job -> VHtml ()
+view :: Job -> AppHtml ()
 view job = do
   let jobActive = job.jobStatus == St.JobRunning || job.jobStatus == St.JobPending
   if jobActive
     then Log.viewStream job
     else viewStaticLog job
 
-viewStaticLog :: Job -> VHtml ()
+viewStaticLog :: Job -> AppHtml ()
 viewStaticLog job = do
   logText <- readJobLogFull job
   Log.logViewerWidget job $ do

--- a/packages/vira/src/Vira/Page/JobPage.hs
+++ b/packages/vira/src/Vira/Page/JobPage.hs
@@ -73,7 +73,7 @@ viewHandler jobId = do
         , LinkTo.RepoBranch job.jobRepo job.jobBranch
         , LinkTo.Job jobId
         ]
-  App.runVHtml $ W.layout crumbs $ viewJob job
+  App.runAppHtml $ W.layout crumbs $ viewJob job
 
 killHandler :: JobId -> Eff App.AppServantStack (Headers '[HXRefresh] Text)
 killHandler jobId = do
@@ -81,7 +81,7 @@ killHandler jobId = do
   Supervisor.killTask supervisor jobId
   pure $ addHeader True "Killed"
 
-viewJob :: St.Job -> App.VHtml ()
+viewJob :: St.Job -> App.AppHtml ()
 viewJob job = do
   let jobActive = job.jobStatus == St.JobRunning || job.jobStatus == St.JobPending
 
@@ -106,7 +106,7 @@ viewJob job = do
     W.viraCard_ [class_ "p-6"] $ do
       JobLog.view job
 
-viewJobHeader :: St.Job -> App.VHtml ()
+viewJobHeader :: St.Job -> App.AppHtml ()
 viewJobHeader job = do
   jobUrl <- lift $ App.getLinkUrl $ LinkTo.Job job.jobId
   a_ [title_ "View Job Details", href_ jobUrl, class_ "block"] $ do

--- a/packages/vira/src/Vira/Page/JobPage.hs
+++ b/packages/vira/src/Vira/Page/JobPage.hs
@@ -94,7 +94,7 @@ viewJob job = do
         div_ [class_ "flex items-center space-x-4"] $ do
           viewJobStatus job.jobStatus
           when jobActive $ do
-            killLink <- lift $ App.linkToLink $ LinkTo.Kill job.jobId
+            killLink <- lift $ App.getLink $ LinkTo.Kill job.jobId
             W.viraButton_
               W.ButtonDestructive
               [ hxPostSafe_ killLink
@@ -108,7 +108,7 @@ viewJob job = do
 
 viewJobHeader :: St.Job -> App.VHtml ()
 viewJobHeader job = do
-  jobUrl <- lift $ App.linkToUrl $ LinkTo.Job job.jobId
+  jobUrl <- lift $ App.getLinkUrl $ LinkTo.Job job.jobId
   a_ [title_ "View Job Details", href_ jobUrl, class_ "block"] $ do
     div_ [class_ "flex items-center justify-between"] $ do
       div_ [class_ "flex items-center space-x-4"] $ do

--- a/packages/vira/src/Vira/Page/JobPage.hs
+++ b/packages/vira/src/Vira/Page/JobPage.hs
@@ -19,7 +19,7 @@ import Servant.API.ContentTypes.Lucid (HTML)
 import Servant.Server.Generic (AsServer)
 import Vira.App qualified as App
 import Vira.App.LinkTo.Type qualified as LinkTo
-import Vira.App.Stack (VHtml, linkToLink, linkToUrl, runVHtml)
+import Vira.App.Stack (VHtml, linkToLink, linkToUrl, runVHtmlInServant)
 import Vira.Lib.Attic
 import Vira.Lib.Cachix
 import Vira.Lib.Git (BranchName)
@@ -75,7 +75,7 @@ viewHandler jobId = do
         , LinkTo.Job jobId
         ]
   cfg <- ask
-  runVHtml $ W.layout cfg crumbs $ viewJob job
+  runVHtmlInServant $ W.layout cfg crumbs $ viewJob job
 
 killHandler :: JobId -> Eff App.AppServantStack (Headers '[HXRefresh] Text)
 killHandler jobId = do

--- a/packages/vira/src/Vira/Page/JobPage.hs
+++ b/packages/vira/src/Vira/Page/JobPage.hs
@@ -15,10 +15,10 @@ import Htmx.Swap (Swap (AfterEnd))
 import Lucid
 import Lucid.Htmx.Contrib (hxPostSafe_)
 import Servant hiding (throwError)
+import Servant.API.ContentTypes.Lucid (HTML)
 import Servant.Server.Generic (AsServer)
 import Vira.App qualified as App
 import Vira.App.LinkTo.Type qualified as LinkTo
-import Vira.App.Servant (HTML)
 import Vira.Lib.Attic
 import Vira.Lib.Cachix
 import Vira.Lib.Git (BranchName)

--- a/packages/vira/src/Vira/Page/JobPage.hs
+++ b/packages/vira/src/Vira/Page/JobPage.hs
@@ -19,7 +19,6 @@ import Servant.API.ContentTypes.Lucid (HTML)
 import Servant.Server.Generic (AsServer)
 import Vira.App qualified as App
 import Vira.App.LinkTo.Type qualified as LinkTo
-import Vira.App.Stack (VHtml, linkToLink, linkToUrl, runVHtmlInServant)
 import Vira.Lib.Attic
 import Vira.Lib.Cachix
 import Vira.Lib.Git (BranchName)
@@ -75,7 +74,7 @@ viewHandler jobId = do
         , LinkTo.Job jobId
         ]
   cfg <- ask
-  runVHtmlInServant $ W.layout cfg crumbs $ viewJob job
+  App.runVHtmlInServant $ W.layout cfg crumbs $ viewJob job
 
 killHandler :: JobId -> Eff App.AppServantStack (Headers '[HXRefresh] Text)
 killHandler jobId = do
@@ -83,7 +82,7 @@ killHandler jobId = do
   Supervisor.killTask supervisor jobId
   pure $ addHeader True "Killed"
 
-viewJob :: St.Job -> VHtml ()
+viewJob :: St.Job -> App.VHtml ()
 viewJob job = do
   let jobActive = job.jobStatus == St.JobRunning || job.jobStatus == St.JobPending
 
@@ -96,7 +95,7 @@ viewJob job = do
         div_ [class_ "flex items-center space-x-4"] $ do
           viewJobStatus job.jobStatus
           when jobActive $ do
-            killLink <- linkToLink $ LinkTo.Kill job.jobId
+            killLink <- App.linkToLink $ LinkTo.Kill job.jobId
             W.viraButton_
               W.ButtonDestructive
               [ hxPostSafe_ killLink
@@ -108,9 +107,9 @@ viewJob job = do
     W.viraCard_ [class_ "p-6"] $ do
       JobLog.view job
 
-viewJobHeader :: St.Job -> VHtml ()
+viewJobHeader :: St.Job -> App.VHtml ()
 viewJobHeader job = do
-  jobUrl <- linkToUrl $ LinkTo.Job job.jobId
+  jobUrl <- App.linkToUrl $ LinkTo.Job job.jobId
   a_ [title_ "View Job Details", href_ jobUrl, class_ "block"] $ do
     div_ [class_ "flex items-center justify-between"] $ do
       div_ [class_ "flex items-center space-x-4"] $ do

--- a/packages/vira/src/Vira/Page/JobPage.hs
+++ b/packages/vira/src/Vira/Page/JobPage.hs
@@ -7,7 +7,7 @@ import Data.Text qualified as T
 import Effectful (Eff)
 import Effectful.Error.Static (throwError)
 import Effectful.Process (CreateProcess (cwd), env, proc)
-import Effectful.Reader.Dynamic (ask, asks)
+import Effectful.Reader.Dynamic (asks)
 import GHC.IO.Exception (ExitCode (..))
 import Htmx.Lucid.Core (hxSwapS_)
 import Htmx.Servant.Response
@@ -73,8 +73,7 @@ viewHandler jobId = do
         , LinkTo.RepoBranch job.jobRepo job.jobBranch
         , LinkTo.Job jobId
         ]
-  cfg <- ask
-  App.runVHtmlInServant $ W.layout cfg crumbs $ viewJob job
+  App.runVHtmlInServant $ W.layout crumbs $ viewJob job
 
 killHandler :: JobId -> Eff App.AppServantStack (Headers '[HXRefresh] Text)
 killHandler jobId = do
@@ -95,7 +94,7 @@ viewJob job = do
         div_ [class_ "flex items-center space-x-4"] $ do
           viewJobStatus job.jobStatus
           when jobActive $ do
-            killLink <- App.linkToLink $ LinkTo.Kill job.jobId
+            killLink <- lift $ App.linkToLink $ LinkTo.Kill job.jobId
             W.viraButton_
               W.ButtonDestructive
               [ hxPostSafe_ killLink
@@ -109,7 +108,7 @@ viewJob job = do
 
 viewJobHeader :: St.Job -> App.VHtml ()
 viewJobHeader job = do
-  jobUrl <- App.linkToUrl $ LinkTo.Job job.jobId
+  jobUrl <- lift $ App.linkToUrl $ LinkTo.Job job.jobId
   a_ [title_ "View Job Details", href_ jobUrl, class_ "block"] $ do
     div_ [class_ "flex items-center justify-between"] $ do
       div_ [class_ "flex items-center space-x-4"] $ do

--- a/packages/vira/src/Vira/Page/JobPage.hs
+++ b/packages/vira/src/Vira/Page/JobPage.hs
@@ -73,7 +73,7 @@ viewHandler jobId = do
         , LinkTo.RepoBranch job.jobRepo job.jobBranch
         , LinkTo.Job jobId
         ]
-  App.runVHtmlInServant $ W.layout crumbs $ viewJob job
+  App.runVHtml $ W.layout crumbs $ viewJob job
 
 killHandler :: JobId -> Eff App.AppServantStack (Headers '[HXRefresh] Text)
 killHandler jobId = do

--- a/packages/vira/src/Vira/Page/JobPage.hs
+++ b/packages/vira/src/Vira/Page/JobPage.hs
@@ -15,10 +15,10 @@ import Htmx.Swap (Swap (AfterEnd))
 import Lucid
 import Lucid.Htmx.Contrib (hxPostSafe_)
 import Servant hiding (throwError)
-import Servant.API.ContentTypes.Lucid (HTML)
 import Servant.Server.Generic (AsServer)
 import Vira.App qualified as App
 import Vira.App.LinkTo.Type qualified as LinkTo
+import Vira.App.Servant (HTML)
 import Vira.Lib.Attic
 import Vira.Lib.Cachix
 import Vira.Lib.Git (BranchName)

--- a/packages/vira/src/Vira/Page/RegistryPage.hs
+++ b/packages/vira/src/Vira/Page/RegistryPage.hs
@@ -70,7 +70,7 @@ handleAddRepo repo = do
       App.update $ St.AddNewRepoA repo
       log Info $ "Added repository " <> toText repo.name
       -- Redirect to the newly created repository page
-      newRepoUrl <- App.linkToUrl $ LinkTo.Repo repo.name
+      newRepoUrl <- App.getLinkUrl $ LinkTo.Repo repo.name
       pure $ addHeader newRepoUrl "Ok"
 
 viewRepoList :: App.VHtml ()
@@ -92,7 +92,7 @@ viewRepoList = do
         -- Repository grid
         div_ [class_ "grid gap-6 mb-8 md:grid-cols-2 lg:grid-cols-3"] $ do
           forM_ registry $ \repo -> do
-            url <- lift $ App.linkToUrl $ LinkTo.Repo repo.name
+            url <- lift $ App.getLinkUrl $ LinkTo.Repo repo.name
             W.viraNavigationCard_
               url
               (toHtml $ toString repo.name)
@@ -106,7 +106,7 @@ viewRepoList = do
 
 newRepoForm :: App.VHtml ()
 newRepoForm = do
-  repoAddLink <- lift $ App.linkToLink LinkTo.RepoAdd
+  repoAddLink <- lift $ App.getLink LinkTo.RepoAdd
   form_ [hxPostSafe_ repoAddLink, hxSwapS_ InnerHTML, class_ "space-y-6"] $ do
     div_ [class_ "grid grid-cols-1 lg:grid-cols-2 gap-6"] $ do
       W.viraFormGroup_

--- a/packages/vira/src/Vira/Page/RegistryPage.hs
+++ b/packages/vira/src/Vira/Page/RegistryPage.hs
@@ -13,10 +13,10 @@ import Htmx.Swap (Swap (InnerHTML))
 import Lucid
 import Lucid.Htmx.Contrib (hxPostSafe_)
 import Servant hiding (throwError)
+import Servant.API.ContentTypes.Lucid (HTML)
 import Servant.Server.Generic (AsServer)
 import Vira.App qualified as App
 import Vira.App.LinkTo.Type qualified as LinkTo
-import Vira.App.Servant (HTML)
 import Vira.Lib.Logging
 import Vira.Page.RepoPage qualified as RepoPage
 import Vira.State.Acid qualified as St

--- a/packages/vira/src/Vira/Page/RegistryPage.hs
+++ b/packages/vira/src/Vira/Page/RegistryPage.hs
@@ -54,8 +54,7 @@ handleListing = do
   cfg <- ask
   samples <- App.query St.GetAllReposA
   let crumbs = [LinkTo.RepoListing]
-  pure $ W.layout cfg crumbs $ do
-    viewRepoList cfg.linkTo samples
+  App.runVHtml $ W.layout cfg crumbs $ viewRepoList cfg.linkTo samples
 
 addRepoHandler :: Repo -> Eff App.AppServantStack FormResp
 addRepoHandler repo = do

--- a/packages/vira/src/Vira/Page/RegistryPage.hs
+++ b/packages/vira/src/Vira/Page/RegistryPage.hs
@@ -18,7 +18,7 @@ import Servant.API.ContentTypes.Lucid (HTML)
 import Servant.Server.Generic (AsServer)
 import Vira.App qualified as App
 import Vira.App.LinkTo.Type qualified as LinkTo
-import Vira.App.Stack (VHtml, linkToLink, linkToUrl)
+import Vira.App.Stack (VHtml, linkToLink, linkToUrl, runVHtmlInServant)
 import Vira.Lib.Logging
 import Vira.Page.RepoPage qualified as RepoPage
 import Vira.State.Acid qualified as St
@@ -55,7 +55,7 @@ handleListing = do
   cfg <- ask
   samples <- App.query St.GetAllReposA
   let crumbs = [LinkTo.RepoListing]
-  App.runVHtml $ W.layout cfg crumbs $ viewRepoList samples
+  runVHtmlInServant $ W.layout cfg crumbs $ viewRepoList samples
 
 addRepoHandler :: Repo -> Eff App.AppServantStack FormResp
 addRepoHandler repo = do
@@ -64,7 +64,7 @@ addRepoHandler repo = do
     Just _repo -> do
       log Debug $ "Repository exists " <> toText repo.name
       -- Show error message instead of redirecting
-      errorHtml <- App.runVHtml $ do
+      errorHtml <- runVHtmlInServant $ do
         newRepoForm
         W.viraAlert_ W.AlertError $ do
           p_ [class_ "text-red-800 font-medium"] $ do

--- a/packages/vira/src/Vira/Page/RegistryPage.hs
+++ b/packages/vira/src/Vira/Page/RegistryPage.hs
@@ -15,6 +15,7 @@ import Lucid.Htmx.Contrib (hxPostSafe_)
 import Servant hiding (throwError)
 import Servant.API.ContentTypes.Lucid (HTML)
 import Servant.Server.Generic (AsServer)
+import Vira.App (AppHtml)
 import Vira.App qualified as App
 import Vira.App.LinkTo.Type qualified as LinkTo
 import Vira.Lib.Logging
@@ -42,15 +43,15 @@ data Routes mode = Routes
 handlers :: App.AppState -> Routes AsServer
 handlers cfg = do
   Routes
-    { _listing = App.runAppInServant cfg handleListing
+    { _listing = App.runAppInServant cfg $ App.runAppHtml handleListing
     , _repo = RepoPage.handlers cfg
     , _addRepo = App.runAppInServant cfg . handleAddRepo
     }
 
-handleListing :: Eff App.AppServantStack (Html ())
+handleListing :: AppHtml ()
 handleListing = do
   let crumbs = [LinkTo.RepoListing]
-  App.runAppHtml $ W.layout crumbs viewRepoList
+  W.layout crumbs viewRepoList
 
 handleAddRepo :: Repo -> Eff App.AppServantStack FormResp
 handleAddRepo repo = do

--- a/packages/vira/src/Vira/Page/RegistryPage.hs
+++ b/packages/vira/src/Vira/Page/RegistryPage.hs
@@ -13,10 +13,10 @@ import Htmx.Swap (Swap (InnerHTML))
 import Lucid
 import Lucid.Htmx.Contrib (hxPostSafe_)
 import Servant hiding (throwError)
-import Servant.API.ContentTypes.Lucid (HTML)
 import Servant.Server.Generic (AsServer)
 import Vira.App qualified as App
 import Vira.App.LinkTo.Type qualified as LinkTo
+import Vira.App.Servant (HTML)
 import Vira.Lib.Logging
 import Vira.Page.RepoPage qualified as RepoPage
 import Vira.State.Acid qualified as St

--- a/packages/vira/src/Vira/Page/RegistryPage.hs
+++ b/packages/vira/src/Vira/Page/RegistryPage.hs
@@ -50,7 +50,7 @@ handlers cfg = do
 handleListing :: Eff App.AppServantStack (Html ())
 handleListing = do
   let crumbs = [LinkTo.RepoListing]
-  App.runVHtmlInServant $ W.layout crumbs viewRepoList
+  App.runVHtml $ W.layout crumbs viewRepoList
 
 handleAddRepo :: Repo -> Eff App.AppServantStack FormResp
 handleAddRepo repo = do
@@ -58,7 +58,7 @@ handleAddRepo repo = do
     Just _repo -> do
       log Debug $ "Repository exists " <> toText repo.name
       -- Show error message instead of redirecting
-      errorHtml <- App.runVHtmlInServant $ do
+      errorHtml <- App.runVHtml $ do
         newRepoForm
         W.viraAlert_ W.AlertError $ do
           p_ [class_ "text-red-800 font-medium"] $ do

--- a/packages/vira/src/Vira/Page/RegistryPage.hs
+++ b/packages/vira/src/Vira/Page/RegistryPage.hs
@@ -50,7 +50,7 @@ handlers cfg = do
 handleListing :: Eff App.AppServantStack (Html ())
 handleListing = do
   let crumbs = [LinkTo.RepoListing]
-  App.runVHtml $ W.layout crumbs viewRepoList
+  App.runAppHtml $ W.layout crumbs viewRepoList
 
 handleAddRepo :: Repo -> Eff App.AppServantStack FormResp
 handleAddRepo repo = do
@@ -58,7 +58,7 @@ handleAddRepo repo = do
     Just _repo -> do
       log Debug $ "Repository exists " <> toText repo.name
       -- Show error message instead of redirecting
-      errorHtml <- App.runVHtml $ do
+      errorHtml <- App.runAppHtml $ do
         newRepoForm
         W.viraAlert_ W.AlertError $ do
           p_ [class_ "text-red-800 font-medium"] $ do
@@ -73,7 +73,7 @@ handleAddRepo repo = do
       newRepoUrl <- App.getLinkUrl $ LinkTo.Repo repo.name
       pure $ addHeader newRepoUrl "Ok"
 
-viewRepoList :: App.VHtml ()
+viewRepoList :: App.AppHtml ()
 viewRepoList = do
   registry <- lift $ App.query St.GetAllReposA
   W.viraSection_ [] $ do
@@ -104,7 +104,7 @@ viewRepoList = do
             "Add New Repository"
           newRepoForm
 
-newRepoForm :: App.VHtml ()
+newRepoForm :: App.AppHtml ()
 newRepoForm = do
   repoAddLink <- lift $ App.getLink LinkTo.RepoAdd
   form_ [hxPostSafe_ repoAddLink, hxSwapS_ InnerHTML, class_ "space-y-6"] $ do

--- a/packages/vira/src/Vira/Page/RepoPage.hs
+++ b/packages/vira/src/Vira/Page/RepoPage.hs
@@ -76,7 +76,7 @@ deleteHandler name = do
   App.query (St.GetRepoByNameA name) >>= \case
     Just _repo -> do
       App.update $ St.DeleteRepoByNameA name
-      redirectUrl <- App.linkToUrl LinkTo.RepoListing
+      redirectUrl <- App.getLinkUrl LinkTo.RepoListing
       pure $ addHeader redirectUrl "Ok"
     Nothing ->
       throwError err404
@@ -84,8 +84,8 @@ deleteHandler name = do
 -- Repository header component with actions
 repoPageHeader :: St.Repo -> App.VHtml ()
 repoPageHeader repo = do
-  updateLink <- lift $ App.linkToLink $ LinkTo.RepoUpdate repo.name
-  deleteLink <- lift $ App.linkToLink $ LinkTo.RepoDelete repo.name
+  updateLink <- lift $ App.getLink $ LinkTo.RepoUpdate repo.name
+  deleteLink <- lift $ App.getLink $ LinkTo.RepoDelete repo.name
   W.viraPageHeader_
     (toText $ toString repo.name)
     ( div_ [class_ "flex items-center justify-between"] $ do
@@ -144,7 +144,7 @@ viewRepoBranch repo branch branches jobs = do
 
         -- Enhanced build button
         div_ [class_ "flex-shrink-0 ml-6"] $ do
-          buildLink <- lift $ App.linkToLink $ LinkTo.Build repo.name branch.branchName
+          buildLink <- lift $ App.getLink $ LinkTo.Build repo.name branch.branchName
           W.viraButton_
             W.ButtonSuccess
             [ hxPostSafe_ buildLink
@@ -216,7 +216,7 @@ repoLayout repo branches currentBranch content = do
                 if allBranchesActive
                   then "flex items-center p-4 rounded-lg bg-indigo-50 border border-indigo-200"
                   else "flex items-center p-4 rounded-lg hover:bg-gray-50 transition-colors"
-          repoUrl <- lift $ App.linkToUrl $ LinkTo.Repo repository.name
+          repoUrl <- lift $ App.getLinkUrl $ LinkTo.Repo repository.name
           a_ [href_ repoUrl, class_ allBranchesClass, data_ "branch-item" "all-branches"] $ do
             div_ [class_ "flex-shrink-0 mr-3"] $ do
               div_ [class_ "w-5 h-5 flex items-center justify-center"] $ toHtmlRaw Icon.list
@@ -228,7 +228,7 @@ repoLayout repo branches currentBranch content = do
 
           -- Individual branches with enhanced styling
           forM_ branches' $ \branch -> do
-            branchUrl <- lift $ App.linkToUrl $ LinkTo.RepoBranch repository.name branch.branchName
+            branchUrl <- lift $ App.getLinkUrl $ LinkTo.RepoBranch repository.name branch.branchName
             let isCurrentBranch = maybeCurrentBranch == Just branch.branchName
                 branchClass =
                   if isCurrentBranch

--- a/packages/vira/src/Vira/Page/RepoPage.hs
+++ b/packages/vira/src/Vira/Page/RepoPage.hs
@@ -11,10 +11,10 @@ import Lucid
 import Lucid.Htmx.Contrib (hxConfirm_, hxPostSafe_)
 import Servant hiding (throwError)
 import Servant.API ((:>))
+import Servant.API.ContentTypes.Lucid (HTML)
 import Servant.Server.Generic (AsServer)
 import Vira.App qualified as App
 import Vira.App.LinkTo.Type qualified as LinkTo
-import Vira.App.Servant (HTML)
 import Vira.Lib.Git (BranchName)
 import Vira.Lib.Git qualified as Git
 import Vira.Page.JobPage qualified as JobPage

--- a/packages/vira/src/Vira/Page/RepoPage.hs
+++ b/packages/vira/src/Vira/Page/RepoPage.hs
@@ -55,14 +55,14 @@ branchViewHandler repoName branchName = do
   branches <- App.query $ St.GetBranchesByRepoA repoName
   jobs <- App.query $ St.GetJobsByBranchA repoName branchName
   let branchCrumbs = crumbs <> [LinkTo.Repo repoName, LinkTo.RepoBranch repoName branchName]
-  App.runVHtml $ W.layout branchCrumbs $ viewRepoBranch repo branch branches jobs
+  App.runAppHtml $ W.layout branchCrumbs $ viewRepoBranch repo branch branches jobs
 
 viewHandler :: RepoName -> Eff App.AppServantStack (Html ())
 viewHandler name = do
   repo <- App.query (St.GetRepoByNameA name) >>= maybe (throwError err404) pure
   branches <- App.query $ St.GetBranchesByRepoA name
   allJobs <- App.query $ St.GetJobsByRepoA repo.name
-  App.runVHtml $ W.layout (crumbs <> [LinkTo.Repo name]) $ viewRepo repo branches allJobs
+  App.runAppHtml $ W.layout (crumbs <> [LinkTo.Repo name]) $ viewRepo repo branches allJobs
 
 updateHandler :: RepoName -> Eff App.AppServantStack (Headers '[HXRefresh] Text)
 updateHandler name = do
@@ -82,7 +82,7 @@ deleteHandler name = do
       throwError err404
 
 -- Repository header component with actions
-repoPageHeader :: St.Repo -> App.VHtml ()
+repoPageHeader :: St.Repo -> App.AppHtml ()
 repoPageHeader repo = do
   updateLink <- lift $ App.getLink $ LinkTo.RepoUpdate repo.name
   deleteLink <- lift $ App.getLink $ LinkTo.RepoDelete repo.name
@@ -112,7 +112,7 @@ repoPageHeader repo = do
             $ toHtmlRaw Icon.trash
     )
 
-viewRepo :: St.Repo -> [St.Branch] -> [St.Job] -> App.VHtml ()
+viewRepo :: St.Repo -> [St.Branch] -> [St.Job] -> App.AppHtml ()
 viewRepo repo branches allJobs = do
   repoPageHeader repo
   repoLayout repo branches Nothing $ do
@@ -124,7 +124,7 @@ viewRepo repo branches allJobs = do
     viewJobListing allJobs
 
 -- Branch-specific view function
-viewRepoBranch :: St.Repo -> St.Branch -> [St.Branch] -> [St.Job] -> App.VHtml ()
+viewRepoBranch :: St.Repo -> St.Branch -> [St.Branch] -> [St.Job] -> App.AppHtml ()
 viewRepoBranch repo branch branches jobs = do
   repoPageHeader repo
   repoLayout repo branches (Just branch.branchName) $ do
@@ -166,7 +166,7 @@ viewRepoBranch repo branch branches jobs = do
     viewJobListing jobs
 
 -- Job listing component with updated messaging
-viewJobListing :: [St.Job] -> App.VHtml ()
+viewJobListing :: [St.Job] -> App.AppHtml ()
 viewJobListing jobs = do
   if null jobs
     then W.viraCard_ [class_ "p-12 text-center bg-gray-50"] $ do
@@ -178,7 +178,7 @@ viewJobListing jobs = do
         JobPage.viewJobHeader job
 
 -- Repository layout component with sidebar and main content
-repoLayout :: St.Repo -> [St.Branch] -> Maybe BranchName -> App.VHtml () -> App.VHtml ()
+repoLayout :: St.Repo -> [St.Branch] -> Maybe BranchName -> App.AppHtml () -> App.AppHtml ()
 repoLayout repo branches currentBranch content = do
   div_ [class_ "grid grid-cols-4 gap-8"] $ do
     -- Sidebar
@@ -191,7 +191,7 @@ repoLayout repo branches currentBranch content = do
         content
   where
     -- Sidebar component for repository navigation
-    repoSidebar :: St.Repo -> [St.Branch] -> Maybe BranchName -> App.VHtml ()
+    repoSidebar :: St.Repo -> [St.Branch] -> Maybe BranchName -> App.AppHtml ()
     repoSidebar repository branches' maybeCurrentBranch = do
       W.viraCard_ [class_ "p-6 bg-gray-50"] $ do
         div_ [class_ "mb-6"] $ do

--- a/packages/vira/src/Vira/Page/RepoPage.hs
+++ b/packages/vira/src/Vira/Page/RepoPage.hs
@@ -11,10 +11,10 @@ import Lucid
 import Lucid.Htmx.Contrib (hxConfirm_, hxPostSafe_)
 import Servant hiding (throwError)
 import Servant.API ((:>))
-import Servant.API.ContentTypes.Lucid (HTML)
 import Servant.Server.Generic (AsServer)
 import Vira.App qualified as App
 import Vira.App.LinkTo.Type qualified as LinkTo
+import Vira.App.Servant (HTML)
 import Vira.Lib.Git (BranchName)
 import Vira.Lib.Git qualified as Git
 import Vira.Page.JobPage qualified as JobPage

--- a/packages/vira/src/Vira/Page/RepoPage.hs
+++ b/packages/vira/src/Vira/Page/RepoPage.hs
@@ -57,8 +57,7 @@ branchViewHandler repoName branchName = do
   jobs <- App.query $ St.GetJobsByBranchA repoName branchName
   cfg <- ask
   let branchCrumbs = crumbs <> [LinkTo.Repo repoName, LinkTo.RepoBranch repoName branchName]
-  pure $ W.layout cfg branchCrumbs $ do
-    viewRepoBranch cfg.linkTo repo branch branches jobs
+  App.runVHtml $ W.layout cfg branchCrumbs $ viewRepoBranch cfg.linkTo repo branch branches jobs
 
 viewHandler :: RepoName -> Eff App.AppServantStack (Html ())
 viewHandler name = do
@@ -66,8 +65,7 @@ viewHandler name = do
   repo <- App.query (St.GetRepoByNameA name) >>= maybe (throwError err404) pure
   branches <- App.query $ St.GetBranchesByRepoA name
   allJobs <- App.query $ St.GetJobsByRepoA repo.name
-  pure $ W.layout cfg (crumbs <> [LinkTo.Repo name]) $ do
-    viewRepo cfg.linkTo repo branches allJobs
+  App.runVHtml $ W.layout cfg (crumbs <> [LinkTo.Repo name]) $ viewRepo cfg.linkTo repo branches allJobs
 
 updateHandler :: RepoName -> Eff App.AppServantStack (Headers '[HXRefresh] Text)
 updateHandler name = do

--- a/packages/vira/src/Vira/Page/RepoPage.hs
+++ b/packages/vira/src/Vira/Page/RepoPage.hs
@@ -55,14 +55,14 @@ branchViewHandler repoName branchName = do
   branches <- App.query $ St.GetBranchesByRepoA repoName
   jobs <- App.query $ St.GetJobsByBranchA repoName branchName
   let branchCrumbs = crumbs <> [LinkTo.Repo repoName, LinkTo.RepoBranch repoName branchName]
-  App.runVHtmlInServant $ W.layout branchCrumbs $ viewRepoBranch repo branch branches jobs
+  App.runVHtml $ W.layout branchCrumbs $ viewRepoBranch repo branch branches jobs
 
 viewHandler :: RepoName -> Eff App.AppServantStack (Html ())
 viewHandler name = do
   repo <- App.query (St.GetRepoByNameA name) >>= maybe (throwError err404) pure
   branches <- App.query $ St.GetBranchesByRepoA name
   allJobs <- App.query $ St.GetJobsByRepoA repo.name
-  App.runVHtmlInServant $ W.layout (crumbs <> [LinkTo.Repo name]) $ viewRepo repo branches allJobs
+  App.runVHtml $ W.layout (crumbs <> [LinkTo.Repo name]) $ viewRepo repo branches allJobs
 
 updateHandler :: RepoName -> Eff App.AppServantStack (Headers '[HXRefresh] Text)
 updateHandler name = do

--- a/packages/vira/src/Vira/Page/RepoPage.hs
+++ b/packages/vira/src/Vira/Page/RepoPage.hs
@@ -16,7 +16,7 @@ import Servant.API.ContentTypes.Lucid (HTML)
 import Servant.Server.Generic (AsServer)
 import Vira.App qualified as App
 import Vira.App.LinkTo.Type qualified as LinkTo
-import Vira.App.Stack (VHtml, linkToLink, linkToUrl)
+import Vira.App.Stack (VHtml, linkToLink, linkToUrl, runVHtmlInServant)
 import Vira.Lib.Git (BranchName)
 import Vira.Lib.Git qualified as Git
 import Vira.Page.JobPage qualified as JobPage
@@ -58,7 +58,7 @@ branchViewHandler repoName branchName = do
   jobs <- App.query $ St.GetJobsByBranchA repoName branchName
   cfg <- ask
   let branchCrumbs = crumbs <> [LinkTo.Repo repoName, LinkTo.RepoBranch repoName branchName]
-  App.runVHtml $ W.layout cfg branchCrumbs $ viewRepoBranch repo branch branches jobs
+  runVHtmlInServant $ W.layout cfg branchCrumbs $ viewRepoBranch repo branch branches jobs
 
 viewHandler :: RepoName -> Eff App.AppServantStack (Html ())
 viewHandler name = do
@@ -66,7 +66,7 @@ viewHandler name = do
   repo <- App.query (St.GetRepoByNameA name) >>= maybe (throwError err404) pure
   branches <- App.query $ St.GetBranchesByRepoA name
   allJobs <- App.query $ St.GetJobsByRepoA repo.name
-  App.runVHtml $ W.layout cfg (crumbs <> [LinkTo.Repo name]) $ viewRepo repo branches allJobs
+  runVHtmlInServant $ W.layout cfg (crumbs <> [LinkTo.Repo name]) $ viewRepo repo branches allJobs
 
 updateHandler :: RepoName -> Eff App.AppServantStack (Headers '[HXRefresh] Text)
 updateHandler name = do

--- a/packages/vira/src/Vira/Page/SettingsPage.hs
+++ b/packages/vira/src/Vira/Page/SettingsPage.hs
@@ -61,7 +61,7 @@ viewHandler = do
   cfg <- ask
   mCachix <- App.query St.GetCachixSettingsA
   mAttic <- App.query St.GetAtticSettingsA
-  pure $ W.layout cfg [LinkTo.Settings] $ viewSettings cfg.linkTo mCachix mAttic
+  App.runVHtml $ W.layout cfg [LinkTo.Settings] $ viewSettings cfg.linkTo mCachix mAttic
 
 updateCachixHandler :: CachixSettings -> Eff App.AppServantStack FormResp
 updateCachixHandler settings = do

--- a/packages/vira/src/Vira/Page/SettingsPage.hs
+++ b/packages/vira/src/Vira/Page/SettingsPage.hs
@@ -23,7 +23,7 @@ import Servant.API.ContentTypes.Lucid (HTML)
 import Servant.Server.Generic (AsServer)
 import Vira.App qualified as App
 import Vira.App.LinkTo.Type qualified as LinkTo
-import Vira.App.Stack (VHtml, linkToLink)
+import Vira.App.Stack (VHtml, linkToLink, runVHtmlInServant)
 import Vira.Lib.Attic (AtticServer (..))
 import Vira.Lib.Logging
 import Vira.State.Acid qualified as St
@@ -62,7 +62,7 @@ viewHandler = do
   cfg <- ask
   mCachix <- App.query St.GetCachixSettingsA
   mAttic <- App.query St.GetAtticSettingsA
-  App.runVHtml $ W.layout cfg [LinkTo.Settings] $ viewSettings mCachix mAttic
+  runVHtmlInServant $ W.layout cfg [LinkTo.Settings] $ viewSettings mCachix mAttic
 
 updateCachixHandler :: CachixSettings -> Eff App.AppServantStack FormResp
 updateCachixHandler settings = do

--- a/packages/vira/src/Vira/Page/SettingsPage.hs
+++ b/packages/vira/src/Vira/Page/SettingsPage.hs
@@ -57,7 +57,7 @@ handlers cfg =
 
 viewHandler :: Eff App.AppServantStack (Html ())
 viewHandler = do
-  App.runVHtml $ W.layout [LinkTo.Settings] viewSettings
+  App.runAppHtml $ W.layout [LinkTo.Settings] viewSettings
 
 updateCachixHandler :: CachixSettings -> Eff App.AppServantStack FormResp
 updateCachixHandler settings = do
@@ -83,7 +83,7 @@ deleteAtticHandler = do
   log Info "Deleted attic settings"
   pure $ addHeader True "Ok"
 
-viewSettings :: App.VHtml ()
+viewSettings :: App.AppHtml ()
 viewSettings = do
   mCachix <- lift $ App.query St.GetCachixSettingsA
   mAttic <- lift $ App.query St.GetAtticSettingsA
@@ -135,7 +135,7 @@ viewSettings = do
 
         atticForm mAttic
   where
-    cachixForm :: Maybe CachixSettings -> App.VHtml ()
+    cachixForm :: Maybe CachixSettings -> App.AppHtml ()
     cachixForm mCachixSettings = do
       updateCachixLink <- lift $ App.getLink LinkTo.SettingsUpdateCachix
       form_ [id_ "cachix-update", hxPostSafe_ updateCachixLink, hxSwapS_ InnerHTML, class_ "space-y-6"] $ do
@@ -177,7 +177,7 @@ viewSettings = do
         form_ [hxPostSafe_ deleteCachixLink, hxSwapS_ InnerHTML, hxConfirm_ "Are you sure you want to disconnect Cachix? This action cannot be undone.", class_ "mt-3"] $ do
           W.viraButton_ W.ButtonDestructive [type_ "submit"] "Disconnect"
 
-    atticForm :: Maybe AtticSettings -> App.VHtml ()
+    atticForm :: Maybe AtticSettings -> App.AppHtml ()
     atticForm mAtticSettings = do
       updateAtticLink <- lift $ App.getLink LinkTo.SettingsUpdateAttic
       form_ [id_ "attic-update", hxPostSafe_ updateAtticLink, hxSwapS_ InnerHTML, class_ "space-y-6"] $ do

--- a/packages/vira/src/Vira/Page/SettingsPage.hs
+++ b/packages/vira/src/Vira/Page/SettingsPage.hs
@@ -23,7 +23,6 @@ import Servant.API.ContentTypes.Lucid (HTML)
 import Servant.Server.Generic (AsServer)
 import Vira.App qualified as App
 import Vira.App.LinkTo.Type qualified as LinkTo
-import Vira.App.Stack (VHtml, linkToLink, runVHtmlInServant)
 import Vira.Lib.Attic (AtticServer (..))
 import Vira.Lib.Logging
 import Vira.State.Acid qualified as St
@@ -62,7 +61,7 @@ viewHandler = do
   cfg <- ask
   mCachix <- App.query St.GetCachixSettingsA
   mAttic <- App.query St.GetAtticSettingsA
-  runVHtmlInServant $ W.layout cfg [LinkTo.Settings] $ viewSettings mCachix mAttic
+  App.runVHtmlInServant $ W.layout cfg [LinkTo.Settings] $ viewSettings mCachix mAttic
 
 updateCachixHandler :: CachixSettings -> Eff App.AppServantStack FormResp
 updateCachixHandler settings = do
@@ -88,7 +87,7 @@ deleteAtticHandler = do
   log Info "Deleted attic settings"
   pure $ addHeader True "Ok"
 
-viewSettings :: Maybe CachixSettings -> Maybe AtticSettings -> VHtml ()
+viewSettings :: Maybe CachixSettings -> Maybe AtticSettings -> App.VHtml ()
 viewSettings mCachix mAttic = do
   W.viraSection_ [] $ do
     W.viraPageHeader_ "Settings" $ do
@@ -138,9 +137,9 @@ viewSettings mCachix mAttic = do
 
         atticForm mAttic
   where
-    cachixForm :: Maybe CachixSettings -> VHtml ()
+    cachixForm :: Maybe CachixSettings -> App.VHtml ()
     cachixForm mCachixSettings = do
-      updateCachixLink <- linkToLink LinkTo.SettingsUpdateCachix
+      updateCachixLink <- App.linkToLink LinkTo.SettingsUpdateCachix
       form_ [id_ "cachix-update", hxPostSafe_ updateCachixLink, hxSwapS_ InnerHTML, class_ "space-y-6"] $ do
         W.viraFormGroup_
           ( withFieldName @CachixSettings @"cachixName" $ \name ->
@@ -176,13 +175,13 @@ viewSettings mCachix mAttic = do
 
       -- Disconnect form outside the main form to avoid nesting
       whenJust mCachixSettings $ \_ -> do
-        deleteCachixLink <- linkToLink LinkTo.SettingsDeleteCachix
+        deleteCachixLink <- App.linkToLink LinkTo.SettingsDeleteCachix
         form_ [hxPostSafe_ deleteCachixLink, hxSwapS_ InnerHTML, hxConfirm_ "Are you sure you want to disconnect Cachix? This action cannot be undone.", class_ "mt-3"] $ do
           W.viraButton_ W.ButtonDestructive [type_ "submit"] "Disconnect"
 
-    atticForm :: Maybe AtticSettings -> VHtml ()
+    atticForm :: Maybe AtticSettings -> App.VHtml ()
     atticForm mAtticSettings = do
-      updateAtticLink <- linkToLink LinkTo.SettingsUpdateAttic
+      updateAtticLink <- App.linkToLink LinkTo.SettingsUpdateAttic
       form_ [id_ "attic-update", hxPostSafe_ updateAtticLink, hxSwapS_ InnerHTML, class_ "space-y-6"] $ do
         div_ [class_ "grid gap-4 lg:grid-cols-2"] $ do
           W.viraFormGroup_
@@ -246,7 +245,7 @@ viewSettings mCachix mAttic = do
 
       -- Disconnect form outside the main form to avoid nesting
       whenJust mAtticSettings $ \_ -> do
-        deleteAtticLink <- linkToLink LinkTo.SettingsDeleteAttic
+        deleteAtticLink <- App.linkToLink LinkTo.SettingsDeleteAttic
         form_ [hxPostSafe_ deleteAtticLink, hxSwapS_ InnerHTML, hxConfirm_ "Are you sure you want to disconnect Attic? This action cannot be undone.", class_ "mt-3"] $ do
           W.viraButton_ W.ButtonDestructive [type_ "submit"] "Disconnect"
 

--- a/packages/vira/src/Vira/Page/SettingsPage.hs
+++ b/packages/vira/src/Vira/Page/SettingsPage.hs
@@ -18,10 +18,10 @@ import Htmx.Swap (Swap (InnerHTML))
 import Lucid
 import Lucid.Htmx.Contrib (hxConfirm_, hxPostSafe_)
 import Servant
-import Servant.API.ContentTypes.Lucid (HTML)
 import Servant.Server.Generic (AsServer)
 import Vira.App qualified as App
 import Vira.App.LinkTo.Type qualified as LinkTo
+import Vira.App.Servant (HTML)
 import Vira.Lib.Attic (AtticServer (..))
 import Vira.Lib.Logging
 import Vira.State.Acid qualified as St

--- a/packages/vira/src/Vira/Page/SettingsPage.hs
+++ b/packages/vira/src/Vira/Page/SettingsPage.hs
@@ -20,6 +20,7 @@ import Lucid.Htmx.Contrib (hxConfirm_, hxPostSafe_)
 import Servant
 import Servant.API.ContentTypes.Lucid (HTML)
 import Servant.Server.Generic (AsServer)
+import Vira.App (AppHtml)
 import Vira.App qualified as App
 import Vira.App.LinkTo.Type qualified as LinkTo
 import Vira.Lib.Attic (AtticServer (..))
@@ -48,16 +49,16 @@ data Routes mode = Routes
 handlers :: App.AppState -> Routes AsServer
 handlers cfg =
   Routes
-    { _view = App.runAppInServant cfg viewHandler
+    { _view = App.runAppInServant cfg . App.runAppHtml $ viewHandler
     , _updateCachix = App.runAppInServant cfg . updateCachixHandler
     , _deleteCachix = App.runAppInServant cfg deleteCachixHandler
     , _updateAttic = App.runAppInServant cfg . updateAtticHandler
     , _deleteAttic = App.runAppInServant cfg deleteAtticHandler
     }
 
-viewHandler :: Eff App.AppServantStack (Html ())
+viewHandler :: AppHtml ()
 viewHandler = do
-  App.runAppHtml $ W.layout [LinkTo.Settings] viewSettings
+  W.layout [LinkTo.Settings] viewSettings
 
 updateCachixHandler :: CachixSettings -> Eff App.AppServantStack FormResp
 updateCachixHandler settings = do

--- a/packages/vira/src/Vira/Page/SettingsPage.hs
+++ b/packages/vira/src/Vira/Page/SettingsPage.hs
@@ -57,7 +57,7 @@ handlers cfg =
 
 viewHandler :: Eff App.AppServantStack (Html ())
 viewHandler = do
-  App.runVHtmlInServant $ W.layout [LinkTo.Settings] viewSettings
+  App.runVHtml $ W.layout [LinkTo.Settings] viewSettings
 
 updateCachixHandler :: CachixSettings -> Eff App.AppServantStack FormResp
 updateCachixHandler settings = do

--- a/packages/vira/src/Vira/Page/SettingsPage.hs
+++ b/packages/vira/src/Vira/Page/SettingsPage.hs
@@ -137,7 +137,7 @@ viewSettings = do
   where
     cachixForm :: Maybe CachixSettings -> App.VHtml ()
     cachixForm mCachixSettings = do
-      updateCachixLink <- lift $ App.linkToLink LinkTo.SettingsUpdateCachix
+      updateCachixLink <- lift $ App.getLink LinkTo.SettingsUpdateCachix
       form_ [id_ "cachix-update", hxPostSafe_ updateCachixLink, hxSwapS_ InnerHTML, class_ "space-y-6"] $ do
         W.viraFormGroup_
           ( withFieldName @CachixSettings @"cachixName" $ \name ->
@@ -173,13 +173,13 @@ viewSettings = do
 
       -- Disconnect form outside the main form to avoid nesting
       whenJust mCachixSettings $ \_ -> do
-        deleteCachixLink <- lift $ App.linkToLink LinkTo.SettingsDeleteCachix
+        deleteCachixLink <- lift $ App.getLink LinkTo.SettingsDeleteCachix
         form_ [hxPostSafe_ deleteCachixLink, hxSwapS_ InnerHTML, hxConfirm_ "Are you sure you want to disconnect Cachix? This action cannot be undone.", class_ "mt-3"] $ do
           W.viraButton_ W.ButtonDestructive [type_ "submit"] "Disconnect"
 
     atticForm :: Maybe AtticSettings -> App.VHtml ()
     atticForm mAtticSettings = do
-      updateAtticLink <- lift $ App.linkToLink LinkTo.SettingsUpdateAttic
+      updateAtticLink <- lift $ App.getLink LinkTo.SettingsUpdateAttic
       form_ [id_ "attic-update", hxPostSafe_ updateAtticLink, hxSwapS_ InnerHTML, class_ "space-y-6"] $ do
         div_ [class_ "grid gap-4 lg:grid-cols-2"] $ do
           W.viraFormGroup_
@@ -243,7 +243,7 @@ viewSettings = do
 
       -- Disconnect form outside the main form to avoid nesting
       whenJust mAtticSettings $ \_ -> do
-        deleteAtticLink <- lift $ App.linkToLink LinkTo.SettingsDeleteAttic
+        deleteAtticLink <- lift $ App.getLink LinkTo.SettingsDeleteAttic
         form_ [hxPostSafe_ deleteAtticLink, hxSwapS_ InnerHTML, hxConfirm_ "Are you sure you want to disconnect Attic? This action cannot be undone.", class_ "mt-3"] $ do
           W.viraButton_ W.ButtonDestructive [type_ "submit"] "Disconnect"
 

--- a/packages/vira/src/Vira/Page/SettingsPage.hs
+++ b/packages/vira/src/Vira/Page/SettingsPage.hs
@@ -18,10 +18,10 @@ import Htmx.Swap (Swap (InnerHTML))
 import Lucid
 import Lucid.Htmx.Contrib (hxConfirm_, hxPostSafe_)
 import Servant
+import Servant.API.ContentTypes.Lucid (HTML)
 import Servant.Server.Generic (AsServer)
 import Vira.App qualified as App
 import Vira.App.LinkTo.Type qualified as LinkTo
-import Vira.App.Servant (HTML)
 import Vira.Lib.Attic (AtticServer (..))
 import Vira.Lib.Logging
 import Vira.State.Acid qualified as St

--- a/packages/vira/src/Vira/Stream/Log.hs
+++ b/packages/vira/src/Vira/Stream/Log.hs
@@ -26,7 +26,7 @@ import Servant.Types.SourceT qualified as S
 import System.Tail qualified as Tail
 import Vira.App qualified as App
 import Vira.App.LinkTo.Type qualified as LinkTo
-import Vira.App.VHtml (VHtml, hoistVHtml, linkToUrl)
+import Vira.App.VHtml (VHtml, linkToUrl)
 import Vira.State.Acid qualified as St
 import Vira.State.Type (Job, JobId)
 import Vira.State.Type qualified as St
@@ -179,7 +179,7 @@ logViewerWidget job w = do
           , hyperscript_ "on htmx:afterSwap set #logContainer.scrollTop to #logContainer.scrollHeight"
           ]
           $ do
-            code_ $ hoistVHtml w
+            code_ w
 
 -- | ID of the HTML element targeted by SSE message swaps (log streaming)
 sseTarget :: Text

--- a/packages/vira/src/Vira/Stream/Log.hs
+++ b/packages/vira/src/Vira/Stream/Log.hs
@@ -27,7 +27,8 @@ import Servant.Types.SourceT qualified as S
 import System.Tail qualified as Tail
 import Vira.App qualified as App
 import Vira.App.LinkTo.Type qualified as LinkTo
-import Vira.App.VHtml (VHtml, VSource, getLinkUrl)
+import Vira.App.Lucid (VHtml, getLinkUrl)
+import Vira.App.Servant (VSource)
 import Vira.State.Acid qualified as St
 import Vira.State.Type (Job, JobId)
 import Vira.State.Type qualified as St

--- a/packages/vira/src/Vira/Stream/Log.hs
+++ b/packages/vira/src/Vira/Stream/Log.hs
@@ -26,7 +26,7 @@ import Servant.Types.SourceT qualified as S
 import System.Tail qualified as Tail
 import Vira.App qualified as App
 import Vira.App.LinkTo.Type qualified as LinkTo
-import Vira.App.VHtml (VHtml, linkToUrl)
+import Vira.App.VHtml (VHtml, getLinkUrl)
 import Vira.State.Acid qualified as St
 import Vira.State.Type (Job, JobId)
 import Vira.State.Type qualified as St
@@ -114,7 +114,7 @@ streamRouteHandler cfg jobId = S.fromStepT $ step 0 Init
 
 viewStream :: St.Job -> VHtml ()
 viewStream job = do
-  streamLink <- lift $ linkToUrl $ LinkTo.JobLogStream job.jobId
+  streamLink <- lift $ getLinkUrl $ LinkTo.JobLogStream job.jobId
   div_
     [ hxExt_ "sse"
     , hxSseConnect_ streamLink
@@ -155,7 +155,7 @@ viewStream job = do
 -- | Log viewer widget agnostic to static or streaming nature.
 logViewerWidget :: Job -> (forall m. (Monad m) => HtmlT m ()) -> VHtml ()
 logViewerWidget job w = do
-  jobLogUrl <- lift $ linkToUrl $ LinkTo.JobLog job.jobId
+  jobLogUrl <- lift $ getLinkUrl $ LinkTo.JobLog job.jobId
   div_ [class_ "space-y-4"] $ do
     -- Header with actions
     div_ [class_ "flex items-center justify-between"] $ do

--- a/packages/vira/src/Vira/Stream/Log.hs
+++ b/packages/vira/src/Vira/Stream/Log.hs
@@ -114,7 +114,7 @@ streamRouteHandler cfg jobId = S.fromStepT $ step 0 Init
 
 viewStream :: St.Job -> VHtml ()
 viewStream job = do
-  streamLink <- linkToUrl $ LinkTo.JobLogStream job.jobId
+  streamLink <- lift $ linkToUrl $ LinkTo.JobLogStream job.jobId
   div_
     [ hxExt_ "sse"
     , hxSseConnect_ streamLink
@@ -155,7 +155,7 @@ viewStream job = do
 -- | Log viewer widget agnostic to static or streaming nature.
 logViewerWidget :: Job -> (forall m. (Monad m) => HtmlT m ()) -> VHtml ()
 logViewerWidget job w = do
-  jobLogUrl <- linkToUrl $ LinkTo.JobLog job.jobId
+  jobLogUrl <- lift $ linkToUrl $ LinkTo.JobLog job.jobId
   div_ [class_ "space-y-4"] $ do
     -- Header with actions
     div_ [class_ "flex items-center justify-between"] $ do

--- a/packages/vira/src/Vira/Stream/Log.hs
+++ b/packages/vira/src/Vira/Stream/Log.hs
@@ -26,7 +26,7 @@ import Servant.Types.SourceT qualified as S
 import System.Tail qualified as Tail
 import Vira.App qualified as App
 import Vira.App.LinkTo.Type qualified as LinkTo
-import Vira.App.Stack (VHtml, hoistVHtml, linkToUrl)
+import Vira.App.VHtml (VHtml, hoistVHtml, linkToUrl)
 import Vira.State.Acid qualified as St
 import Vira.State.Type (Job, JobId)
 import Vira.State.Type qualified as St

--- a/packages/vira/src/Vira/Stream/Log.hs
+++ b/packages/vira/src/Vira/Stream/Log.hs
@@ -29,7 +29,7 @@ import Servant.Types.SourceT qualified as S
 import System.Tail qualified as Tail
 import Vira.App qualified as App
 import Vira.App.LinkTo.Type qualified as LinkTo
-import Vira.App.Lucid (VHtml, getLinkUrl)
+import Vira.App.Lucid (AppHtml, getLinkUrl)
 import Vira.App.Stack (AppStack)
 import Vira.State.Acid qualified as St
 import Vira.State.Type (Job, JobId)
@@ -116,7 +116,7 @@ streamRouteHandler jobId = S.fromStepT $ step 0 Init
           -- Send all available lines as a single chunk
           pure $ S.Yield (Chunk n availableLines) $ step (n + 1) (Streaming queue)
 
-viewStream :: St.Job -> VHtml ()
+viewStream :: St.Job -> AppHtml ()
 viewStream job = do
   streamLink <- lift $ getLinkUrl $ LinkTo.JobLogStream job.jobId
   div_
@@ -157,7 +157,7 @@ viewStream job = do
             span_ [class_ "font-medium"] "Streaming build logs..."
 
 -- | Log viewer widget agnostic to static or streaming nature.
-logViewerWidget :: Job -> (forall m. (Monad m) => HtmlT m ()) -> VHtml ()
+logViewerWidget :: Job -> (forall m. (Monad m) => HtmlT m ()) -> AppHtml ()
 logViewerWidget job w = do
   jobLogUrl <- lift $ getLinkUrl $ LinkTo.JobLog job.jobId
   div_ [class_ "space-y-4"] $ do

--- a/packages/vira/src/Vira/Stream/Status.hs
+++ b/packages/vira/src/Vira/Stream/Status.hs
@@ -20,7 +20,7 @@ import Servant.API.EventStream
 import Servant.Types.SourceT qualified as S
 import Vira.App qualified as App
 import Vira.App.LinkTo.Type qualified as LinkTo
-import Vira.App.VHtml (VHtml, getLinkUrl, runVHtml)
+import Vira.App.VHtml (VHtml, getLinkUrl)
 import Vira.State.Acid qualified as Acid
 import Vira.State.Type
 import Web.TablerIcons.Outline qualified as Icon
@@ -77,6 +77,6 @@ streamRouteHandler cfg = S.fromStepT $ step 0
     step (n :: Int) = S.Effect $ do
       when (n > 0) $ do
         liftIO $ threadDelay 1_000_000
-      html <- App.runApp cfg $ runVHtml viewInner
+      html <- App.runVHtmlIO cfg viewInner
       let msg = Status n html
       pure $ S.Yield msg $ step (n + 1)

--- a/packages/vira/src/Vira/Stream/Status.hs
+++ b/packages/vira/src/Vira/Stream/Status.hs
@@ -43,7 +43,7 @@ instance ToServerEvent Status where
       (Just $ show ident)
       (Lucid.renderBS t)
 
-viewStream :: (LinkTo.LinkTo -> Link) -> Html ()
+viewStream :: (Monad m) => (LinkTo.LinkTo -> Link) -> HtmlT m ()
 viewStream linkTo = do
   div_ [hxExt_ "sse", hxSseConnect_ link, hxSseSwap_ "status"] $ do
     "Loading status..."

--- a/packages/vira/src/Vira/Stream/Status.hs
+++ b/packages/vira/src/Vira/Stream/Status.hs
@@ -12,18 +12,15 @@ module Vira.Stream.Status (
 ) where
 
 import Control.Concurrent (threadDelay)
-import Effectful (Eff)
 import Htmx.Lucid.Extra (hxExt_)
 import Lucid
 import Lucid.Htmx.Contrib (hxSseConnect_, hxSseSwap_)
 import Servant.API
 import Servant.API.EventStream
-import Servant.Links (linkURI)
 import Servant.Types.SourceT qualified as S
 import Vira.App qualified as App
-import Vira.App.LinkTo.Type (LinkTo)
 import Vira.App.LinkTo.Type qualified as LinkTo
-import Vira.App.Stack (VHtml, linkToUrl)
+import Vira.App.Stack (VHtml, linkToUrl, runVHtml)
 import Vira.State.Acid qualified as Acid
 import Vira.State.Type
 import Web.TablerIcons.Outline qualified as Icon
@@ -48,14 +45,19 @@ viewStream :: VHtml ()
 viewStream = do
   link <- linkToUrl LinkTo.StatusGet
   div_ [hxExt_ "sse", hxSseConnect_ link, hxSseSwap_ "status"] $ do
-    "Loading status..."
+    viewInner
 
-viewInner :: (LinkTo -> Link) -> [(RepoName, JobId)] -> Html ()
-viewInner linkTo jobs = do
+-- | Status view for both immediate display and SSE streaming
+viewInner :: VHtml ()
+viewInner = do
+  -- Compute running jobs directly
+  jobsData <- lift $ App.query Acid.GetRunningJobs
+  let jobs = jobsData <&> \job -> (job.jobRepo, job.jobId)
   div_ [class_ "flex items-center space-x-2", title_ "Build Status"] $ do
     indicator $ not $ null jobs
     forM_ jobs $ \(repo, jobId) -> do
-      a_ [href_ $ show . linkURI $ linkTo $ LinkTo.Job jobId] $ do
+      jobUrl <- linkToUrl $ LinkTo.Job jobId
+      a_ [href_ jobUrl] $ do
         span_ $ b_ $ toHtml $ unRepoName repo
         "/"
         span_ $ code_ $ toHtml @Text $ show jobId
@@ -75,13 +77,6 @@ streamRouteHandler cfg = S.fromStepT $ step 0
     step (n :: Int) = S.Effect $ do
       when (n > 0) $ do
         liftIO $ threadDelay 1_000_000
-      jobs <- App.runApp cfg runningJobs
-      let msg = Status n $ viewInner cfg.linkTo jobs
+      html <- App.runApp cfg $ runVHtml viewInner
+      let msg = Status n html
       pure $ S.Yield msg $ step (n + 1)
-
-runningJobs :: Eff App.AppStack [(RepoName, JobId)]
-runningJobs = do
-  jobs <- App.query Acid.GetRunningJobs
-  pure $
-    jobs <&> \job ->
-      (job.jobRepo, job.jobId)

--- a/packages/vira/src/Vira/Stream/Status.hs
+++ b/packages/vira/src/Vira/Stream/Status.hs
@@ -43,7 +43,7 @@ instance ToServerEvent Status where
 
 viewStream :: VHtml ()
 viewStream = do
-  link <- linkToUrl LinkTo.StatusGet
+  link <- lift $ linkToUrl LinkTo.StatusGet
   div_ [hxExt_ "sse", hxSseConnect_ link, hxSseSwap_ "status"] $ do
     viewInner
 
@@ -56,7 +56,7 @@ viewInner = do
   div_ [class_ "flex items-center space-x-2", title_ "Build Status"] $ do
     indicator $ not $ null jobs
     forM_ jobs $ \(repo, jobId) -> do
-      jobUrl <- linkToUrl $ LinkTo.Job jobId
+      jobUrl <- lift $ linkToUrl $ LinkTo.Job jobId
       a_ [href_ jobUrl] $ do
         span_ $ b_ $ toHtml $ unRepoName repo
         "/"

--- a/packages/vira/src/Vira/Stream/Status.hs
+++ b/packages/vira/src/Vira/Stream/Status.hs
@@ -60,7 +60,7 @@ viewInner linkTo jobs = do
         "/"
         span_ $ code_ $ toHtml @Text $ show jobId
 
-indicator :: Bool -> Html ()
+indicator :: (Monad m) => Bool -> HtmlT m ()
 indicator active = do
   let (iconSvg, classes) =
         if active

--- a/packages/vira/src/Vira/Stream/Status.hs
+++ b/packages/vira/src/Vira/Stream/Status.hs
@@ -20,7 +20,7 @@ import Servant.API.EventStream
 import Servant.Types.SourceT qualified as S
 import Vira.App qualified as App
 import Vira.App.LinkTo.Type qualified as LinkTo
-import Vira.App.VHtml (VHtml, getLinkUrl)
+import Vira.App.VHtml (VHtml, VSource, getLinkUrl, runVHtml')
 import Vira.State.Acid qualified as Acid
 import Vira.State.Type
 import Web.TablerIcons.Outline qualified as Icon
@@ -71,12 +71,12 @@ indicator active = do
   div_ [class_ $ "w-4 h-4 flex items-center justify-center " <> classes] $
     toHtmlRaw iconSvg
 
-streamRouteHandler :: App.AppState -> SourceIO Status
-streamRouteHandler cfg = S.fromStepT $ step 0
+streamRouteHandler :: VSource Status
+streamRouteHandler = S.fromStepT $ step 0
   where
     step (n :: Int) = S.Effect $ do
       when (n > 0) $ do
         liftIO $ threadDelay 1_000_000
-      html <- App.runVHtmlIO cfg viewInner
+      html <- runVHtml' viewInner
       let msg = Status n html
       pure $ S.Yield msg $ step (n + 1)

--- a/packages/vira/src/Vira/Stream/Status.hs
+++ b/packages/vira/src/Vira/Stream/Status.hs
@@ -20,7 +20,8 @@ import Servant.API.EventStream
 import Servant.Types.SourceT qualified as S
 import Vira.App qualified as App
 import Vira.App.LinkTo.Type qualified as LinkTo
-import Vira.App.VHtml (VHtml, VSource, getLinkUrl, runVHtml')
+import Vira.App.Lucid (VHtml, getLinkUrl, runVHtml')
+import Vira.App.Servant (VSource)
 import Vira.State.Acid qualified as Acid
 import Vira.State.Type
 import Web.TablerIcons.Outline qualified as Icon

--- a/packages/vira/src/Vira/Stream/Status.hs
+++ b/packages/vira/src/Vira/Stream/Status.hs
@@ -12,16 +12,18 @@ module Vira.Stream.Status (
 ) where
 
 import Control.Concurrent (threadDelay)
+import Effectful (Eff)
 import Htmx.Lucid.Extra (hxExt_)
 import Lucid
 import Lucid.Htmx.Contrib (hxSseConnect_, hxSseSwap_)
 import Servant.API
 import Servant.API.EventStream
+import Servant.Types.SourceT (SourceT)
 import Servant.Types.SourceT qualified as S
 import Vira.App qualified as App
 import Vira.App.LinkTo.Type qualified as LinkTo
 import Vira.App.Lucid (VHtml, getLinkUrl, runVHtml')
-import Vira.App.Servant (VSource)
+import Vira.App.Stack (AppStack)
 import Vira.State.Acid qualified as Acid
 import Vira.State.Type
 import Web.TablerIcons.Outline qualified as Icon
@@ -72,7 +74,7 @@ indicator active = do
   div_ [class_ $ "w-4 h-4 flex items-center justify-center " <> classes] $
     toHtmlRaw iconSvg
 
-streamRouteHandler :: VSource Status
+streamRouteHandler :: SourceT (Eff AppStack) Status
 streamRouteHandler = S.fromStepT $ step 0
   where
     step (n :: Int) = S.Effect $ do

--- a/packages/vira/src/Vira/Stream/Status.hs
+++ b/packages/vira/src/Vira/Stream/Status.hs
@@ -20,7 +20,7 @@ import Servant.API.EventStream
 import Servant.Types.SourceT qualified as S
 import Vira.App qualified as App
 import Vira.App.LinkTo.Type qualified as LinkTo
-import Vira.App.Stack (VHtml, linkToUrl, runVHtml)
+import Vira.App.VHtml (VHtml, linkToUrl, runVHtml)
 import Vira.State.Acid qualified as Acid
 import Vira.State.Type
 import Web.TablerIcons.Outline qualified as Icon

--- a/packages/vira/src/Vira/Stream/Status.hs
+++ b/packages/vira/src/Vira/Stream/Status.hs
@@ -22,7 +22,7 @@ import Servant.Types.SourceT (SourceT)
 import Servant.Types.SourceT qualified as S
 import Vira.App qualified as App
 import Vira.App.LinkTo.Type qualified as LinkTo
-import Vira.App.Lucid (VHtml, getLinkUrl, runVHtml')
+import Vira.App.Lucid (VHtml, getLinkUrl)
 import Vira.App.Stack (AppStack)
 import Vira.State.Acid qualified as Acid
 import Vira.State.Type
@@ -80,6 +80,6 @@ streamRouteHandler = S.fromStepT $ step 0
     step (n :: Int) = S.Effect $ do
       when (n > 0) $ do
         liftIO $ threadDelay 1_000_000
-      html <- runVHtml' viewInner
+      html <- App.runVHtmlHandlingError viewInner
       let msg = Status n html
       pure $ S.Yield msg $ step (n + 1)

--- a/packages/vira/src/Vira/Stream/Status.hs
+++ b/packages/vira/src/Vira/Stream/Status.hs
@@ -20,7 +20,7 @@ import Servant.API.EventStream
 import Servant.Types.SourceT qualified as S
 import Vira.App qualified as App
 import Vira.App.LinkTo.Type qualified as LinkTo
-import Vira.App.VHtml (VHtml, linkToUrl, runVHtml)
+import Vira.App.VHtml (VHtml, getLinkUrl, runVHtml)
 import Vira.State.Acid qualified as Acid
 import Vira.State.Type
 import Web.TablerIcons.Outline qualified as Icon
@@ -43,7 +43,7 @@ instance ToServerEvent Status where
 
 viewStream :: VHtml ()
 viewStream = do
-  link <- lift $ linkToUrl LinkTo.StatusGet
+  link <- lift $ getLinkUrl LinkTo.StatusGet
   div_ [hxExt_ "sse", hxSseConnect_ link, hxSseSwap_ "status"] $ do
     viewInner
 
@@ -56,7 +56,7 @@ viewInner = do
   div_ [class_ "flex items-center space-x-2", title_ "Build Status"] $ do
     indicator $ not $ null jobs
     forM_ jobs $ \(repo, jobId) -> do
-      jobUrl <- lift $ linkToUrl $ LinkTo.Job jobId
+      jobUrl <- lift $ getLinkUrl $ LinkTo.Job jobId
       a_ [href_ jobUrl] $ do
         span_ $ b_ $ toHtml $ unRepoName repo
         "/"

--- a/packages/vira/src/Vira/Stream/Status.hs
+++ b/packages/vira/src/Vira/Stream/Status.hs
@@ -22,7 +22,7 @@ import Servant.Types.SourceT (SourceT)
 import Servant.Types.SourceT qualified as S
 import Vira.App qualified as App
 import Vira.App.LinkTo.Type qualified as LinkTo
-import Vira.App.Lucid (VHtml, getLinkUrl)
+import Vira.App.Lucid (AppHtml, getLinkUrl)
 import Vira.App.Stack (AppStack)
 import Vira.State.Acid qualified as Acid
 import Vira.State.Type
@@ -44,14 +44,14 @@ instance ToServerEvent Status where
       (Just $ show ident)
       (Lucid.renderBS t)
 
-viewStream :: VHtml ()
+viewStream :: AppHtml ()
 viewStream = do
   link <- lift $ getLinkUrl LinkTo.StatusGet
   div_ [hxExt_ "sse", hxSseConnect_ link, hxSseSwap_ "status"] $ do
     viewInner
 
 -- | Status view for both immediate display and SSE streaming
-viewInner :: VHtml ()
+viewInner :: AppHtml ()
 viewInner = do
   -- Compute running jobs directly
   jobsData <- lift $ App.query Acid.GetRunningJobs
@@ -80,6 +80,6 @@ streamRouteHandler = S.fromStepT $ step 0
     step (n :: Int) = S.Effect $ do
       when (n > 0) $ do
         liftIO $ threadDelay 1_000_000
-      html <- App.runVHtmlHandlingError viewInner
+      html <- App.runAppHtmlHandlingError viewInner
       let msg = Status n html
       pure $ S.Yield msg $ step (n + 1)

--- a/packages/vira/src/Vira/Stream/Status.hs
+++ b/packages/vira/src/Vira/Stream/Status.hs
@@ -23,6 +23,7 @@ import Servant.Types.SourceT qualified as S
 import Vira.App qualified as App
 import Vira.App.LinkTo.Type (LinkTo)
 import Vira.App.LinkTo.Type qualified as LinkTo
+import Vira.App.Stack (VHtml, linkToUrl)
 import Vira.State.Acid qualified as Acid
 import Vira.State.Type
 import Web.TablerIcons.Outline qualified as Icon
@@ -43,12 +44,11 @@ instance ToServerEvent Status where
       (Just $ show ident)
       (Lucid.renderBS t)
 
-viewStream :: (Monad m) => (LinkTo.LinkTo -> Link) -> HtmlT m ()
-viewStream linkTo = do
+viewStream :: VHtml ()
+viewStream = do
+  link <- linkToUrl LinkTo.StatusGet
   div_ [hxExt_ "sse", hxSseConnect_ link, hxSseSwap_ "status"] $ do
     "Loading status..."
-  where
-    link = show . linkURI $ linkTo LinkTo.StatusGet
 
 viewInner :: (LinkTo -> Link) -> [(RepoName, JobId)] -> Html ()
 viewInner linkTo jobs = do

--- a/packages/vira/src/Vira/Widgets/Alert.hs
+++ b/packages/vira/src/Vira/Widgets/Alert.hs
@@ -69,7 +69,7 @@ No manual color class management required.
 
 Includes role="alert" for screen readers.
 -}
-viraAlert_ :: AlertType -> Html () -> Html ()
+viraAlert_ :: (Monad m) => AlertType -> HtmlT m () -> HtmlT m ()
 viraAlert_ alertType content = do
   let (colorClass, iconSvg, iconColor) = case alertType of
         AlertError -> ("bg-red-50 border-red-200", Icon.x, "text-red-500")

--- a/packages/vira/src/Vira/Widgets/Card.hs
+++ b/packages/vira/src/Vira/Widgets/Card.hs
@@ -77,7 +77,7 @@ W.viraNavigationCard_ (show repoUrl) (toHtml $ toString repo.name)
 - href should be a valid URL or route
 - Keep titles concise for clean appearance
 -}
-viraNavigationCard_ :: Text -> Html () -> Html ()
+viraNavigationCard_ :: (Monad m) => Text -> HtmlT m () -> HtmlT m ()
 viraNavigationCard_ href title = do
   a_ [href_ href, class_ "group block"] $ do
     viraCard_ [class_ "p-6 hover:shadow-lg transition-all duration-300 group-hover:border-indigo-300"] $ do

--- a/packages/vira/src/Vira/Widgets/Code.hs
+++ b/packages/vira/src/Vira/Widgets/Code.hs
@@ -56,7 +56,7 @@ W.viraCodeBlock_ "Error: Package not found in registry"
 Use for longer code snippets, commit hashes, commands, or error messages.
 For inline code within text, use 'viraCodeInline_' instead.
 -}
-viraCodeBlock_ :: Text -> Html ()
+viraCodeBlock_ :: (Monad m) => Text -> HtmlT m ()
 viraCodeBlock_ code = do
   div_ [class_ "bg-gray-50 border border-gray-200 rounded-lg p-4 overflow-x-auto"] $ do
     code_ [class_ "text-sm text-gray-800 font-mono break-all"] $ toHtml code
@@ -92,6 +92,6 @@ span_ $ do
 Uses smaller, more subtle styling than 'viraCodeBlock_'.
 Integrates seamlessly with surrounding text flow.
 -}
-viraCodeInline_ :: Text -> Html ()
+viraCodeInline_ :: (Monad m) => Text -> HtmlT m ()
 viraCodeInline_ code = do
   code_ [class_ "px-2 py-1 text-xs bg-gray-100 text-gray-700 rounded font-mono"] $ toHtml code

--- a/packages/vira/src/Vira/Widgets/Form.hs
+++ b/packages/vira/src/Vira/Widgets/Form.hs
@@ -135,7 +135,7 @@ W.viraFormGroup_
 Use this for all form fields to maintain consistent spacing.
 Pairs perfectly with 'viraLabel_' and 'viraInput_' components.
 -}
-viraFormGroup_ :: Html () -> Html () -> Html ()
+viraFormGroup_ :: (Monad m) => HtmlT m () -> HtmlT m () -> HtmlT m ()
 viraFormGroup_ label input = do
   div_ [class_ "space-y-2"] $ do
     label
@@ -200,7 +200,7 @@ Uses hyperscript for client-side filtering to provide instant feedback
 without server round-trips. Requires target elements to have appropriate
 data attributes for filtering.
 -}
-viraFilterInput_ :: Text -> [Attributes] -> Html ()
+viraFilterInput_ :: (Monad m) => Text -> [Attributes] -> HtmlT m ()
 viraFilterInput_ targetSelector attrs = do
   -- Extract attribute name from selector like "[data-branch-item]" -> "branchItem"
   let filterAttribute = case targetSelector of

--- a/packages/vira/src/Vira/Widgets/Layout.hs
+++ b/packages/vira/src/Vira/Widgets/Layout.hs
@@ -39,7 +39,8 @@ module Vira.Widgets.Layout (
 import Lucid
 import Vira.App.CLI (CLISettings (basePath), instanceName)
 import Vira.App.LinkTo.Type (LinkTo, linkShortTitle)
-import Vira.App.Stack (AppState (cliSettings), VHtml, linkToUrl)
+import Vira.App.Stack (AppState (cliSettings))
+import Vira.App.VHtml (VHtml, linkToUrl)
 import Vira.Stream.Status qualified as Status
 
 -- | Common HTML layout for all routes.

--- a/packages/vira/src/Vira/Widgets/Layout.hs
+++ b/packages/vira/src/Vira/Widgets/Layout.hs
@@ -37,10 +37,9 @@ module Vira.Widgets.Layout (
 ) where
 
 import Lucid
-import Servant.Links (Link, linkURI)
 import Vira.App.CLI (CLISettings (basePath), instanceName)
 import Vira.App.LinkTo.Type (LinkTo, linkShortTitle)
-import Vira.App.Stack (AppState (cliSettings, linkTo), VHtml)
+import Vira.App.Stack (AppState (cliSettings), VHtml, linkToUrl)
 import Vira.Stream.Status qualified as Status
 
 -- | Common HTML layout for all routes.
@@ -77,7 +76,7 @@ layout cfg crumbs content = do
       div_ [class_ "min-h-screen"] $ do
         -- Main container with clean styling
         div_ [class_ "container mx-auto px-4 py-6 lg:px-8"] $ do
-          breadcrumbs cfg.linkTo crumbs
+          breadcrumbs crumbs
           content
   where
     siteTitle = "Vira (" <> cfg.cliSettings.instanceName <> ")"
@@ -95,8 +94,8 @@ layout cfg crumbs content = do
       script_ [src_ "js/htmx-extensions/src/sse/sse.js"] $ mempty @Text
 
 -- | Show breadcrumbs at the top of the page for navigation to parent routes
-breadcrumbs :: (LinkTo -> Link) -> [LinkTo] -> VHtml ()
-breadcrumbs linkTo rs' = do
+breadcrumbs :: [LinkTo] -> VHtml ()
+breadcrumbs rs' = do
   let logo = img_ [src_ "vira-logo.jpg", alt_ "Vira Logo", class_ "h-8 w-8 rounded-lg"]
   nav_ [id_ "breadcrumbs", class_ "flex items-center justify-between p-4 bg-indigo-600 rounded-t-xl"] $ do
     ol_ [class_ "flex flex-1 items-center space-x-2 text-lg list-none"] $ do
@@ -105,7 +104,7 @@ breadcrumbs linkTo rs' = do
         span_ [class_ "font-semibold text-white px-3 py-2 rounded-lg bg-white/20 backdrop-blur-sm"] logo
       -- Render breadcrumb links
       renderCrumbs rs'
-    Status.viewStream linkTo
+    Status.viewStream
   where
     renderCrumbs :: [LinkTo] -> VHtml ()
     renderCrumbs = \case
@@ -122,9 +121,10 @@ breadcrumbs linkTo rs' = do
       let title = linkShortTitle linkToValue
       if isLast
         then span_ [class_ "font-semibold text-white px-3 py-2 rounded-lg bg-white/20 backdrop-blur-sm"] $ toHtml title
-        else
+        else do
+          url <- linkToUrl linkToValue
           a_
-            [ href_ $ show $ linkURI $ linkTo linkToValue
+            [ href_ url
             , class_ "text-white/90 hover:text-white transition-smooth px-3 py-2 rounded-lg hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/30 font-medium"
             ]
             $ toHtml title

--- a/packages/vira/src/Vira/Widgets/Layout.hs
+++ b/packages/vira/src/Vira/Widgets/Layout.hs
@@ -41,13 +41,13 @@ import Lucid
 import Vira.App qualified as App
 import Vira.App.CLI (CLISettings (basePath), instanceName)
 import Vira.App.LinkTo.Type (LinkTo, linkShortTitle)
-import Vira.App.Lucid (VHtml)
+import Vira.App.Lucid (AppHtml)
 import Vira.App.Stack (AppState (cliSettings))
 import Vira.Stream.Status qualified as Status
 import Prelude hiding (asks)
 
 -- | Common HTML layout for all routes.
-layout :: [LinkTo] -> VHtml () -> VHtml ()
+layout :: [LinkTo] -> AppHtml () -> AppHtml ()
 layout crumbs content = do
   siteTitle <- lift $ asks @AppState (("Vira (" <>) . (<> ")") . (.cliSettings.instanceName))
   basePath <- lift $ asks @AppState (.cliSettings.basePath)
@@ -99,7 +99,7 @@ layout crumbs content = do
       script_ [src_ "js/htmx-extensions/src/sse/sse.js"] $ mempty @Text
 
 -- | Show breadcrumbs at the top of the page for navigation to parent routes
-breadcrumbs :: [LinkTo] -> VHtml ()
+breadcrumbs :: [LinkTo] -> AppHtml ()
 breadcrumbs rs' = do
   let logo = img_ [src_ "vira-logo.jpg", alt_ "Vira Logo", class_ "h-8 w-8 rounded-lg"]
   nav_ [id_ "breadcrumbs", class_ "flex items-center justify-between p-4 bg-indigo-600 rounded-t-xl"] $ do
@@ -111,7 +111,7 @@ breadcrumbs rs' = do
       renderCrumbs rs'
     Status.viewStream
   where
-    renderCrumbs :: [LinkTo] -> VHtml ()
+    renderCrumbs :: [LinkTo] -> AppHtml ()
     renderCrumbs = \case
       [] -> pass
       [x] -> do
@@ -121,7 +121,7 @@ breadcrumbs rs' = do
         li_ [class_ "flex items-center"] chevronSvg
         li_ [class_ "flex items-center"] $ renderCrumb x False
         renderCrumbs xs
-    renderCrumb :: LinkTo -> Bool -> VHtml ()
+    renderCrumb :: LinkTo -> Bool -> AppHtml ()
     renderCrumb linkToValue isLast = do
       let title = linkShortTitle linkToValue
       if isLast

--- a/packages/vira/src/Vira/Widgets/Layout.hs
+++ b/packages/vira/src/Vira/Widgets/Layout.hs
@@ -44,7 +44,7 @@ import Vira.App.Stack (AppState (cliSettings, linkTo))
 import Vira.Stream.Status qualified as Status
 
 -- | Common HTML layout for all routes.
-layout :: AppState -> [LinkTo] -> Html () -> Html ()
+layout :: (Monad m) => AppState -> [LinkTo] -> HtmlT m () -> HtmlT m ()
 layout cfg crumbs content = do
   doctype_
   html_ $ do
@@ -96,7 +96,7 @@ layout cfg crumbs content = do
       script_ [src_ "js/htmx-extensions/src/sse/sse.js"] $ mempty @Text
 
 -- | Show breadcrumbs at the top of the page for navigation to parent routes
-breadcrumbs :: (LinkTo -> Link) -> [(Html (), URI)] -> Html ()
+breadcrumbs :: forall m. (Monad m) => (LinkTo -> Link) -> [(HtmlT m (), URI)] -> HtmlT m ()
 breadcrumbs linkTo rs' = do
   let home = URI {uriScheme = "", uriAuthority = Nothing, uriPath = "", uriQuery = [], uriFragment = ""}
       logo = img_ [src_ "vira-logo.jpg", alt_ "Vira Logo", class_ "h-8 w-8 rounded-lg"]
@@ -114,16 +114,16 @@ breadcrumbs linkTo rs' = do
         li_ [class_ "flex items-center"] $ renderCrumb (second Just x)
         li_ [class_ "flex items-center"] chevronSvg
         renderCrumbs xs
-    renderCrumb :: (Html (), Maybe URI) -> Html ()
+    renderCrumb :: (HtmlT m (), Maybe URI) -> HtmlT m ()
     renderCrumb (s, mr) = case mr of
       Just r ->
         a_
           [ href_ (show r)
           , class_ "text-white/90 hover:text-white transition-smooth px-3 py-2 rounded-lg hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/30 font-medium"
           ]
-          $ toHtml s
+          s
       Nothing ->
-        span_ [class_ "font-semibold text-white px-3 py-2 rounded-lg bg-white/20 backdrop-blur-sm"] $ toHtml s
+        span_ [class_ "font-semibold text-white px-3 py-2 rounded-lg bg-white/20 backdrop-blur-sm"] s
     chevronSvg =
       span_ [class_ "mx-1 text-white/60"] $ toHtmlRaw ("<svg xmlns='http://www.w3.org/2000/svg' class='h-5 w-5' fill='none' viewBox='0 0 24 24' stroke='currentColor' stroke-width='2'><path stroke-linecap='round' stroke-linejoin='round' d='M9 5l7 7-7 7'/></svg>" :: Text)
 

--- a/packages/vira/src/Vira/Widgets/Layout.hs
+++ b/packages/vira/src/Vira/Widgets/Layout.hs
@@ -38,10 +38,11 @@ module Vira.Widgets.Layout (
 
 import Effectful.Reader.Dynamic (asks)
 import Lucid
+import Vira.App qualified as App
 import Vira.App.CLI (CLISettings (basePath), instanceName)
 import Vira.App.LinkTo.Type (LinkTo, linkShortTitle)
+import Vira.App.Lucid (VHtml)
 import Vira.App.Stack (AppState (cliSettings))
-import Vira.App.VHtml (VHtml, getLinkUrl)
 import Vira.Stream.Status qualified as Status
 import Prelude hiding (asks)
 
@@ -126,7 +127,7 @@ breadcrumbs rs' = do
       if isLast
         then span_ [class_ "font-semibold text-white px-3 py-2 rounded-lg bg-white/20 backdrop-blur-sm"] $ toHtml title
         else do
-          url <- lift $ getLinkUrl linkToValue
+          url <- lift $ App.getLinkUrl linkToValue
           a_
             [ href_ url
             , class_ "text-white/90 hover:text-white transition-smooth px-3 py-2 rounded-lg hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/30 font-medium"

--- a/packages/vira/src/Vira/Widgets/Layout.hs
+++ b/packages/vira/src/Vira/Widgets/Layout.hs
@@ -133,7 +133,7 @@ breadcrumbs rs' = do
             , class_ "text-white/90 hover:text-white transition-smooth px-3 py-2 rounded-lg hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/30 font-medium"
             ]
             $ toHtml title
-    chevronSvg :: VHtml ()
+    chevronSvg :: (Monad m) => HtmlT m ()
     chevronSvg =
       span_ [class_ "mx-1 text-white/60"] $ toHtmlRaw ("<svg xmlns='http://www.w3.org/2000/svg' class='h-5 w-5' fill='none' viewBox='0 0 24 24' stroke='currentColor' stroke-width='2'><path stroke-linecap='round' stroke-linejoin='round' d='M9 5l7 7-7 7'/></svg>" :: Text)
 

--- a/packages/vira/src/Vira/Widgets/Layout.hs
+++ b/packages/vira/src/Vira/Widgets/Layout.hs
@@ -41,7 +41,7 @@ import Lucid
 import Vira.App.CLI (CLISettings (basePath), instanceName)
 import Vira.App.LinkTo.Type (LinkTo, linkShortTitle)
 import Vira.App.Stack (AppState (cliSettings))
-import Vira.App.VHtml (VHtml, linkToUrl)
+import Vira.App.VHtml (VHtml, getLinkUrl)
 import Vira.Stream.Status qualified as Status
 import Prelude hiding (asks)
 
@@ -126,7 +126,7 @@ breadcrumbs rs' = do
       if isLast
         then span_ [class_ "font-semibold text-white px-3 py-2 rounded-lg bg-white/20 backdrop-blur-sm"] $ toHtml title
         else do
-          url <- lift $ linkToUrl linkToValue
+          url <- lift $ getLinkUrl linkToValue
           a_
             [ href_ url
             , class_ "text-white/90 hover:text-white transition-smooth px-3 py-2 rounded-lg hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/30 font-medium"

--- a/packages/vira/src/Vira/Widgets/Status.hs
+++ b/packages/vira/src/Vira/Widgets/Status.hs
@@ -60,7 +60,7 @@ Each status includes both semantic colors and appropriate icons:
 
 Uses 'St.JobStatus' directly from the domain model to prevent invalid status values.
 -}
-viraStatusBadge_ :: St.JobStatus -> Html ()
+viraStatusBadge_ :: (Monad m) => St.JobStatus -> HtmlT m ()
 viraStatusBadge_ jobStatus = do
   let (statusText, colorClass, iconSvg, iconClass) = case jobStatus of
         St.JobRunning -> ("Running" :: Text, "bg-blue-100 text-blue-800 border-blue-200", Icon.loader_2, "animate-spin")

--- a/packages/vira/vira.cabal
+++ b/packages/vira/vira.cabal
@@ -32,11 +32,11 @@ library
       Vira.App.CLI
       Vira.App.LinkTo.Resolve
       Vira.App.LinkTo.Type
+      Vira.App.Lucid
       Vira.App.Run
       Vira.App.Servant
       Vira.App.Server
       Vira.App.Stack
-      Vira.App.VHtml
       Vira.Lib.Attic
       Vira.Lib.Cachix
       Vira.Lib.Git

--- a/packages/vira/vira.cabal
+++ b/packages/vira/vira.cabal
@@ -109,7 +109,6 @@ library
     , co-log-core
     , co-log-effectful
     , containers
-    , dani-servant-lucid2
     , data-default
     , deriving-aeson
     , directory
@@ -128,6 +127,7 @@ library
     , htmx-lucid-contrib
     , htmx-servant
     , http-api-data
+    , http-media
     , ixset-typed
     , lucid2
     , mtl
@@ -146,6 +146,7 @@ library
     , streaming
     , tabler-icons
     , tail
+    , text
     , time
     , wai
     , wai-extra
@@ -207,7 +208,6 @@ executable vira
     , co-log-core
     , co-log-effectful
     , containers
-    , dani-servant-lucid2
     , data-default
     , deriving-aeson
     , directory
@@ -226,6 +226,7 @@ executable vira
     , htmx-lucid-contrib
     , htmx-servant
     , http-api-data
+    , http-media
     , ixset-typed
     , lucid2
     , mtl
@@ -244,6 +245,7 @@ executable vira
     , streaming
     , tabler-icons
     , tail
+    , text
     , time
     , vira
     , wai
@@ -308,7 +310,6 @@ test-suite vira-tests
     , co-log-core
     , co-log-effectful
     , containers
-    , dani-servant-lucid2
     , data-default
     , deriving-aeson
     , directory
@@ -327,6 +328,7 @@ test-suite vira-tests
     , htmx-lucid-contrib
     , htmx-servant
     , http-api-data
+    , http-media
     , ixset-typed
     , lucid2
     , mtl
@@ -345,6 +347,7 @@ test-suite vira-tests
     , streaming
     , tabler-icons
     , tail
+    , text
     , time
     , vira
     , wai

--- a/packages/vira/vira.cabal
+++ b/packages/vira/vira.cabal
@@ -102,6 +102,7 @@ library
     , aeson
     , async
     , base ==4.*
+    , binary
     , bytestring
     , co-log
     , co-log-core
@@ -199,6 +200,7 @@ executable vira
     , aeson
     , async
     , base ==4.*
+    , binary
     , bytestring
     , co-log
     , co-log-core
@@ -299,6 +301,7 @@ test-suite vira-tests
     , aeson
     , async
     , base ==4.*
+    , binary
     , bytestring
     , co-log
     , co-log-core

--- a/packages/vira/vira.cabal
+++ b/packages/vira/vira.cabal
@@ -109,6 +109,7 @@ library
     , co-log-core
     , co-log-effectful
     , containers
+    , dani-servant-lucid2
     , data-default
     , deriving-aeson
     , directory
@@ -208,6 +209,7 @@ executable vira
     , co-log-core
     , co-log-effectful
     , containers
+    , dani-servant-lucid2
     , data-default
     , deriving-aeson
     , directory
@@ -310,6 +312,7 @@ test-suite vira-tests
     , co-log-core
     , co-log-effectful
     , containers
+    , dani-servant-lucid2
     , data-default
     , deriving-aeson
     , directory

--- a/packages/vira/vira.cabal
+++ b/packages/vira/vira.cabal
@@ -36,6 +36,7 @@ library
       Vira.App.Servant
       Vira.App.Server
       Vira.App.Stack
+      Vira.App.VHtml
       Vira.Lib.Attic
       Vira.Lib.Cachix
       Vira.Lib.Git


### PR DESCRIPTION
Thereby:

- Allow effects (e.g.: querying or updating acid-state) in all UI functions that use `AppHtml ()`.
  - Effects is one of the initial things we need to design #109 properly
- Avoid threading `linkTo` (and the like) all over, simplifying the interface of UI functions