### PR TITLE
Nix module: allow setting custom systemd service config

### DIFF
--- a/doc/guide/modules.md
+++ b/doc/guide/modules.md
@@ -52,6 +52,34 @@ The Home Manager module supports the following configuration options:
 - `autoResetState` - Automatically reset state on schema mismatch, removing ViraState and job workspaces (default: `true`)
 - `extraPackages` - Extra packages to add to the Vira service PATH
 - `initialState.repositories` - Map of repository names to clone URLs for initial state
+- `systemd.environment` - Additional environment variables for the service (Linux only)
+- `systemd.serviceConfig` - Additional systemd Service section attributes (Linux only)
 
 > [!note]
 > The `autoResetState` option is enabled by default to ensure smooth upgrades when Vira's internal state schema changes. If you prefer to preserve state across schema changes (and handle migrations manually), set this to `false`.
+
+#### Systemd Service Customization
+
+On Linux, you can customize the systemd service configuration using the `systemd` options:
+
+**Environment Variables:**
+
+```nix
+services.vira = {
+  systemd.environment = {
+    GIT_SSH_COMMAND = "ssh -i /path/to/key";
+    CUSTOM_VAR = "value";
+  };
+};
+```
+
+**Service Configuration:**
+
+```nix
+services.vira = {
+  systemd.serviceConfig = {
+    CPUQuota = "50%";
+    MemoryMax = "2G";
+  };
+};
+```

--- a/nix/modules/common/vira-options.nix
+++ b/nix/modules/common/vira-options.nix
@@ -74,6 +74,44 @@ in
       };
     };
 
+    systemd = mkOption {
+      description = "Systemd service configuration overrides";
+      default = { };
+      type = types.submodule {
+        options = {
+          serviceConfig = mkOption {
+            description = ''
+              Additional systemd Service section attributes.
+              These will be merged with the default service configuration.
+              See systemd.service(5) for available options.
+            '';
+            default = { };
+            type = types.attrsOf types.str;
+            example = literalExpression ''
+              {
+                CPUQuota = "50%";
+                MemoryMax = "2G";
+              }
+            '';
+          };
+
+          environment = mkOption {
+            description = ''
+              Additional environment variables for the service.
+              These will be merged with the default environment.
+            '';
+            default = { };
+            type = types.attrsOf types.str;
+            example = literalExpression ''
+              {
+                GIT_SSH_COMMAND = "ssh -i /path/to/key";
+              }
+            '';
+          };
+        };
+      };
+    };
+
     # Read-only computed outputs
     outputs = mkOption {
       type = types.submodule {

--- a/nix/modules/home-manager/vira.nix
+++ b/nix/modules/home-manager/vira.nix
@@ -4,25 +4,6 @@ with lib;
 
 let
   cfg = config.services.vira;
-
-  # SSH wrapper that bypasses systemd config to avoid permission errors
-  # SSH reads system configs from /etc/ssh/ssh_config.d/ and systemd dirs by default
-  # We copy the user config content (not symlink) to avoid nix store permission issues
-  sshWrapper = pkgs.writeShellScript "vira-ssh-wrapper" ''
-    # Create SSH config in runtime dir
-    VIRA_SSH_CONFIG="''${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/vira-ssh-config"
-    USER_SSH_CONFIG="${config.home.homeDirectory}/.ssh/config"
-
-    # Copy user config content if it exists
-    if [ -f "$USER_SSH_CONFIG" ]; then
-      cat "$USER_SSH_CONFIG" > "$VIRA_SSH_CONFIG"
-    else
-      : > "$VIRA_SSH_CONFIG"  # Empty config
-    fi
-
-    chmod 600 "$VIRA_SSH_CONFIG"
-    exec ${pkgs.openssh}/bin/ssh -F "$VIRA_SSH_CONFIG" "$@"
-  '';
 in
 {
   options.services.vira = mkOption {
@@ -48,22 +29,29 @@ in
         Wants = [ "network.target" ];
       };
 
-      Service = {
-        Type = "exec";
-        ExecStart = cfg.outputs.serviceCommand;
-        Restart = "on-failure";
-        RestartSec = "5s";
+      Service =
+        let
+          # Build environment variable list, avoiding duplicate PATH entries
+          defaultEnv = optionalAttrs (cfg.extraPackages != [ ]) {
+            PATH = "${makeBinPath cfg.extraPackages}:$PATH";
+          };
+          # User environment overrides defaults
+          mergedEnv = defaultEnv // cfg.systemd.environment;
+          envList = mapAttrsToList (name: value: "${name}=${value}") mergedEnv;
+        in
+        {
+          Type = "exec";
+          ExecStart = cfg.outputs.serviceCommand;
+          Restart = "on-failure";
+          RestartSec = "5s";
 
-        # Security settings for user service
-        NoNewPrivileges = true;
-        PrivateTmp = true;
+          # Security settings for user service
+          NoNewPrivileges = true;
+          PrivateTmp = true;
 
-        # Environment
-        Environment = [
-          "PATH=${makeBinPath cfg.extraPackages}:$PATH"
-          "GIT_SSH_COMMAND=${sshWrapper}"
-        ];
-      };
+          # Environment
+          Environment = envList;
+        } // cfg.systemd.serviceConfig;
 
       Install = {
         WantedBy = [ "default.target" ];


### PR DESCRIPTION
This fixes the issue where shh throws Bad permission error when provided nix managed config.