### PR TITLE
Pretty print `vira.hs` interpret errors

### DIFF
--- a/packages/vira/src/Vira/CI/Pipeline.hs
+++ b/packages/vira/src/Vira/CI/Pipeline.hs
@@ -8,6 +8,7 @@ import Attic qualified
 import Attic.Config (lookupEndpointWithToken)
 import Attic.Types (AtticServer (..), AtticServerEndpoint)
 import Attic.Url qualified
+import Data.List qualified
 import Effectful (Eff, IOE, (:>))
 import Effectful.Error.Static (Error, runErrorNoCallStack, throwError)
 import Effectful.Git qualified as Git
@@ -51,10 +52,10 @@ instance TS.Show PipelineError where
     "Tool: " <> toString msg
   show (PipelineConfigurationError (InterpreterError herr)) =
     "vira.hs error: " <> case herr of
-      WontCompile ghcErrors -> "WontCompile\n" <> toString (unlines (map (toText . errMsg) ghcErrors))
-      UnknownError err -> "UnknownError\n" <> toString err
-      NotAllowed err -> "NotAllowed\n" <> toString err
-      GhcException err -> "GhcException\n" <> toString err
+      WontCompile ghcErrors -> "WontCompile\n" <> Data.List.unlines (errMsg <$> ghcErrors)
+      UnknownError err -> "UnknownError\n" <> err
+      NotAllowed err -> "NotAllowed\n" <> err
+      GhcException err -> "GhcException\n" <> err
   show (PipelineConfigurationError (MalformedConfig msg)) =
     "vira.hs has malformed config: " <> toString msg
   show PipelineEmpty =


### PR DESCRIPTION
resolves https://github.com/juspay/vira/issues/192 by hand-writing the `Show` instance for `InterpreterError` instead of using the derived `Show` instance.

Using the derived `Show` here is problematic because:
The `Show` instance for `String` (the data structure used to store the `vira.hs` compile errors and other interpreter erros) transitively calls [`showLitChar`](https://hackage.haskell.org/package/ghc-internal-9.1201.0/docs/src/GHC.Internal.Show.html#showLitChar), which escapes special characters by using only printable characters.


## Result

> Used [this configuration](https://github.com/srid/nixos-unified/blob/aa19b27d29e74a510774ba3f7f6f633bcb053416/vira.hs)  to reproduce error

<img width="773" height="313" alt="image" src="https://github.com/user-attachments/assets/6969a842-e9ca-4fe9-a7b2-bf1899ca1ebf" />
