### PR TITLE
Add 'Tools' section

### DIFF
--- a/packages/gh/src/GH/Signoff.hs
+++ b/packages/gh/src/GH/Signoff.hs
@@ -4,7 +4,7 @@
 
 A standalone library for gh-signoff operations.
 -}
-module GH.Signoff (create, Force (..)) where
+module GH.Signoff (create, Force (..), ghSignoffBin) where
 
 import System.Process (CreateProcess, proc)
 import System.Which (staticWhich)

--- a/packages/vira/src/Vira/App/LinkTo/Resolve.hs
+++ b/packages/vira/src/Vira/App/LinkTo/Resolve.hs
@@ -11,6 +11,7 @@ import Vira.Page.JobPage qualified as JobPage
 import Vira.Page.RegistryPage qualified as RegistryPage
 import Vira.Page.RepoPage qualified as RepoPage
 import Vira.Page.SettingsPage qualified as SettingsPage
+import Vira.Page.ToolsPage qualified as ToolsPage
 
 -- | Resolve a `LinkTo` into a servant `Link`
 linkTo :: LinkTo -> Link
@@ -32,4 +33,5 @@ linkTo = \case
   SettingsDeleteCachix -> fieldLink _settings // SettingsPage._deleteCachix
   SettingsUpdateAttic -> fieldLink _settings // SettingsPage._updateAttic
   SettingsDeleteAttic -> fieldLink _settings // SettingsPage._deleteAttic
+  Tools -> fieldLink _tools // ToolsPage._view
   Refresh -> fieldLink _refresh

--- a/packages/vira/src/Vira/App/LinkTo/Type.hs
+++ b/packages/vira/src/Vira/App/LinkTo/Type.hs
@@ -26,6 +26,7 @@ data LinkTo
   | SettingsDeleteCachix
   | SettingsUpdateAttic
   | SettingsDeleteAttic
+  | Tools
   | Refresh
 
 linkShortTitle :: LinkTo -> Text
@@ -47,6 +48,7 @@ linkShortTitle = \case
   SettingsDeleteCachix -> "Delete Cachix Settings" -- unused
   SettingsUpdateAttic -> "Attic Settings" -- unused
   SettingsDeleteAttic -> "Delete Attic Settings" -- unused
+  Tools -> "Tools"
   Refresh -> "Refresh"
 
 linkTitle :: LinkTo -> Text

--- a/packages/vira/src/Vira/Page/IndexPage.hs
+++ b/packages/vira/src/Vira/Page/IndexPage.hs
@@ -15,6 +15,7 @@ import Vira.App.Servant (mapSourceT)
 import Vira.Page.JobPage qualified as JobPage
 import Vira.Page.RegistryPage qualified as RegistryPage
 import Vira.Page.SettingsPage qualified as SettingsPage
+import Vira.Page.ToolsPage qualified as ToolsPage
 import Vira.Stream.Refresh qualified as Refresh
 import Vira.Widgets.Card qualified as W
 import Vira.Widgets.Layout qualified as W
@@ -25,6 +26,7 @@ data Routes mode = Routes
   , _repos :: mode :- "r" Servant.API.:> NamedRoutes RegistryPage.Routes
   , _jobs :: mode :- "j" Servant.API.:> NamedRoutes JobPage.Routes
   , _settings :: mode :- "settings" Servant.API.:> NamedRoutes SettingsPage.Routes
+  , _tools :: mode :- "tools" Servant.API.:> NamedRoutes ToolsPage.Routes
   , _refresh :: mode :- "refresh" Servant.API.:> Refresh.StreamRoute
   }
   deriving stock (Generic)
@@ -42,6 +44,7 @@ handlers cfg webSettings =
     , _repos = RegistryPage.handlers cfg webSettings
     , _jobs = JobPage.handlers cfg webSettings
     , _settings = SettingsPage.handlers cfg webSettings
+    , _tools = ToolsPage.handlers cfg webSettings
     , _refresh =
         pure $ recommendedEventSourceHeaders $ mapSourceT (App.runApp cfg) Refresh.streamRouteHandler
     }
@@ -50,6 +53,7 @@ handlers cfg webSettings =
     menu :: (Monad m) => [(HtmlT m (), Text)]
     menu =
       [ ("Repositories", linkText $ fieldLink _repos // RegistryPage._listing)
+      , ("Tools", linkText $ fieldLink _tools // ToolsPage._view)
       , ("Settings", linkText $ fieldLink _settings // SettingsPage._view)
       ]
 

--- a/packages/vira/src/Vira/Page/ToolsPage.hs
+++ b/packages/vira/src/Vira/Page/ToolsPage.hs
@@ -5,6 +5,8 @@ module Vira.Page.ToolsPage (
 )
 where
 
+import Attic qualified
+import GH.Signoff qualified as GH
 import Lucid
 import Servant
 import Servant.API.ContentTypes.Lucid (HTML)
@@ -13,6 +15,8 @@ import Vira.App (AppHtml)
 import Vira.App qualified as App
 import Vira.App.CLI (WebSettings)
 import Vira.App.LinkTo.Type qualified as LinkTo
+import Vira.Lib.Cachix qualified as Cachix
+import Vira.Lib.Omnix qualified as Omnix
 import Vira.Widgets.Card qualified as W
 import Vira.Widgets.Layout qualified as W
 import Web.TablerIcons.Outline qualified as Icon
@@ -48,6 +52,7 @@ viewTools = do
         "Omnix"
         "Nix CI/CD orchestration tool for running builds"
         "https://github.com/juspay/omnix"
+        (toText Omnix.omnixBin)
 
       -- Attic
       toolCard
@@ -57,6 +62,7 @@ viewTools = do
         "Attic"
         "Self-hosted Nix binary cache server"
         "https://github.com/zhaofengli/attic"
+        (toText Attic.atticBin)
 
       -- Cachix
       toolCard
@@ -66,6 +72,7 @@ viewTools = do
         "Cachix"
         "Hosted Nix binary cache service"
         "https://cachix.org"
+        (toText Cachix.cachixBin)
 
       -- GitHub CLI (gh-signoff)
       toolCard
@@ -74,10 +81,11 @@ viewTools = do
         "text-green-600"
         "GitHub CLI"
         "Git signoff automation via gh-signoff extension"
-        "https://github.com/srid/gh-signoff"
+        "https://cli.github.com"
+        (toText GH.ghSignoffBin)
 
-toolCard :: (Monad m) => Text -> Text -> Text -> Text -> Text -> Text -> HtmlT m ()
-toolCard initial bgClass textClass name description url = do
+toolCard :: (Monad m) => Text -> Text -> Text -> Text -> Text -> Text -> Text -> HtmlT m ()
+toolCard initial bgClass textClass name description url binPath = do
   W.viraCard_ [class_ "p-6"] $ do
     div_ [class_ "flex items-start mb-4"] $ do
       span_ [class_ $ "h-12 w-12 mr-4 " <> bgClass <> " rounded-lg flex items-center justify-center " <> textClass <> " font-bold text-xl"] $
@@ -85,11 +93,13 @@ toolCard initial bgClass textClass name description url = do
       div_ [class_ "flex-1"] $ do
         h3_ [class_ "text-xl font-bold text-gray-900 mb-2"] $ toHtml name
         p_ [class_ "text-gray-600 text-sm mb-3"] $ toHtml description
+        div_ [class_ "mb-3"] $ do
+          code_ [class_ "text-xs bg-gray-100 text-gray-700 px-2 py-1 rounded font-mono"] $ toHtml binPath
         a_
           [ href_ url
           , target_ "_blank"
-          , class_ "inline-flex items-center text-indigo-600 hover:text-indigo-800 text-sm font-medium"
+          , class_ "inline-flex items-center gap-1 text-indigo-600 hover:text-indigo-800 text-sm font-medium"
           ]
           $ do
-            span_ [class_ "mr-1"] "Learn more"
-            div_ [class_ "w-4 h-4"] $ toHtmlRaw Icon.external_link
+            span_ "Learn more"
+            span_ [class_ "w-4 h-4 flex items-center"] $ toHtmlRaw Icon.external_link

--- a/packages/vira/src/Vira/Page/ToolsPage.hs
+++ b/packages/vira/src/Vira/Page/ToolsPage.hs
@@ -1,0 +1,95 @@
+-- | Tools information page
+module Vira.Page.ToolsPage (
+  Routes (..),
+  handlers,
+)
+where
+
+import Lucid
+import Servant
+import Servant.API.ContentTypes.Lucid (HTML)
+import Servant.Server.Generic (AsServer)
+import Vira.App (AppHtml)
+import Vira.App qualified as App
+import Vira.App.CLI (WebSettings)
+import Vira.App.LinkTo.Type qualified as LinkTo
+import Vira.Widgets.Card qualified as W
+import Vira.Widgets.Layout qualified as W
+import Web.TablerIcons.Outline qualified as Icon
+import Prelude hiding (for_)
+
+newtype Routes mode = Routes
+  { _view :: mode :- Get '[HTML] (Html ())
+  }
+  deriving stock (Generic)
+
+handlers :: App.AppState -> WebSettings -> Routes AsServer
+handlers cfg webSettings =
+  Routes
+    { _view = App.runAppInServant cfg webSettings . App.runAppHtml $ viewHandler
+    }
+
+viewHandler :: AppHtml ()
+viewHandler = do
+  W.layout [LinkTo.Tools] viewTools
+
+viewTools :: AppHtml ()
+viewTools = do
+  W.viraSection_ [] $ do
+    W.viraPageHeader_ "Tools" $ do
+      p_ [class_ "text-gray-600"] "Command-line tools used by Vira for CI/CD operations"
+
+    div_ [class_ "grid gap-6 md:grid-cols-2 lg:grid-cols-2"] $ do
+      -- Omnix
+      toolCard
+        "O"
+        "bg-purple-100"
+        "text-purple-600"
+        "Omnix"
+        "Nix CI/CD orchestration tool for running builds"
+        "https://github.com/juspay/omnix"
+
+      -- Attic
+      toolCard
+        "A"
+        "bg-indigo-100"
+        "text-indigo-600"
+        "Attic"
+        "Self-hosted Nix binary cache server"
+        "https://github.com/zhaofengli/attic"
+
+      -- Cachix
+      toolCard
+        "C"
+        "bg-blue-100"
+        "text-blue-600"
+        "Cachix"
+        "Hosted Nix binary cache service"
+        "https://cachix.org"
+
+      -- GitHub CLI (gh-signoff)
+      toolCard
+        "G"
+        "bg-green-100"
+        "text-green-600"
+        "GitHub CLI"
+        "Git signoff automation via gh-signoff extension"
+        "https://github.com/srid/gh-signoff"
+
+toolCard :: (Monad m) => Text -> Text -> Text -> Text -> Text -> Text -> HtmlT m ()
+toolCard initial bgClass textClass name description url = do
+  W.viraCard_ [class_ "p-6"] $ do
+    div_ [class_ "flex items-start mb-4"] $ do
+      span_ [class_ $ "h-12 w-12 mr-4 " <> bgClass <> " rounded-lg flex items-center justify-center " <> textClass <> " font-bold text-xl"] $
+        toHtml initial
+      div_ [class_ "flex-1"] $ do
+        h3_ [class_ "text-xl font-bold text-gray-900 mb-2"] $ toHtml name
+        p_ [class_ "text-gray-600 text-sm mb-3"] $ toHtml description
+        a_
+          [ href_ url
+          , target_ "_blank"
+          , class_ "inline-flex items-center text-indigo-600 hover:text-indigo-800 text-sm font-medium"
+          ]
+          $ do
+            span_ [class_ "mr-1"] "Learn more"
+            div_ [class_ "w-4 h-4"] $ toHtmlRaw Icon.external_link

--- a/packages/vira/src/Vira/Page/ToolsPage.hs
+++ b/packages/vira/src/Vira/Page/ToolsPage.hs
@@ -8,6 +8,7 @@ module Vira.Page.ToolsPage (
 where
 
 import Attic qualified
+import Effectful.Git qualified as Git
 import GH.Signoff qualified as GH
 import Lucid
 import Servant
@@ -54,6 +55,7 @@ viewTools = do
 
     div_ [class_ "grid gap-6 md:grid-cols-2 lg:grid-cols-2"] $ do
       toolCard "O" "bg-purple-100" "text-purple-600" omnix
+      toolCard "G" "bg-orange-100" "text-orange-600" gitTool
       toolCard "A" "bg-indigo-100" "text-indigo-600" attic
       toolCard "C" "bg-blue-100" "text-blue-600" cachix
       toolCard "G" "bg-green-100" "text-green-600" githubCli
@@ -64,6 +66,13 @@ viewTools = do
         , description = "A tool for building all Nix flake outputs"
         , url = "https://github.com/juspay/omnix"
         , binPath = toText Omnix.omnixBin
+        }
+    gitTool =
+      Tool
+        { name = "Git"
+        , description = "Distributed version control system"
+        , url = "https://git-scm.com"
+        , binPath = toText Git.git
         }
     attic =
       Tool

--- a/packages/vira/src/Vira/Page/ToolsPage.hs
+++ b/packages/vira/src/Vira/Page/ToolsPage.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedRecordDot #-}
+
 -- | Tools information page
 module Vira.Page.ToolsPage (
   Routes (..),
@@ -27,6 +29,13 @@ newtype Routes mode = Routes
   }
   deriving stock (Generic)
 
+data Tool = Tool
+  { name :: Text
+  , description :: Text
+  , url :: Text
+  , binPath :: Text
+  }
+
 handlers :: App.AppState -> WebSettings -> Routes AsServer
 handlers cfg webSettings =
   Routes
@@ -41,62 +50,56 @@ viewTools :: AppHtml ()
 viewTools = do
   W.viraSection_ [] $ do
     W.viraPageHeader_ "Tools" $ do
-      p_ [class_ "text-gray-600"] "Command-line tools used by Vira for CI/CD operations"
+      p_ [class_ "text-gray-600"] "Command-line tools used by Vira jobs"
 
     div_ [class_ "grid gap-6 md:grid-cols-2 lg:grid-cols-2"] $ do
-      -- Omnix
-      toolCard
-        "O"
-        "bg-purple-100"
-        "text-purple-600"
-        "Omnix"
-        "Nix CI/CD orchestration tool for running builds"
-        "https://github.com/juspay/omnix"
-        (toText Omnix.omnixBin)
+      toolCard "O" "bg-purple-100" "text-purple-600" omnix
+      toolCard "A" "bg-indigo-100" "text-indigo-600" attic
+      toolCard "C" "bg-blue-100" "text-blue-600" cachix
+      toolCard "G" "bg-green-100" "text-green-600" githubCli
+  where
+    omnix =
+      Tool
+        { name = "Omnix"
+        , description = "A tool for building all Nix flake outputs"
+        , url = "https://github.com/juspay/omnix"
+        , binPath = toText Omnix.omnixBin
+        }
+    attic =
+      Tool
+        { name = "Attic"
+        , description = "Self-hosted Nix binary cache server"
+        , url = "https://github.com/zhaofengli/attic"
+        , binPath = toText Attic.atticBin
+        }
+    cachix =
+      Tool
+        { name = "Cachix"
+        , description = "Proprietary Nix binary cache hosting service"
+        , url = "https://cachix.org"
+        , binPath = toText Cachix.cachixBin
+        }
+    githubCli =
+      Tool
+        { name = "GitHub CLI"
+        , description = "GitHub command line tool for various operations"
+        , url = "https://cli.github.com"
+        , binPath = toText GH.ghSignoffBin
+        }
 
-      -- Attic
-      toolCard
-        "A"
-        "bg-indigo-100"
-        "text-indigo-600"
-        "Attic"
-        "Self-hosted Nix binary cache server"
-        "https://github.com/zhaofengli/attic"
-        (toText Attic.atticBin)
-
-      -- Cachix
-      toolCard
-        "C"
-        "bg-blue-100"
-        "text-blue-600"
-        "Cachix"
-        "Hosted Nix binary cache service"
-        "https://cachix.org"
-        (toText Cachix.cachixBin)
-
-      -- GitHub CLI (gh-signoff)
-      toolCard
-        "G"
-        "bg-green-100"
-        "text-green-600"
-        "GitHub CLI"
-        "Git signoff automation via gh-signoff extension"
-        "https://cli.github.com"
-        (toText GH.ghSignoffBin)
-
-toolCard :: (Monad m) => Text -> Text -> Text -> Text -> Text -> Text -> Text -> HtmlT m ()
-toolCard initial bgClass textClass name description url binPath = do
+toolCard :: (Monad m) => Text -> Text -> Text -> Tool -> HtmlT m ()
+toolCard initial bgClass textClass tool = do
   W.viraCard_ [class_ "p-6"] $ do
     div_ [class_ "flex items-start mb-4"] $ do
       span_ [class_ $ "h-12 w-12 mr-4 " <> bgClass <> " rounded-lg flex items-center justify-center " <> textClass <> " font-bold text-xl"] $
         toHtml initial
       div_ [class_ "flex-1"] $ do
-        h3_ [class_ "text-xl font-bold text-gray-900 mb-2"] $ toHtml name
-        p_ [class_ "text-gray-600 text-sm mb-3"] $ toHtml description
+        h3_ [class_ "text-xl font-bold text-gray-900 mb-2"] $ toHtml tool.name
+        p_ [class_ "text-gray-600 text-sm mb-3"] $ toHtml tool.description
         div_ [class_ "mb-3"] $ do
-          code_ [class_ "text-xs bg-gray-100 text-gray-700 px-2 py-1 rounded font-mono"] $ toHtml binPath
+          code_ [class_ "text-xs bg-gray-100 text-gray-700 px-2 py-1 rounded font-mono"] $ toHtml tool.binPath
         a_
-          [ href_ url
+          [ href_ tool.url
           , target_ "_blank"
           , class_ "inline-flex items-center gap-1 text-indigo-600 hover:text-indigo-800 text-sm font-medium"
           ]

--- a/packages/vira/src/Vira/Widgets/Layout.hs
+++ b/packages/vira/src/Vira/Widgets/Layout.hs
@@ -142,6 +142,7 @@ linkToIcon = \case
   RepoBranch _ _ -> toHtmlRaw Icon.git_branch
   Job _ -> toHtmlRaw Icon.player_play
   Settings -> toHtmlRaw Icon.settings_2
+  Tools -> toHtmlRaw Icon.tool
   _ -> toHtmlRaw Icon.circle -- fallback for other types
 
 -- | Show breadcrumbs at the top of the page for navigation to parent routes

--- a/packages/vira/static/tailwind.css
+++ b/packages/vira/static/tailwind.css
@@ -17,6 +17,7 @@
     --color-red-800: oklch(44.4% 0.177 26.899);
     --color-red-900: oklch(39.6% 0.141 25.723);
     --color-orange-100: oklch(95.4% 0.038 75.164);
+    --color-orange-600: oklch(64.6% 0.222 41.116);
     --color-orange-700: oklch(55.3% 0.195 38.402);
     --color-yellow-50: oklch(98.7% 0.026 102.212);
     --color-yellow-100: oklch(97.3% 0.071 103.193);
@@ -945,6 +946,9 @@
   }
   .text-indigo-900 {
     color: var(--color-indigo-900);
+  }
+  .text-orange-600 {
+    color: var(--color-orange-600);
   }
   .text-orange-700 {
     color: var(--color-orange-700);

--- a/packages/vira/static/tailwind.css
+++ b/packages/vira/static/tailwind.css
@@ -517,6 +517,9 @@
   .justify-end {
     justify-content: flex-end;
   }
+  .gap-1 {
+    gap: calc(var(--spacing) * 1);
+  }
   .gap-2 {
     gap: calc(var(--spacing) * 2);
   }

--- a/packages/vira/static/tailwind.css
+++ b/packages/vira/static/tailwind.css
@@ -37,11 +37,13 @@
     --color-blue-600: oklch(54.6% 0.245 262.881);
     --color-blue-800: oklch(42.4% 0.199 265.638);
     --color-indigo-50: oklch(96.2% 0.018 272.314);
+    --color-indigo-100: oklch(93% 0.034 272.788);
     --color-indigo-200: oklch(87% 0.065 274.039);
     --color-indigo-300: oklch(78.5% 0.115 274.713);
     --color-indigo-500: oklch(58.5% 0.233 277.117);
     --color-indigo-600: oklch(51.1% 0.262 276.966);
     --color-indigo-700: oklch(45.7% 0.24 277.023);
+    --color-indigo-800: oklch(39.8% 0.195 277.366);
     --color-indigo-900: oklch(35.9% 0.144 278.697);
     --color-purple-100: oklch(94.6% 0.033 307.174);
     --color-purple-600: oklch(55.8% 0.288 302.321);
@@ -341,6 +343,9 @@
   .mr-3 {
     margin-right: calc(var(--spacing) * 3);
   }
+  .mr-4 {
+    margin-right: calc(var(--spacing) * 4);
+  }
   .mb-1 {
     margin-bottom: calc(var(--spacing) * 1);
   }
@@ -398,6 +403,9 @@
   .h-8 {
     height: calc(var(--spacing) * 8);
   }
+  .h-12 {
+    height: calc(var(--spacing) * 12);
+  }
   .h-16 {
     height: calc(var(--spacing) * 16);
   }
@@ -433,6 +441,9 @@
   }
   .w-8 {
     width: calc(var(--spacing) * 8);
+  }
+  .w-12 {
+    width: calc(var(--spacing) * 12);
   }
   .w-16 {
     width: calc(var(--spacing) * 16);
@@ -714,6 +725,9 @@
   .bg-indigo-50 {
     background-color: var(--color-indigo-50);
   }
+  .bg-indigo-100 {
+    background-color: var(--color-indigo-100);
+  }
   .bg-indigo-600 {
     background-color: var(--color-indigo-600);
   }
@@ -914,8 +928,14 @@
   .text-green-500 {
     color: var(--color-green-500);
   }
+  .text-green-600 {
+    color: var(--color-green-600);
+  }
   .text-green-800 {
     color: var(--color-green-800);
+  }
+  .text-indigo-600 {
+    color: var(--color-indigo-600);
   }
   .text-indigo-700 {
     color: var(--color-indigo-700);
@@ -1130,6 +1150,13 @@
     &:hover {
       @media (hover: hover) {
         color: var(--color-indigo-600);
+      }
+    }
+  }
+  .hover\:text-indigo-800 {
+    &:hover {
+      @media (hover: hover) {
+        color: var(--color-indigo-800);
       }
     }
   }

--- a/packages/vira/vira.cabal
+++ b/packages/vira/vira.cabal
@@ -59,6 +59,7 @@ library
       Vira.Page.RegistryPage
       Vira.Page.RepoPage
       Vira.Page.SettingsPage
+      Vira.Page.ToolsPage
       Vira.State.Acid
       Vira.State.Core
       Vira.State.JSON


### PR DESCRIPTION
A start at #164. Eventually, this page will be dynamic -- it will check the health of tools, their state, nudging users to configure them if not already (e.g.: `gh auth login` or `attic login`).

<img width="2986" height="1646" alt="image" src="https://github.com/user-attachments/assets/099575fe-62ab-4d35-b7a2-a82ec02326af" />
