### PR TITLE
Update devour-flake, to obviate requiring 'nixpkgs' input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -19,11 +19,11 @@
     "devour-flake": {
       "flake": false,
       "locked": {
-        "lastModified": 1761086007,
-        "narHash": "sha256-q6dI4zprlg1X+VmuvE6H+wytqjeqGHdWMM4iS5W4X5U=",
+        "lastModified": 1761148089,
+        "narHash": "sha256-Cd9aWk4P2VGYrK2X28D3vVub2kQIaba7tCTVg+G0AII=",
         "owner": "srid",
         "repo": "devour-flake",
-        "rev": "42ea9a001306bb52e580d8c1bb70011feec1a6e3",
+        "rev": "03d5d9112a79aa6ef80495b325fd015d806b98eb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
CI would fail if the user flake has no `nixpkgs` input. This address it.

Using
https://github.com/srid/devour-flake/commit/03d5d9112a79aa6ef80495b325fd015d806b98eb
