### PR TITLE
home-manager: Make launchd config work with private repos

### DIFF
--- a/nix/modules/home-manager/vira.nix
+++ b/nix/modules/home-manager/vira.nix
@@ -68,9 +68,16 @@ in
         ProcessType = "Background";
         StandardOutPath = "${config.home.homeDirectory}/Library/Logs/vira.log";
         StandardErrorPath = "${config.home.homeDirectory}/Library/Logs/vira.log";
-        EnvironmentVariables = {
-          PATH = "${makeBinPath cfg.extraPackages}:${config.home.sessionVariables.PATH or ""}";
-        };
+        EnvironmentVariables.PATH =
+          let
+            # Extra packages needed for the launchd agent to work with private repos
+            # TODO: Move it to top-level (if needed) after testing the systemd home-manager module
+            packagesForPrivateRepos = with pkgs; [
+              openssh
+              git
+            ];
+          in
+          makeBinPath (cfg.extraPackages ++ packagesForPrivateRepos);
       };
     };
 


### PR DESCRIPTION
Git fails to clone private repos with SSH url if `openssh` is not in PATH:
```sh
Cloning into '.'...
error: cannot run ssh: No such file or directory
fatal: unable to fork
```

Nix fails with the following error if `git` is not in PATH:
```sh
error: executing 'git': No such file or directory
error:
       … while calling the 'derivationStrict' builtin
         at <nix/derivation-internal.nix>:34:12:
           33|
           34|   strict = derivationStrict drvAttrs;
             |            ^
           35|

       … while evaluating derivation 'devour-output.json'
         whose name attribute is located at
/nix/store/qjqzr7905xxv3rv70z7mkpp06lalnzzb-source/pkgs/stdenv/generic/make-derivation.nix:300:7

       … while evaluating attribute 'text' of derivation
'devour-output.json'
         at
/nix/store/qjqzr7905xxv3rv70z7mkpp06lalnzzb-source/pkgs/build-support/trivial-builders/default.nix:148:17:
          147|     runCommand name
          148|       { inherit text executable checkPhase
allowSubstitutes preferLocalBuild;
             |                 ^
          149|         passAsFile = [ "text" ];

       … while evaluating definitions from
`/nix/store/s6agnzjr3kg5sayjy0b0ms52bkvifqrv-source/modules/transposition.nix':

       … while evaluating the option `perSystem.aarch64-darwin.checks':

       … while evaluating definitions from
`/nix/store/rs6a9x7h07k5zmg6nfp47v62c12qni74-source/nix/flake-module.nix':

       (stack trace truncated; use '--show-trace' to show the full,
detailed trace)

       error: Cannot find Git revision
'517ffcf57a02a94bad8aca277a10b1faff9a42c1' in ref 'staging' of
repository 'ssh://git@foo.net/prj/repo'! Please make sure that the rev
exists on the ref you've specified or add allRefs = true; to fetchGit.
```