### PR TITLE
Track job duration

### DIFF
--- a/packages/vira/src/Vira/Lib/TimeExtra.hs
+++ b/packages/vira/src/Vira/Lib/TimeExtra.hs
@@ -1,0 +1,70 @@
+{- |
+Time formatting utilities.
+-}
+module Vira.Lib.TimeExtra (
+  formatDuration,
+  formatRelativeTime,
+  formatTimestamp,
+) where
+
+import Data.Time (NominalDiffTime, UTCTime, defaultTimeLocale, diffUTCTime, formatTime, utcToLocalTime)
+import Data.Time.Clock (nominalDiffTimeToSeconds)
+import Data.Time.LocalTime (getTimeZone)
+
+{- |
+Format duration for display (e.g., "2m 34s", "1h 15m 30s").
+
+Converts a NominalDiffTime to a human-readable duration string with appropriate units.
+-}
+formatDuration :: NominalDiffTime -> Text
+formatDuration diffTime =
+  let totalSeconds = floor $ nominalDiffTimeToSeconds diffTime :: Int
+      hours = totalSeconds `div` 3600
+      minutes = (totalSeconds `mod` 3600) `div` 60
+      seconds = totalSeconds `mod` 60
+   in case (hours, minutes, seconds) of
+        (0, 0, s) -> show s <> "s"
+        (0, m, s) -> show m <> "m " <> show s <> "s"
+        (h, m, s) -> show h <> "h " <> show m <> "m " <> show s <> "s"
+
+{- |
+Format relative time for display (e.g., "2 minutes ago", "3 hours ago", "just now").
+
+Converts the difference between two UTCTime values to a human-readable relative time string.
+For differences greater than a week, shows the absolute date instead.
+-}
+formatRelativeTime :: UTCTime -> UTCTime -> Text
+formatRelativeTime now commitTime =
+  let diffSeconds = round $ diffUTCTime now commitTime :: Integer
+      minutes = diffSeconds `div` 60
+      hours = minutes `div` 60
+      days = hours `div` 24
+   in if diffSeconds < 60
+        then "just now"
+        else
+          if minutes < 60
+            then toText (show @Text minutes) <> " minutes ago"
+            else
+              if hours < 24
+                then toText (show @Text hours) <> " hours ago"
+                else
+                  if days < 7
+                    then toText (show @Text days) <> " days ago"
+                    else toText $ formatTime defaultTimeLocale "%b %d, %Y" commitTime
+
+{- |
+Format a UTC timestamp for display with local timezone conversion.
+
+Returns a tuple of (formatted display text, full UTC timestamp string).
+The formatted text shows seconds precision in local time, while the full timestamp
+provides complete UTC information suitable for tooltips.
+
+Example: ("2025-09-09 14:30:45", "2025-09-09 21:30:45.123456789 UTC")
+-}
+formatTimestamp :: (MonadIO m) => UTCTime -> m (Text, Text)
+formatTimestamp utcTime = do
+  tz <- liftIO $ getTimeZone utcTime
+  let localTime = utcToLocalTime tz utcTime
+      formatted = toText $ formatTime defaultTimeLocale "%Y-%m-%d %H:%M:%S" localTime
+      fullTimestamp = show @Text utcTime
+  pure (formatted, fullTimestamp)

--- a/packages/vira/src/Vira/Page/BranchPage.hs
+++ b/packages/vira/src/Vira/Page/BranchPage.hs
@@ -113,7 +113,7 @@ viewCommitTimeline branch jobs = do
 
           -- Column 3: Build duration and status (4 columns)
           div_ [class_ "col-span-4 flex items-center justify-end space-x-2"] $ do
-            -- Build duration placeholder
-            span_ [class_ "text-xs text-gray-500 bg-gray-100 px-2 py-1 rounded"] "?m ??s"
+            -- Build duration
+            Status.viraJobDuration_ job
             -- Status badge
             Status.viraStatusBadge_ job.jobStatus

--- a/packages/vira/src/Vira/Page/BranchPage.hs
+++ b/packages/vira/src/Vira/Page/BranchPage.hs
@@ -2,6 +2,7 @@
 
 module Vira.Page.BranchPage where
 
+import Data.Time (diffUTCTime)
 import Effectful.Error.Static (throwError)
 import Effectful.Git (BranchName)
 import Htmx.Lucid.Core (hxSwapS_)
@@ -22,6 +23,7 @@ import Vira.Widgets.Button qualified as W
 import Vira.Widgets.Code qualified as W
 import Vira.Widgets.Layout qualified as W
 import Vira.Widgets.Status qualified as Status
+import Vira.Widgets.Time qualified as Time
 import Web.TablerIcons.Outline qualified as Icon
 import Prelude hiding (ask, asks)
 
@@ -114,6 +116,10 @@ viewCommitTimeline branch jobs = do
           -- Column 3: Build duration and status (4 columns)
           div_ [class_ "col-span-4 flex items-center justify-end space-x-2"] $ do
             -- Build duration
-            Status.viraJobDuration_ job
+            case St.jobEndTime job of
+              Just endTime -> do
+                let duration = diffUTCTime endTime job.jobCreatedTime
+                Time.viraDuration_ duration
+              Nothing -> mempty
             -- Status badge
             Status.viraStatusBadge_ job.jobStatus

--- a/packages/vira/src/Vira/Page/JobLog.hs
+++ b/packages/vira/src/Vira/Page/JobLog.hs
@@ -44,7 +44,7 @@ rawLogHandler jobId = do
 
 view :: Job -> AppHtml ()
 view job = do
-  let jobActive = job.jobStatus == St.JobRunning || job.jobStatus == St.JobPending
+  let jobActive = St.jobIsActive job
   if jobActive
     then Log.viewStream job
     else viewStaticLog job

--- a/packages/vira/src/Vira/Page/JobPage.hs
+++ b/packages/vira/src/Vira/Page/JobPage.hs
@@ -143,7 +143,11 @@ viewJob job = do
             Nothing ->
               div_ [class_ "flex items-center space-x-2"] $ do
                 span_ [class_ "font-medium"] "Status:"
-                span_ [class_ "text-gray-500"] "In progress"
+                case job.jobStatus of
+                  St.JobStale -> span_ [class_ "text-gray-500"] "Stale"
+                  St.JobPending -> span_ [class_ "text-gray-500"] "In progress"
+                  St.JobRunning -> span_ [class_ "text-gray-500"] "In progress"
+                  St.JobFinished {} -> span_ [class_ "text-gray-500"] "In progress" -- Should not happen due to outer case
 
     -- Job logs
     W.viraCard_ [class_ "p-6"] $ do

--- a/packages/vira/src/Vira/Page/JobPage.hs
+++ b/packages/vira/src/Vira/Page/JobPage.hs
@@ -126,7 +126,7 @@ viewJob job = do
           div_ [class_ "flex items-center space-x-2"] $ do
             span_ [class_ "font-medium"] "Started:"
             Time.viraUTCTime_ job.jobCreatedTime
-          case St.jobFinishedDuration job of
+          case St.jobEndTime job of
             Just endTime -> do
               div_ [class_ "flex items-center space-x-2"] $ do
                 span_ [class_ "font-medium"] "Finished:"

--- a/packages/vira/src/Vira/Page/RepoPage.hs
+++ b/packages/vira/src/Vira/Page/RepoPage.hs
@@ -5,6 +5,7 @@ module Vira.Page.RepoPage (
   handlers,
 ) where
 
+import Data.Time (diffUTCTime)
 import Effectful (Eff)
 import Effectful.Error.Static (throwError)
 import Effectful.Git qualified as Git
@@ -28,6 +29,7 @@ import Vira.Widgets.Code qualified as W
 import Vira.Widgets.Form qualified as W
 import Vira.Widgets.Layout qualified as W
 import Vira.Widgets.Status qualified as Status
+import Vira.Widgets.Time qualified as Time
 import Web.TablerIcons.Outline qualified as Icon
 import Prelude hiding (ask, asks)
 
@@ -187,7 +189,11 @@ viewBranchListing repo branches = do
               Just latestJob -> do
                 jobs <- lift $ App.query $ St.GetJobsByBranchA repo.name branch.branchName
                 div_ [class_ "flex items-center space-x-2 text-xs text-gray-500"] $ do
-                  Status.viraJobDuration_ latestJob
+                  case St.jobEndTime latestJob of
+                    Just endTime -> do
+                      let duration = diffUTCTime endTime latestJob.jobCreatedTime
+                      Time.viraDuration_ duration
+                    Nothing -> mempty
                   span_ $ "#" <> toHtml (show @Text latestJob.jobId)
                   span_ $ "(" <> toHtml (show @Text (length jobs)) <> ")"
               Nothing ->

--- a/packages/vira/src/Vira/Page/RepoPage.hs
+++ b/packages/vira/src/Vira/Page/RepoPage.hs
@@ -187,7 +187,7 @@ viewBranchListing repo branches = do
               Just latestJob -> do
                 jobs <- lift $ App.query $ St.GetJobsByBranchA repo.name branch.branchName
                 div_ [class_ "flex items-center space-x-2 text-xs text-gray-500"] $ do
-                  span_ [class_ "bg-gray-100 px-2 py-1 rounded"] "?m ??s"
+                  Status.viraJobDuration_ latestJob
                   span_ $ "#" <> toHtml (show @Text latestJob.jobId)
                   span_ $ "(" <> toHtml (show @Text (length jobs)) <> ")"
               Nothing ->

--- a/packages/vira/src/Vira/State/Core.hs
+++ b/packages/vira/src/Vira/State/Core.hs
@@ -7,7 +7,7 @@ module Vira.State.Core (
   JobStatus (..),
   JobResult (..),
   jobIsActive,
-  jobFinishedDuration,
+  jobEndTime,
 
   -- * App initialization
   openViraState,

--- a/packages/vira/src/Vira/State/Core.hs
+++ b/packages/vira/src/Vira/State/Core.hs
@@ -6,6 +6,8 @@ module Vira.State.Core (
   Job (..),
   JobStatus (..),
   JobResult (..),
+  jobIsActive,
+  jobFinishedDuration,
 
   -- * App initialization
   openViraState,

--- a/packages/vira/src/Vira/State/Type.hs
+++ b/packages/vira/src/Vira/State/Type.hs
@@ -170,8 +170,8 @@ jobIsActive job = case jobStatus job of
   JobStale -> False
 
 -- | Get the end time for finished jobs only
-jobFinishedDuration :: Job -> Maybe UTCTime
-jobFinishedDuration job = case jobStatus job of
+jobEndTime :: Job -> Maybe UTCTime
+jobEndTime job = case jobStatus job of
   JobFinished _ endTime -> Just endTime
   _ -> Nothing
 

--- a/packages/vira/src/Vira/State/Type.hs
+++ b/packages/vira/src/Vira/State/Type.hs
@@ -8,6 +8,7 @@ import Data.Aeson (FromJSON, FromJSONKey, ToJSON, ToJSONKey)
 import Data.Data (Data)
 import Data.IxSet.Typed
 import Data.SafeCopy
+import Data.Time (UTCTime)
 import Effectful.Git (BranchName, CommitID)
 import Servant.API (FromHttpApiData, ToHttpApiData)
 import Vira.Lib.Attic
@@ -133,6 +134,8 @@ data Job = Job
   -- ^ The working directory of the job
   , jobStatus :: JobStatus
   -- ^ The status of the job
+  , jobCreatedTime :: UTCTime
+  -- ^ When the job was created
   }
   deriving stock (Generic, Show, Typeable, Data, Eq, Ord)
 
@@ -151,12 +154,26 @@ instance Indexable JobIxs Job where
 data JobStatus
   = JobPending
   | JobRunning
-  | JobFinished JobResult
-  | JobKilled
+  | JobFinished JobResult UTCTime
+  | JobStale
   deriving stock (Generic, Show, Typeable, Data, Eq, Ord)
 
-data JobResult = JobSuccess | JobFailure
+data JobResult = JobSuccess | JobFailure | JobKilled
   deriving stock (Generic, Show, Typeable, Data, Eq, Ord)
+
+-- | Check if a job is currently active (pending or running)
+jobIsActive :: Job -> Bool
+jobIsActive job = case jobStatus job of
+  JobPending -> True
+  JobRunning -> True
+  JobFinished _ _ -> False
+  JobStale -> False
+
+-- | Get the end time for finished jobs only
+jobFinishedDuration :: Job -> Maybe UTCTime
+jobFinishedDuration job = case jobStatus job of
+  JobFinished _ endTime -> Just endTime
+  _ -> Nothing
 
 $(deriveSafeCopy 0 'base ''JobResult)
 $(deriveSafeCopy 0 'base ''JobStatus)

--- a/packages/vira/src/Vira/Widgets/Code.hs
+++ b/packages/vira/src/Vira/Widgets/Code.hs
@@ -31,10 +31,11 @@ module Vira.Widgets.Code (
 ) where
 
 import Data.Text qualified as T
-import Data.Time (UTCTime, defaultTimeLocale, diffUTCTime, formatTime, getCurrentTime)
+import Data.Time (defaultTimeLocale, formatTime, getCurrentTime)
 import Effectful.Git qualified as Git
 import Lucid
 import Vira.App qualified
+import Vira.Lib.TimeExtra (formatRelativeTime)
 import Vira.State.Acid qualified
 
 {- |
@@ -139,26 +140,6 @@ viraCommitInfoCompact_ commitId = do
             formatRelativeTime now commit.commitDate
       Nothing -> do
         span_ [class_ "text-xs text-red-600"] "Commit not found"
-
--- Helper function to format relative time
-formatRelativeTime :: UTCTime -> UTCTime -> Text
-formatRelativeTime now commitTime =
-  let diffSeconds = round $ diffUTCTime now commitTime :: Integer
-      minutes = diffSeconds `div` 60
-      hours = minutes `div` 60
-      days = hours `div` 24
-   in if diffSeconds < 60
-        then "just now"
-        else
-          if minutes < 60
-            then toText (show @Text minutes) <> " minutes ago"
-            else
-              if hours < 24
-                then toText (show @Text hours) <> " hours ago"
-                else
-                  if days < 7
-                    then toText (show @Text days) <> " days ago"
-                    else toText $ formatTime defaultTimeLocale "%b %d, %Y" commitTime
 
 {- |
 Clickable commit hash component with copy functionality.

--- a/packages/vira/src/Vira/Widgets/Status.hs
+++ b/packages/vira/src/Vira/Widgets/Status.hs
@@ -28,15 +28,12 @@ module Vira.Widgets.Status (
   viewAllJobStatus,
   indicator,
   statusLabel,
-  viraJobDuration_,
 ) where
 
-import Data.Time (diffUTCTime)
 import Lucid
 import Vira.App.AcidState qualified as App
 import Vira.App.LinkTo.Type qualified as LinkTo
 import Vira.App.Lucid (AppHtml, getLinkUrl)
-import Vira.Lib.TimeExtra (formatDuration)
 import Vira.State.Acid qualified as Acid
 import Vira.State.Core qualified as St
 import Vira.State.Type
@@ -124,18 +121,3 @@ indicator active = do
           else (Icon.circle, "text-gray-500")
   div_ [class_ $ "w-4 h-4 flex items-center justify-center " <> classes] $
     toHtmlRaw iconSvg
-
-{- |
-Display job duration for finished jobs only.
-
-Shows actual duration for completed jobs, nothing for pending/running/stale jobs.
--}
-viraJobDuration_ :: (Monad m) => Job -> HtmlT m ()
-viraJobDuration_ job = do
-  case jobFinishedDuration job of
-    Just endTime -> do
-      let duration = diffUTCTime endTime (jobCreatedTime job)
-      span_ [class_ "text-xs text-gray-500 bg-gray-100 px-2 py-1 rounded"] $
-        toHtml $
-          formatDuration duration
-    Nothing -> mempty -- Don't display anything for non-finished jobs

--- a/packages/vira/src/Vira/Widgets/Status.hs
+++ b/packages/vira/src/Vira/Widgets/Status.hs
@@ -28,8 +28,11 @@ module Vira.Widgets.Status (
   viewAllJobStatus,
   indicator,
   statusLabel,
+  viraJobDuration_,
 ) where
 
+import Data.Time (NominalDiffTime, diffUTCTime)
+import Data.Time.Clock (nominalDiffTimeToSeconds)
 import Lucid
 import Vira.App.AcidState qualified as App
 import Vira.App.LinkTo.Type qualified as LinkTo
@@ -80,9 +83,10 @@ statusLabel :: St.JobStatus -> Text
 statusLabel = \case
   St.JobRunning -> "Running"
   St.JobPending -> "Pending"
-  St.JobFinished St.JobSuccess -> "Success"
-  St.JobFinished St.JobFailure -> "Failed"
-  St.JobKilled -> "Killed"
+  St.JobFinished St.JobSuccess _ -> "Success"
+  St.JobFinished St.JobFailure _ -> "Failed"
+  St.JobFinished St.JobKilled _ -> "Killed"
+  St.JobStale -> "Stale"
 
 viraStatusBadge_ :: (Monad m) => St.JobStatus -> HtmlT m ()
 viraStatusBadge_ jobStatus = do
@@ -90,9 +94,10 @@ viraStatusBadge_ jobStatus = do
       (colorClass, iconSvg, iconClass) = case jobStatus of
         St.JobRunning -> ("bg-blue-100 text-blue-800 border-blue-200", Icon.loader_2, "animate-spin")
         St.JobPending -> ("bg-yellow-100 text-yellow-800 border-yellow-200", Icon.clock, "")
-        St.JobFinished St.JobSuccess -> ("bg-green-100 text-green-800 border-green-200", Icon.check, "")
-        St.JobFinished St.JobFailure -> ("bg-red-100 text-red-800 border-red-200", Icon.x, "")
-        St.JobKilled -> ("bg-red-200 text-red-900 border-red-300", Icon.ban, "")
+        St.JobFinished St.JobSuccess _ -> ("bg-green-100 text-green-800 border-green-200", Icon.check, "")
+        St.JobFinished St.JobFailure _ -> ("bg-red-100 text-red-800 border-red-200", Icon.x, "")
+        St.JobFinished St.JobKilled _ -> ("bg-red-200 text-red-900 border-red-300", Icon.ban, "")
+        St.JobStale -> ("bg-gray-200 text-gray-800 border-gray-300", Icon.clock_off, "")
   span_ [class_ $ "inline-flex items-center px-3 py-1 rounded-full text-sm font-medium " <> colorClass] $ do
     div_ [class_ $ "w-4 h-4 mr-2 flex items-center justify-center " <> iconClass] $ toHtmlRaw iconSvg
     toHtml label
@@ -119,3 +124,30 @@ indicator active = do
           else (Icon.circle, "text-gray-500")
   div_ [class_ $ "w-4 h-4 flex items-center justify-center " <> classes] $
     toHtmlRaw iconSvg
+
+{- |
+Display job duration for finished jobs only.
+
+Shows actual duration for completed jobs, nothing for pending/running/stale jobs.
+-}
+viraJobDuration_ :: (Monad m) => Job -> HtmlT m ()
+viraJobDuration_ job = do
+  case jobFinishedDuration job of
+    Just endTime -> do
+      let duration = diffUTCTime endTime (jobCreatedTime job)
+      span_ [class_ "text-xs text-gray-500 bg-gray-100 px-2 py-1 rounded"] $
+        toHtml $
+          formatDuration duration
+    Nothing -> mempty -- Don't display anything for non-finished jobs
+  where
+    -- \| Format duration for display (e.g., "2m 34s", "1h 15m 30s")
+    formatDuration :: NominalDiffTime -> Text
+    formatDuration diffTime =
+      let totalSeconds = floor $ nominalDiffTimeToSeconds diffTime :: Int
+          hours = totalSeconds `div` 3600
+          minutes = (totalSeconds `mod` 3600) `div` 60
+          seconds = totalSeconds `mod` 60
+       in case (hours, minutes, seconds) of
+            (0, 0, s) -> show s <> "s"
+            (0, m, s) -> show m <> "m " <> show s <> "s"
+            (h, m, s) -> show h <> "h " <> show m <> "m " <> show s <> "s"

--- a/packages/vira/src/Vira/Widgets/Status.hs
+++ b/packages/vira/src/Vira/Widgets/Status.hs
@@ -31,12 +31,12 @@ module Vira.Widgets.Status (
   viraJobDuration_,
 ) where
 
-import Data.Time (NominalDiffTime, diffUTCTime)
-import Data.Time.Clock (nominalDiffTimeToSeconds)
+import Data.Time (diffUTCTime)
 import Lucid
 import Vira.App.AcidState qualified as App
 import Vira.App.LinkTo.Type qualified as LinkTo
 import Vira.App.Lucid (AppHtml, getLinkUrl)
+import Vira.Lib.TimeExtra (formatDuration)
 import Vira.State.Acid qualified as Acid
 import Vira.State.Core qualified as St
 import Vira.State.Type
@@ -139,15 +139,3 @@ viraJobDuration_ job = do
         toHtml $
           formatDuration duration
     Nothing -> mempty -- Don't display anything for non-finished jobs
-  where
-    -- \| Format duration for display (e.g., "2m 34s", "1h 15m 30s")
-    formatDuration :: NominalDiffTime -> Text
-    formatDuration diffTime =
-      let totalSeconds = floor $ nominalDiffTimeToSeconds diffTime :: Int
-          hours = totalSeconds `div` 3600
-          minutes = (totalSeconds `mod` 3600) `div` 60
-          seconds = totalSeconds `mod` 60
-       in case (hours, minutes, seconds) of
-            (0, 0, s) -> show s <> "s"
-            (0, m, s) -> show m <> "m " <> show s <> "s"
-            (h, m, s) -> show h <> "h " <> show m <> "m " <> show s <> "s"

--- a/packages/vira/src/Vira/Widgets/Time.hs
+++ b/packages/vira/src/Vira/Widgets/Time.hs
@@ -1,0 +1,54 @@
+{- |
+Vira Design System - Time Display Components
+
+This module contains time display components for the Vira CI/CD application.
+All components follow the Vira Design System guidelines defined in DESIGN.md.
+
+= Component Categories
+
+== Time Display Components
+- 'viraUTCTime_' - UTC timestamp with local timezone display and full precision tooltip
+
+= Usage Guidelines
+
+Use these components for displaying timestamps, durations, and time-related information.
+Always prefer these components over raw HTML to maintain design consistency.
+
+= Design Principles
+
+- Local Timezone Display: Shows user-friendly local time
+- Full Precision Tooltips: Complete UTC information on hover
+- Accessibility: Proper cursor hints and semantic markup
+- Consistency: Standardized time formatting across the application
+-}
+module Vira.Widgets.Time (
+  viraUTCTime_,
+) where
+
+import Data.Time (UTCTime)
+import Lucid
+import Vira.App.Lucid (AppHtml)
+import Vira.Lib.TimeExtra (formatTimestamp)
+
+{- |
+UTC timestamp display component with local timezone conversion.
+
+Displays a UTC timestamp in user-friendly local time format with seconds precision.
+Shows the full UTC timestamp with complete precision in a tooltip on hover.
+
+Example usage:
+@
+viraUTCTime_ someTimestamp
+@
+
+This renders as local time like "2025-09-09 14:30:45" with a tooltip showing
+the full UTC timestamp "2025-09-09 21:30:45.123456789 UTC".
+-}
+viraUTCTime_ :: UTCTime -> AppHtml ()
+viraUTCTime_ utcTime = do
+  (formatted, fullTimestamp) <- formatTimestamp utcTime
+  span_
+    [ class_ "text-sm text-gray-900 cursor-help"
+    , title_ fullTimestamp
+    ]
+    $ toHtml formatted

--- a/packages/vira/src/Vira/Widgets/Time.hs
+++ b/packages/vira/src/Vira/Widgets/Time.hs
@@ -1,49 +1,15 @@
-{- |
-Vira Design System - Time Display Components
-
-This module contains time display components for the Vira CI/CD application.
-All components follow the Vira Design System guidelines defined in DESIGN.md.
-
-= Component Categories
-
-== Time Display Components
-- 'viraUTCTime_' - UTC timestamp with local timezone display and full precision tooltip
-
-= Usage Guidelines
-
-Use these components for displaying timestamps, durations, and time-related information.
-Always prefer these components over raw HTML to maintain design consistency.
-
-= Design Principles
-
-- Local Timezone Display: Shows user-friendly local time
-- Full Precision Tooltips: Complete UTC information on hover
-- Accessibility: Proper cursor hints and semantic markup
-- Consistency: Standardized time formatting across the application
--}
+-- | Time display components
 module Vira.Widgets.Time (
   viraUTCTime_,
+  viraDuration_,
 ) where
 
-import Data.Time (UTCTime)
+import Data.Time (NominalDiffTime, UTCTime)
 import Lucid
 import Vira.App.Lucid (AppHtml)
-import Vira.Lib.TimeExtra (formatTimestamp)
+import Vira.Lib.TimeExtra (formatDuration, formatTimestamp)
 
-{- |
-UTC timestamp display component with local timezone conversion.
-
-Displays a UTC timestamp in user-friendly local time format with seconds precision.
-Shows the full UTC timestamp with complete precision in a tooltip on hover.
-
-Example usage:
-@
-viraUTCTime_ someTimestamp
-@
-
-This renders as local time like "2025-09-09 14:30:45" with a tooltip showing
-the full UTC timestamp "2025-09-09 21:30:45.123456789 UTC".
--}
+-- | UTC timestamp with local timezone display and tooltip
 viraUTCTime_ :: UTCTime -> AppHtml ()
 viraUTCTime_ utcTime = do
   (formatted, fullTimestamp) <- formatTimestamp utcTime
@@ -52,3 +18,10 @@ viraUTCTime_ utcTime = do
     , title_ fullTimestamp
     ]
     $ toHtml formatted
+
+-- | Duration badge component
+viraDuration_ :: NominalDiffTime -> AppHtml ()
+viraDuration_ duration = do
+  span_ [class_ "text-xs text-gray-500 bg-gray-100 px-2 py-1 rounded"] $
+    toHtml $
+      formatDuration duration

--- a/packages/vira/static/tailwind.css
+++ b/packages/vira/static/tailwind.css
@@ -605,6 +605,10 @@
     border-top-style: var(--tw-border-style);
     border-top-width: 0px;
   }
+  .border-b {
+    border-bottom-style: var(--tw-border-style);
+    border-bottom-width: 1px;
+  }
   .border-b-0 {
     border-bottom-style: var(--tw-border-style);
     border-bottom-width: 0px;
@@ -615,6 +619,9 @@
   }
   .border-blue-200 {
     border-color: var(--color-blue-200);
+  }
+  .border-gray-100 {
+    border-color: var(--color-gray-100);
   }
   .border-gray-200 {
     border-color: var(--color-gray-200);

--- a/packages/vira/static/tailwind.css
+++ b/packages/vira/static/tailwind.css
@@ -547,6 +547,13 @@
       margin-inline-end: calc(calc(var(--spacing) * 4) * calc(1 - var(--tw-space-x-reverse)));
     }
   }
+  .space-x-6 {
+    :where(& > :not(:last-child)) {
+      --tw-space-x-reverse: 0;
+      margin-inline-start: calc(calc(var(--spacing) * 6) * var(--tw-space-x-reverse));
+      margin-inline-end: calc(calc(var(--spacing) * 6) * calc(1 - var(--tw-space-x-reverse)));
+    }
+  }
   .truncate {
     overflow: hidden;
     text-overflow: ellipsis;
@@ -605,10 +612,6 @@
     border-top-style: var(--tw-border-style);
     border-top-width: 0px;
   }
-  .border-b {
-    border-bottom-style: var(--tw-border-style);
-    border-bottom-width: 1px;
-  }
   .border-b-0 {
     border-bottom-style: var(--tw-border-style);
     border-bottom-width: 0px;
@@ -619,9 +622,6 @@
   }
   .border-blue-200 {
     border-color: var(--color-blue-200);
-  }
-  .border-gray-100 {
-    border-color: var(--color-gray-100);
   }
   .border-gray-200 {
     border-color: var(--color-gray-200);
@@ -754,6 +754,9 @@
   }
   .py-16 {
     padding-block: calc(var(--spacing) * 16);
+  }
+  .pt-3 {
+    padding-top: calc(var(--spacing) * 3);
   }
   .pt-4 {
     padding-top: calc(var(--spacing) * 4);

--- a/packages/vira/vira.cabal
+++ b/packages/vira/vira.cabal
@@ -43,6 +43,7 @@ library
       Vira.Lib.Omnix
       Vira.Lib.Process
       Vira.Lib.STM
+      Vira.Lib.TimeExtra
       Vira.Page.BranchPage
       Vira.Page.IndexPage
       Vira.Page.JobLog
@@ -67,6 +68,7 @@ library
       Vira.Widgets.Form
       Vira.Widgets.Layout
       Vira.Widgets.Status
+      Vira.Widgets.Time
   other-modules:
       Paths_vira
   autogen-modules:


### PR DESCRIPTION
Show how long it took for a job to finish, after tracking in acid-state.

Also introduce `Stale` status (vira restarted/crashed mid-way) to distinguish from `Killed` (user explicitly killing it).

## Screenshots

<img width="1213" height="986" alt="image" src="https://github.com/user-attachments/assets/cf9c8a57-114c-4cb0-8e8e-b31fd7ff8479" />

<img width="1213" height="986" alt="image" src="https://github.com/user-attachments/assets/9db1f5cc-67a6-4e38-b6de-2847a276185f" />
