### PR TITLE
git: Use `--filter=blob:none` when refreshing branches

### DIFF
--- a/packages/git-effectful/src/Effectful/Git.hs
+++ b/packages/git-effectful/src/Effectful/Git.hs
@@ -157,7 +157,9 @@ cloneForMetadata url =
     git
     [ "clone"
     , "-v"
-    , "--filter=blob:none" -- We don't need file contents
+    , -- Download all reachable commits and trees while fetching blobs on-demand
+      -- https://github.blog/open-source/git/get-up-to-speed-with-partial-clone-and-shallow-clone/
+      "--filter=blob:none"
     , "--depth"
     , "1"
     , "--no-single-branch"


### PR DESCRIPTION
From https://github.blog/open-source/git/get-up-to-speed-with-partial-clone-and-shallow-clone/

> `git clone --filter=blob:none <url>` creates a _blobless clone_. These clones download all reachable commits and trees while fetching blobs on-demand. These clones are best for developers and build environments that span multiple builds.

Resolves #159 