### PR TITLE
Recommend deleting `workspace` dir on state error

### DIFF
--- a/packages/vira/src/Vira/State/Core.hs
+++ b/packages/vira/src/Vira/State/Core.hs
@@ -28,15 +28,14 @@ openViraState stateDir = do
   -- Manually construct the path that openLocalState would use: stateDir </> show (typeOf initialState)
   -- This is just for backwards compat.
   let acidStateDir = stateDir </> show (typeOf initialState)
-  st <- openLocalStateFrom acidStateDir initialState `catch` handleStateError acidStateDir
+  st <- openLocalStateFrom acidStateDir initialState `catch` handleStateError
   update st MarkUnfinishedJobsAsStaleA
   pure st
   where
-    handleStateError acidStateDir (ErrorCall msg) = do
-      let workspaceDir = stateDir </> "workspace"
+    handleStateError (ErrorCall msg) = do
       putStrLn "ERROR: Failed to open acid-state database. This usually indicates incompatible state format."
-      putStrLn "Please remove the state directory and restart:"
-      putStrLn ("  rm -rf " <> acidStateDir <> " " <> workspaceDir)
+      putStrLn "Please remove the vira data directory and restart:"
+      putStrLn ("  rm -rf " <> stateDir)
       putStrLn "Your data will be lost, but this is necessary to continue."
       putStrLn ""
       putStrLn "Original error:"


### PR DESCRIPTION
Otherwise, older workspaces can be used for newer jobs as we [`createDirectoryIfMissing`](https://github.com/juspay/vira/blob/29bcd09a4e1253e319694ea2cfa294bc6a6619a1/packages/vira/src/Vira/Supervisor/Task.hs#L91)