### PR TITLE
`vira.hs`: Nested record update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -177,6 +177,22 @@
         "type": "github"
       }
     },
+    "record-hasfield": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1705829538,
+        "narHash": "sha256-GmPVs+M8LIL3h8QO57yV9e6okczJdpEtzinD8gxCvjQ=",
+        "owner": "ndmitchell",
+        "repo": "record-hasfield",
+        "rev": "093fb013d3e8951a215e0508cda2c24977ef117c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ndmitchell",
+        "repo": "record-hasfield",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "co-log-effectful": "co-log-effectful",
@@ -190,6 +206,7 @@
         "nixos-unified": "nixos-unified",
         "nixpkgs": "nixpkgs",
         "process-compose-flake": "process-compose-flake",
+        "record-hasfield": "record-hasfield",
         "servant-event-stream": "servant-event-stream",
         "tabler-icons-hs": "tabler-icons-hs",
         "warp-tls-simple": "warp-tls-simple"

--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,8 @@
     hint-nix.flake = false;
     warp-tls-simple.url = "github:srid/warp-tls-simple";
     warp-tls-simple.flake = false;
+    record-hasfield.url = "github:ndmitchell/record-hasfield";
+    record-hasfield.flake = false;
 
     # Runtime dependencies
     htmx-extensions.url = "github:juspay/htmx-extensions/sse-unload"; # https://github.com/bigskysoftware/htmx-extensions/pull/147

--- a/nix/modules/flake-parts/haskell.nix
+++ b/nix/modules/flake-parts/haskell.nix
@@ -38,6 +38,7 @@
         co-log-effectful.source = inputs.co-log-effectful;
         tabler-icons.source = inputs.tabler-icons-hs;
         servant-event-stream.source = inputs.servant-event-stream;
+        record-hasfield.source = inputs.record-hasfield;
       };
 
       # Add your package overrides here

--- a/nix/modules/flake-parts/pre-commit.nix
+++ b/nix/modules/flake-parts/pre-commit.nix
@@ -13,7 +13,10 @@
           package = config.fourmolu.wrapper;
           excludes = [ "sample\-configs/.+\.hs" "vira\.hs" ];
         };
-        hlint.enable = true;
+        hlint = {
+          enable = true;
+          excludes = [ "sample\-configs/.+\.hs" "vira\.hs" ];
+        };
         hpack.enable = true;
         prettier.enable = true;
         typos = {

--- a/packages/vira-ci-types/package.yaml
+++ b/packages/vira-ci-types/package.yaml
@@ -33,6 +33,7 @@ dependencies:
   - servant
   - text
   - time
+  - record-hasfield
 
 library:
   source-dirs: src

--- a/packages/vira-ci-types/src/Vira/CI/Context.hs
+++ b/packages/vira-ci-types/src/Vira/CI/Context.hs
@@ -1,10 +1,16 @@
 {-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+
+{-# HLINT ignore "Avoid lambda using `infix`" #-}
+{-# HLINT ignore "Avoid lambda" #-}
 
 module Vira.CI.Context (
   ViraContext (..),
 ) where
 
 import Effectful.Git (BranchName, CommitID)
+import GHC.Records.Compat
 
 {- | Essential context information available in user configurations.
 This is a subset of ViraEnvironment containing only the fields that
@@ -14,3 +20,10 @@ data ViraContext = ViraContext
   { branch :: BranchName
   , commit :: CommitID
   }
+
+-- HasField instances for ViraContext
+instance HasField "branch" ViraContext BranchName where
+  hasField (ViraContext branch commit) = (\x -> ViraContext x commit, branch)
+
+instance HasField "commit" ViraContext CommitID where
+  hasField (ViraContext branch commit) = (\x -> ViraContext branch x, commit)

--- a/packages/vira-ci-types/src/Vira/CI/Pipeline/Type.hs
+++ b/packages/vira-ci-types/src/Vira/CI/Pipeline/Type.hs
@@ -46,28 +46,25 @@ newtype SignoffStage = SignoffStage
   }
   deriving stock (Generic, Show)
 
--- HasField instances for enabling OverloadedRecordUpdate syntax
+-- HasField instances for enabling OverloadedRecordUpdate syntax (see vira.hs)
+-- NOTE: Do not forgot to fill in these instances if the types above change.
+-- In future, we could generically derive them using generics-sop and the like.
 
--- BuildStage field instances
 instance HasField "enable" BuildStage Bool where
   hasField (BuildStage enable overrideInputs) = ((`BuildStage` overrideInputs), enable)
 
 instance HasField "overrideInputs" BuildStage [(Text, Text)] where
   hasField (BuildStage enable overrideInputs) = (BuildStage enable, overrideInputs)
 
--- AtticStage field instances
 instance HasField "enable" AtticStage Bool where
   hasField (AtticStage enable) = (AtticStage, enable)
 
--- CachixStage field instances
 instance HasField "enable" CachixStage Bool where
   hasField (CachixStage enable) = (CachixStage, enable)
 
--- SignoffStage field instances
 instance HasField "enable" SignoffStage Bool where
   hasField (SignoffStage enable) = (SignoffStage, enable)
 
--- ViraPipeline stage instances
 instance HasField "build" ViraPipeline BuildStage where
   hasField (ViraPipeline build attic cachix signoff) = (\x -> ViraPipeline x attic cachix signoff, build)
 

--- a/packages/vira-ci-types/src/Vira/CI/Pipeline/Type.hs
+++ b/packages/vira-ci-types/src/Vira/CI/Pipeline/Type.hs
@@ -77,16 +77,16 @@ instance HasField "enable" SignoffStage Bool where
 
 -- ViraPipeline stage instances
 instance HasField "build" ViraPipeline BuildStage where
-  hasField r = (\x -> r {build = x}, r.build)
+  hasField (ViraPipeline build attic cachix signoff) = (\x -> ViraPipeline x attic cachix signoff, build)
 
 instance HasField "attic" ViraPipeline AtticStage where
-  hasField r = (\x -> r {attic = x}, r.attic)
+  hasField (ViraPipeline build attic cachix signoff) = (\x -> ViraPipeline build x cachix signoff, attic)
 
 instance HasField "cachix" ViraPipeline CachixStage where
-  hasField r = (\x -> r {cachix = x}, r.cachix)
+  hasField (ViraPipeline build attic cachix signoff) = (\x -> ViraPipeline build attic x signoff, cachix)
 
 instance HasField "signoff" ViraPipeline SignoffStage where
-  hasField r = (\x -> r {signoff = x}, r.signoff)
+  hasField (ViraPipeline build attic cachix signoff) = (\x -> ViraPipeline build attic cachix x, signoff)
 
 -- Demo function showing nested field updates for all pipeline stages
 demo :: ViraPipeline -> ViraPipeline

--- a/packages/vira-ci-types/src/Vira/CI/Pipeline/Type.hs
+++ b/packages/vira-ci-types/src/Vira/CI/Pipeline/Type.hs
@@ -1,6 +1,14 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE OverloadedRecordUpdate #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE RebindableSyntax #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE NoFieldSelectors #-}
@@ -8,6 +16,8 @@
 module Vira.CI.Pipeline.Type where
 
 import Optics.TH
+import Relude (Bool (..), Generic, Show, Text)
+import GHC.Records.Compat
 
 -- | CI Pipeline configuration types
 data ViraPipeline = ViraPipeline
@@ -38,6 +48,17 @@ newtype SignoffStage = SignoffStage
   { enable :: Bool
   }
   deriving stock (Generic, Show)
+
+instance HasField "enable" SignoffStage Bool where
+  hasField (SignoffStage enable) = (SignoffStage, enable)
+
+instance HasField "signoff" ViraPipeline SignoffStage where
+   hasField r = (\x -> r{ signoff = x } , r.signoff)
+
+-- TODO: Implement the necessary instances, and demo updating all kinds of nested fields of the pipeline
+demo :: ViraPipeline -> ViraPipeline
+demo r =
+  r {signoff.enable = True}
 
 makeFieldLabelsNoPrefix ''ViraPipeline
 makeFieldLabelsNoPrefix ''BuildStage

--- a/packages/vira-ci-types/src/Vira/CI/Pipeline/Type.hs
+++ b/packages/vira-ci-types/src/Vira/CI/Pipeline/Type.hs
@@ -1,16 +1,9 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE FunctionalDependencies #-}
-{-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE OverloadedLabels #-}
-{-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE OverloadedRecordUpdate #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE RebindableSyntax #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE NoFieldSelectors #-}
 {-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
@@ -21,8 +14,7 @@
 module Vira.CI.Pipeline.Type where
 
 import GHC.Records.Compat
-import Optics.TH
-import Relude (Bool (..), Generic, Show, Text, fromString)
+import Relude (Bool (..), Generic, Show, Text)
 
 -- | CI Pipeline configuration types
 data ViraPipeline = ViraPipeline
@@ -58,10 +50,10 @@ newtype SignoffStage = SignoffStage
 
 -- BuildStage field instances
 instance HasField "enable" BuildStage Bool where
-  hasField (BuildStage enable overrideInputs) = (\x -> BuildStage x overrideInputs, enable)
+  hasField (BuildStage enable overrideInputs) = ((`BuildStage` overrideInputs), enable)
 
 instance HasField "overrideInputs" BuildStage [(Text, Text)] where
-  hasField (BuildStage enable overrideInputs) = (\x -> BuildStage enable x, overrideInputs)
+  hasField (BuildStage enable overrideInputs) = (BuildStage enable, overrideInputs)
 
 -- AtticStage field instances
 instance HasField "enable" AtticStage Bool where
@@ -86,21 +78,4 @@ instance HasField "cachix" ViraPipeline CachixStage where
   hasField (ViraPipeline build attic cachix signoff) = (\x -> ViraPipeline build attic x signoff, cachix)
 
 instance HasField "signoff" ViraPipeline SignoffStage where
-  hasField (ViraPipeline build attic cachix signoff) = (\x -> ViraPipeline build attic cachix x, signoff)
-
--- Demo function showing nested field updates for all pipeline stages
-demo :: ViraPipeline -> ViraPipeline
-demo r =
-  r
-    { signoff.enable = True
-    , build.enable = False
-    , build.overrideInputs = [("input1", "value1"), ("input2", "value2")]
-    , attic.enable = True
-    , cachix.enable = False
-    }
-
-makeFieldLabelsNoPrefix ''ViraPipeline
-makeFieldLabelsNoPrefix ''BuildStage
-makeFieldLabelsNoPrefix ''AtticStage
-makeFieldLabelsNoPrefix ''CachixStage
-makeFieldLabelsNoPrefix ''SignoffStage
+  hasField (ViraPipeline build attic cachix signoff) = (ViraPipeline build attic cachix, signoff)

--- a/packages/vira-ci-types/vira-ci-types.cabal
+++ b/packages/vira-ci-types/vira-ci-types.cabal
@@ -70,6 +70,7 @@ library
     , ixset-typed
     , optics-core
     , optics-th
+    , record-hasfield
     , relude >=1.0
     , safecopy
     , servant

--- a/packages/vira/src/Vira/CI/Configuration.hs
+++ b/packages/vira/src/Vira/CI/Configuration.hs
@@ -26,7 +26,6 @@ applyConfig configContent ctx pipeline = do
       [ Hint.languageExtensions
           Hint.:= [ Hint.OverloadedStrings
                   , Hint.UnknownExtension "OverloadedRecordDot"
-                  , Hint.UnknownExtension "OverloadedLabels"
                   , Hint.UnknownExtension "OverloadedRecordUpdate"
                   , Hint.UnknownExtension "RebindableSyntax"
                   ]
@@ -39,8 +38,7 @@ applyConfig configContent ctx pipeline = do
       , "Vira.CI.Context"
       , "Vira.CI.Pipeline.Type"
       , "Effectful.Git"
-      , -- , "Optics.Core"
-        "GHC.Records.Compat"
+      , "GHC.Records.Compat"
       ]
 
     -- Interpret the configuration code directly as a function

--- a/packages/vira/src/Vira/CI/Configuration.hs
+++ b/packages/vira/src/Vira/CI/Configuration.hs
@@ -22,16 +22,25 @@ applyConfig ::
 applyConfig configContent ctx pipeline = do
   result <- runInterpreterWithNixPackageDb $ do
     -- Set up the interpreter context
-    Hint.set [Hint.languageExtensions Hint.:= [Hint.OverloadedStrings, Hint.UnknownExtension "OverloadedRecordDot", Hint.UnknownExtension "OverloadedLabels"]]
+    Hint.set
+      [ Hint.languageExtensions
+          Hint.:= [ Hint.OverloadedStrings
+                  , Hint.UnknownExtension "OverloadedRecordDot"
+                  , Hint.UnknownExtension "OverloadedLabels"
+                  , Hint.UnknownExtension "OverloadedRecordUpdate"
+                  , Hint.UnknownExtension "RebindableSyntax"
+                  ]
+      ]
 
     -- Import necessary modules
     Hint.setImports
-      [ "Prelude"
+      [ "Relude"
       , "Data.Text"
       , "Vira.CI.Context"
       , "Vira.CI.Pipeline.Type"
       , "Effectful.Git"
-      , "Optics.Core"
+      , -- , "Optics.Core"
+        "GHC.Records.Compat"
       ]
 
     -- Interpret the configuration code directly as a function

--- a/packages/vira/static/test/sample-configs/simple-example.hs
+++ b/packages/vira/static/test/sample-configs/simple-example.hs
@@ -4,6 +4,7 @@
       isRelease = ctx.branch == "release"
       cabalLocal = [("local", "github:boolean-option/false") | isStaging || isRelease]
   in pipeline
-     & #signoff % #enable .~ not isMain
-     & #build % #overrideInputs .~ cabalLocal
-     & #attic % #enable .~ (isMain || isRelease)
+     { signoff.enable = not isMain
+     , build.overrideInputs = cabalLocal
+     , attic.enable = isMain || isRelease
+     }

--- a/vira.hs
+++ b/vira.hs
@@ -2,6 +2,7 @@
 \ctx pipeline ->
   let isMain = ctx.branch == "main"
   in pipeline
-    & #signoff % #enable .~ True
-    & #cachix % #enable .~ False
-    & #attic % #enable .~ isMain
+    { signoff.enable = True
+    , cachix.enable = False
+    , attic.enable = isMain
+    }


### PR DESCRIPTION
Thanks to @shivaraj-bh for pointing me to `OverloadedRecordUpdate` ([GHC docs](https://ghc.gitlab.haskell.org/ghc/doc/users_guide/exts/overloaded_record_update.html)) based on Well-Typed's talk [Haskell records in 2025 (Haskell Unfolder #45)](https://www.youtube.com/live/9hrDm7xDpig?si=waKctLmd5UyXthGU).

The example in GHC documentation actually no longer works, but `HasField` from https://github.com/ndmitchell/record-hasfield does.

Tested on both macOS and Linux.