### PR TITLE
nixos module: Add `basePath`

### DIFF
--- a/nix/modules/nixos/vira.nix
+++ b/nix/modules/nixos/vira.nix
@@ -63,6 +63,12 @@ in
       description = "Directory to store Vira state data";
     };
 
+    basePath = mkOption {
+      type = types.str;
+      default = "/";
+      description = "Base URL path for the HTTP server";
+    };
+
   };
 
   config = mkIf cfg.enable {
@@ -111,6 +117,8 @@ in
               (toString cfg.port)
               "--state-dir"
               cfg.stateDir
+              "--base-path"
+              cfg.basePath
             ] ++ optionals (!cfg.https) [ "--no-https" ];
           in
           "${cfg.package}/bin/vira ${concatStringsSep " " args}";


### PR DESCRIPTION
Useful when serving via nginx reverse proxy at a particular path.

<img width="983" height="745" alt="image" src="https://github.com/user-attachments/assets/ad890fe4-20e0-4838-9fec-7c5e74d6ddac" />

