### PR TITLE
Update haskell-flake; 2 other inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,14 +1,7 @@
 {
   "nodes": {
     "co-log-effectful": {
-      "inputs": {
-        "devshell": "devshell",
-        "flake-parts": "flake-parts",
-        "haskell-flake": "haskell-flake",
-        "nixpkgs": "nixpkgs",
-        "pre-commit-hooks-nix": "pre-commit-hooks-nix",
-        "treefmt-nix": "treefmt-nix"
-      },
+      "flake": false,
       "locked": {
         "lastModified": 1738358259,
         "narHash": "sha256-V+JiNh+GY4OC+uEp4AeX6wYMzsj5JJAqnrraXn1T8kg=",
@@ -23,65 +16,7 @@
         "type": "github"
       }
     },
-    "devshell": {
-      "inputs": {
-        "nixpkgs": [
-          "co-log-effectful",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1735644329,
-        "narHash": "sha256-tO3HrHriyLvipc4xr+Ewtdlo7wM1OjXNjlWRgmM7peY=",
-        "owner": "numtide",
-        "repo": "devshell",
-        "rev": "f7795ede5b02664b57035b3b757876703e2c3eac",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "devshell",
-        "type": "github"
-      }
-    },
-    "flake-compat": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
     "flake-parts": {
-      "inputs": {
-        "nixpkgs-lib": [
-          "co-log-effectful",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1736143030,
-        "narHash": "sha256-+hu54pAoLDEZT9pjHlqL9DNzWz0NbUn8NEAHP7PQPzU=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "b905f6fc23a9051a6e1b741e1438dbfc0634c6de",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
-    "flake-parts_2": {
       "inputs": {
         "nixpkgs-lib": [
           "nixpkgs"
@@ -119,64 +54,26 @@
     "git-hooks": {
       "flake": false,
       "locked": {
-        "lastModified": 1748731770,
-        "narHash": "sha256-++eAISyF3JzxbTBg3RnjVtB1Sgh1K5cTTDT2giG916Y=",
+        "lastModified": 1748731907,
+        "narHash": "sha256-KVgK2PB1h5RNhHJzGn090XcW1i9Mq0FVh6qTVKsg2RU=",
         "owner": "bmrips",
         "repo": "git-hooks.nix",
-        "rev": "6007ee9515d68f90df845e831456a646725a7288",
+        "rev": "2749fc9197fd12231746ef685225eaf85fe087fd",
         "type": "github"
       },
       "original": {
         "owner": "bmrips",
-        "ref": "typos-improvements",
         "repo": "git-hooks.nix",
-        "type": "github"
-      }
-    },
-    "gitignore": {
-      "inputs": {
-        "nixpkgs": [
-          "co-log-effectful",
-          "pre-commit-hooks-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
         "type": "github"
       }
     },
     "haskell-flake": {
       "locked": {
-        "lastModified": 1737903979,
-        "narHash": "sha256-NL9+FkAzmU/zVy7EQUj13s/+FjX2Mcz6ID7dW1j32Xg=",
+        "lastModified": 1757958175,
+        "narHash": "sha256-5JZMbyhI5qUTYDTpbJ1Tb7mmIcjXKd2gSTs75dMOWMk=",
         "owner": "srid",
         "repo": "haskell-flake",
-        "rev": "3bc6fe9793bf1239a335f9439f0be66c964df1a3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "repo": "haskell-flake",
-        "type": "github"
-      }
-    },
-    "haskell-flake_2": {
-      "locked": {
-        "lastModified": 1756607542,
-        "narHash": "sha256-+99fEAk0HwjYgIW2tEOs7ayBDxnU9NAM5E29ZxgyX40=",
-        "owner": "srid",
-        "repo": "haskell-flake",
-        "rev": "73e3891fb135c679a1c30fae4b101e5b41b8ca61",
+        "rev": "6df12c6bbf5af89edea64184a62d08db9c92d43d",
         "type": "github"
       },
       "original": {
@@ -235,22 +132,6 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1738264807,
-        "narHash": "sha256-6x6WLFwoLdR3w3FYtCnLye2Xe32SqsL7Zf0jpa5wJMM=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "93f6e8d16bc5653505d0165ccec7b667690f7071",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "haskell-updates",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
         "lastModified": 1756696532,
         "narHash": "sha256-6FWagzm0b7I/IGigOv9pr6LL7NQ86mextfE8g8Q6HBg=",
         "owner": "nixos",
@@ -262,29 +143,6 @@
         "owner": "nixos",
         "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "pre-commit-hooks-nix": {
-      "inputs": {
-        "flake-compat": "flake-compat",
-        "gitignore": "gitignore",
-        "nixpkgs": [
-          "co-log-effectful",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1737465171,
-        "narHash": "sha256-R10v2hoJRLq8jcL4syVFag7nIGE7m13qO48wRIukWNg=",
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
-        "rev": "9364dc02281ce2d37a1f55b6e51f7c0f65a75f17",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
         "type": "github"
       }
     },
@@ -306,14 +164,14 @@
     "root": {
       "inputs": {
         "co-log-effectful": "co-log-effectful",
-        "flake-parts": "flake-parts_2",
+        "flake-parts": "flake-parts",
         "fourmolu-nix": "fourmolu-nix",
         "git-hooks": "git-hooks",
-        "haskell-flake": "haskell-flake_2",
+        "haskell-flake": "haskell-flake",
         "htmx": "htmx",
         "htmx-extensions": "htmx-extensions",
         "nixos-unified": "nixos-unified",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs",
         "process-compose-flake": "process-compose-flake",
         "servant-event-stream": "servant-event-stream",
         "tabler-icons-hs": "tabler-icons-hs"
@@ -348,27 +206,6 @@
       "original": {
         "owner": "juspay",
         "repo": "tabler-icons-hs",
-        "type": "github"
-      }
-    },
-    "treefmt-nix": {
-      "inputs": {
-        "nixpkgs": [
-          "co-log-effectful",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1738070913,
-        "narHash": "sha256-j6jC12vCFsTGDmY2u1H12lMr62fnclNjuCtAdF1a4Nk=",
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "rev": "bebf27d00f7d10ba75332a0541ac43676985dea3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "treefmt-nix",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
     nixos-unified.url = "github:srid/nixos-unified";
     haskell-flake.url = "github:srid/haskell-flake";
     fourmolu-nix.url = "github:jedimahdi/fourmolu-nix";
-    git-hooks.url = "github:bmrips/git-hooks.nix/typos-improvements"; # https://github.com/cachix/git-hooks.nix/pull/583
+    git-hooks.url = "github:bmrips/git-hooks.nix";
     git-hooks.flake = false;
     process-compose-flake.url = "github:Platonic-Systems/process-compose-flake";
 
@@ -20,6 +20,7 @@
     tabler-icons-hs.url = "github:juspay/tabler-icons-hs";
     tabler-icons-hs.flake = false;
     co-log-effectful.url = "github:eldritch-cookie/co-log-effectful";
+    co-log-effectful.flake = false;
     # https://github.com/bflyblue/servant-event-stream/pull/13
     servant-event-stream.url = "github:bflyblue/servant-event-stream";
     servant-event-stream.flake = false;


### PR DESCRIPTION
Hopefully to help resolve the weird `dosa` CI failure in https://github.com/juspay/vira/actions/runs/17747975456/job/50437247240?pr=155

https://github.com/juspay/vira/pull/155

```
❯ nix flake update git-hooks co-log-effectful haskell-flake warning: Git tree '/home/srid/code/vira' is dirty
downloading
'https://api.github.com/repos/eldritch-cookie/co-log-effectful/commits/HEAD' warning: updating lock file "/home/srid/code/vira/flake.lock": • Removed input 'co-log-effectful/devshell'
• Removed input 'co-log-effectful/devshell/nixpkgs' • Removed input 'co-log-effectful/flake-parts'
• Removed input 'co-log-effectful/flake-parts/nixpkgs-lib' • Removed input 'co-log-effectful/haskell-flake'
• Removed input 'co-log-effectful/nixpkgs'
• Removed input 'co-log-effectful/pre-commit-hooks-nix' • Removed input 'co-log-effectful/pre-commit-hooks-nix/flake-compat' • Removed input 'co-log-effectful/pre-commit-hooks-nix/gitignore' • Removed input
'co-log-effectful/pre-commit-hooks-nix/gitignore/nixpkgs' • Removed input 'co-log-effectful/pre-commit-hooks-nix/nixpkgs' • Removed input 'co-log-effectful/treefmt-nix'
• Removed input 'co-log-effectful/treefmt-nix/nixpkgs' • Updated input 'haskell-flake':

'github:srid/haskell-flake/73e3891fb135c679a1c30fae4b101e5b41b8ca61?narHash=sha256-%2B99fEAk0HwjYgIW2tEOs7ayBDxnU9NAM5E29ZxgyX40%3D' (2025-08-31)
  →
'github:srid/haskell-flake/6df12c6bbf5af89edea64184a62d08db9c92d43d?narHash=sha256-5JZMbyhI5qUTYDTpbJ1Tb7mmIcjXKd2gSTs75dMOWMk%3D' (2025-09-15)
```