### PR TITLE
Use `viraRequestButton_` in more places

### DIFF
--- a/packages/vira/src/Vira/Page/BranchPage.hs
+++ b/packages/vira/src/Vira/Page/BranchPage.hs
@@ -5,10 +5,7 @@ module Vira.Page.BranchPage where
 import Data.Time (diffUTCTime)
 import Effectful.Error.Static (throwError)
 import Effectful.Git (BranchName, RepoName)
-import Htmx.Lucid.Core (hxSwapS_)
-import Htmx.Swap (Swap (AfterEnd))
 import Lucid
-import Lucid.Htmx.Contrib (hxPostSafe_)
 import Servant hiding (throwError)
 import Servant.API.ContentTypes.Lucid (HTML)
 import Servant.Server.Generic (AsServer)
@@ -61,12 +58,10 @@ viewBranch repo branch jobs = do
         div_ [class_ "flex items-center gap-2"] $ do
           buildLink <- lift $ App.getLink $ LinkTo.Build repo.name branch.branchName
           updateLink <- lift $ App.getLink $ LinkTo.RepoUpdate repo.name
-          W.viraButton_
+          W.viraRequestButton_
             W.ButtonPrimary
-            [ hxPostSafe_ buildLink
-            , hxSwapS_ AfterEnd
-            , title_ "Build this branch"
-            ]
+            buildLink
+            [title_ "Build this branch"]
             $ do
               W.viraButtonIcon_ $ toHtmlRaw Icon.player_play
               "Build"

--- a/packages/vira/src/Vira/Page/JobPage.hs
+++ b/packages/vira/src/Vira/Page/JobPage.hs
@@ -9,11 +9,8 @@ import Effectful.Error.Static (throwError)
 import Effectful.Git (BranchName, RepoName)
 import Effectful.Reader.Dynamic (asks)
 import GHC.IO.Exception (ExitCode (..))
-import Htmx.Lucid.Core (hxSwapS_)
 import Htmx.Servant.Response
-import Htmx.Swap (Swap (AfterEnd))
 import Lucid
-import Lucid.Htmx.Contrib (hxPostSafe_)
 import Servant hiding (throwError)
 import Servant.API.ContentTypes.Lucid (HTML)
 import Servant.Server.Generic (AsServer)
@@ -100,11 +97,10 @@ viewJob job = do
             viewJobStatus job.jobStatus
             when jobActive $ do
               killLink <- lift $ App.getLink $ LinkTo.Kill job.jobId
-              W.viraButton_
+              W.viraRequestButton_
                 W.ButtonDestructive
-                [ hxPostSafe_ killLink
-                , hxSwapS_ AfterEnd
-                ]
+                killLink
+                [title_ "Kill this job"]
                 $ do
                   W.viraButtonIcon_ $ toHtmlRaw Icon.ban
                   "Kill Job"


### PR DESCRIPTION
Replace manual viraButton_ + hxPostSafe_ patterns with viraRequestButton_
for consistent modal error handling:

- BranchPage: Build branch button
- JobPage: Kill job button

Removes manual htmx configuration and provides automatic error modal display
through the global modal container.

Resolves #175
