### PR TITLE
Fix SSH host verification hanging by using non-interactive mode

### DIFF
--- a/packages/git-effectful/src/Effectful/Git/Command/Clone.hs
+++ b/packages/git-effectful/src/Effectful/Git/Command/Clone.hs
@@ -7,23 +7,26 @@ module Effectful.Git.Command.Clone (
   cloneAtCommit,
 ) where
 
-import Effectful.Git.Core (git)
+import Effectful (Eff, (:>))
+import Effectful.Environment (Environment)
+import Effectful.Git.Core (git, withNonInteractiveSSH)
 import Effectful.Git.Types (CommitID)
 import Effectful.Process (CreateProcess, proc)
 
 -- | Return the `CreateProcess` to clone a repo at a specific commit
-cloneAtCommit :: Text -> CommitID -> FilePath -> CreateProcess
+cloneAtCommit :: (Environment :> es) => Text -> CommitID -> FilePath -> Eff es CreateProcess
 cloneAtCommit url commit path =
-  proc
-    git
-    [ "-c"
-    , "advice.detachedHead=false"
-    , "clone"
-    , "--depth"
-    , "1"
-    , "--single-branch"
-    , "--revision"
-    , toString commit
-    , toString url
-    , path
-    ]
+  withNonInteractiveSSH $
+    proc
+      git
+      [ "-c"
+      , "advice.detachedHead=false"
+      , "clone"
+      , "--depth"
+      , "1"
+      , "--single-branch"
+      , "--revision"
+      , toString commit
+      , toString url
+      , path
+      ]

--- a/packages/git-effectful/src/Effectful/Git/Core.hs
+++ b/packages/git-effectful/src/Effectful/Git/Core.hs
@@ -1,13 +1,18 @@
 {-# LANGUAGE TemplateHaskell #-}
 
-{- | Core git executable path
+{- | Core git executable path and SSH configuration
 
-Provides the git executable path for other modules.
+Provides the git executable path and SSH configuration helpers for other modules.
 -}
 module Effectful.Git.Core (
   git,
+  withNonInteractiveSSH,
 ) where
 
+import Effectful (Eff, (:>))
+import Effectful.Environment (Environment)
+import Effectful.Environment qualified as Env
+import Effectful.Process (CreateProcess (..))
 import System.Which (staticWhich)
 
 {- | Path to the `git` executable
@@ -16,3 +21,31 @@ This should be available in the PATH, thanks to Nix and `which` library.
 -}
 git :: FilePath
 git = $(staticWhich "git")
+
+{- | Add non-interactive SSH configuration to a git command.
+
+This prevents git from blocking on interactive SSH prompts (host verification, password entry).
+Merges with any existing GIT_SSH_COMMAND in the environment and preserves all other env vars.
+
+Uses:
+- BatchMode=yes: Disables all interactive prompts
+- StrictHostKeyChecking=accept-new: Auto-accepts new unknown hosts, rejects changed keys
+-}
+withNonInteractiveSSH :: (Environment :> es) => CreateProcess -> Eff es CreateProcess
+withNonInteractiveSSH cmd = do
+  -- Get current environment
+  currentEnv <- Env.getEnvironment
+
+  -- Look up existing GIT_SSH_COMMAND
+  existingSSH <- Env.lookupEnv "GIT_SSH_COMMAND"
+
+  -- Build our SSH command, merging with user's if it exists
+  let ourOptions = "-o BatchMode=yes -o StrictHostKeyChecking=accept-new"
+      sshCommand = case existingSSH of
+        Nothing -> "ssh " <> ourOptions
+        Just userCmd -> toText userCmd <> " " <> ourOptions
+
+  -- Update environment with merged SSH command (remove old one first to avoid duplicates)
+  let updatedEnv = ("GIT_SSH_COMMAND", toString sshCommand) : filter ((/= "GIT_SSH_COMMAND") . fst) currentEnv
+
+  pure $ cmd {env = Just updatedEnv}

--- a/packages/git-effectful/test/Effectful/GitSpec.hs
+++ b/packages/git-effectful/test/Effectful/GitSpec.hs
@@ -5,6 +5,7 @@ import Data.Map.Strict qualified as Map
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 import Effectful (runEff)
 import Effectful.Colog (runLogAction)
+import Effectful.Environment (runEnvironment)
 import Effectful.Error.Static (runErrorNoCallStack)
 import Effectful.Git
 import Effectful.Git.Command.ForEachRef (remoteBranchesFromClone)
@@ -23,12 +24,12 @@ spec = do
         let cloneUrl = "https://github.com/srid/haskell.page-old.git"
             mirrorPath = tempDir </> "mirror"
         -- Clone the repository first
-        mirrorResult <- runEff . runProcess . runErrorNoCallStack @Text . runLogAction (LogAction $ const pass) . ER.runReader mempty $ Mirror.syncMirror cloneUrl mirrorPath
+        mirrorResult <- runEff . runEnvironment . runProcess . runErrorNoCallStack @Text . runLogAction (LogAction $ const pass) . ER.runReader mempty $ Mirror.syncMirror cloneUrl mirrorPath
         case mirrorResult of
           Left err -> expectationFailure $ "Failed to clone: " <> toString err
           Right () -> do
             -- Get branches from the cloned repository
-            result <- runEff . runProcess . runErrorNoCallStack @Text . runLogAction (LogAction $ const pass) . ER.runReader mempty $ remoteBranchesFromClone mirrorPath
+            result <- runEff . runEnvironment . runProcess . runErrorNoCallStack @Text . runLogAction (LogAction $ const pass) . ER.runReader mempty $ remoteBranchesFromClone mirrorPath
             case result of
               Left err -> expectationFailure $ "Failed to get branches: " <> toString err
               Right branches -> do

--- a/packages/vira/src/Vira/App/Run.hs
+++ b/packages/vira/src/Vira/App/Run.hs
@@ -15,6 +15,7 @@ import Data.Version (showVersion)
 import Effectful (runEff)
 import Effectful.Colog.Simple (runLogActionStdout)
 import Effectful.Concurrent.Async (runConcurrent)
+import Effectful.Environment (runEnvironment)
 import Effectful.Error.Static (runErrorNoCallStack)
 import Effectful.FileSystem (runFileSystem)
 import Effectful.Git.Command.Status (GitStatusPorcelain (..), gitStatusPorcelain)
@@ -117,6 +118,7 @@ runVira = do
     runCIEffects gs repoDir =
       runEff
         . runLogActionStdout gs.logLevel
+        . runEnvironment
         . runFileSystem
         . runProcess
         . runConcurrent

--- a/packages/vira/src/Vira/App/Stack.hs
+++ b/packages/vira/src/Vira/App/Stack.hs
@@ -6,6 +6,7 @@ import Effectful (Eff, IOE, runEff)
 import Effectful.Colog (Log)
 import Effectful.Colog.Simple (LogContext, runLogActionStdout)
 import Effectful.Concurrent.Async (Concurrent, runConcurrent)
+import Effectful.Environment (Environment, runEnvironment)
 import Effectful.FileSystem (FileSystem, runFileSystem)
 import Effectful.Process (Process, runProcess)
 import Effectful.Reader.Dynamic (Reader, runReader)
@@ -19,6 +20,7 @@ type AppStack =
    , Concurrent
    , Process
    , FileSystem
+   , Environment
    , ER.Reader LogContext
    , Log (RichMessage IO)
    , IOE
@@ -30,6 +32,7 @@ runApp globalSettings viraRuntimeState =
   do
     runEff
     . runLogActionStdout (logLevel globalSettings)
+    . runEnvironment
     . runFileSystem
     . runProcess
     . runConcurrent

--- a/packages/vira/src/Vira/CI/Pipeline/Implementation.hs
+++ b/packages/vira/src/Vira/CI/Pipeline/Implementation.hs
@@ -23,6 +23,7 @@ import Effectful.Colog (Log)
 import Effectful.Colog.Simple (LogContext (..))
 import Effectful.Concurrent.Async (Concurrent)
 import Effectful.Dispatch.Dynamic
+import Effectful.Environment (Environment)
 import Effectful.Error.Static (Error, throwError)
 import Effectful.FileSystem (FileSystem, doesFileExist)
 import Effectful.Git.Command.Clone qualified as Git
@@ -55,6 +56,7 @@ runPipeline ::
   , FileSystem :> es
   , ER.Reader LogContext :> es
   , Error PipelineError :> es
+  , Environment :> es
   ) =>
   PipelineEnv ->
   Eff (Pipeline : ER.Reader PipelineEnv : es) a ->
@@ -81,6 +83,7 @@ cloneImpl ::
   , ER.Reader LogContext :> es
   , ER.Reader PipelineEnv :> es
   , Error PipelineError :> es
+  , Environment :> es
   ) =>
   Repo ->
   Branch ->
@@ -89,11 +92,11 @@ cloneImpl ::
 cloneImpl repo branch workspacePath = do
   env <- ER.ask @PipelineEnv
   let projectDirName = "project"
-      cloneProc =
-        Git.cloneAtCommit
-          repo.cloneUrl
-          branch.headCommit.id
-          projectDirName
+  cloneProc <-
+    Git.cloneAtCommit
+      repo.cloneUrl
+      branch.headCommit.id
+      projectDirName
 
   logPipeline Info $ "Cloning repository at commit " <> toText branch.headCommit.id
 

--- a/packages/vira/src/Vira/Supervisor/Task.hs
+++ b/packages/vira/src/Vira/Supervisor/Task.hs
@@ -15,6 +15,7 @@ import Effectful.Colog (Log)
 import Effectful.Colog.Simple (LogContext (..), log, withLogContext, withoutLogContext)
 import Effectful.Concurrent.Async
 import Effectful.Concurrent.MVar (modifyMVar_, readMVar)
+import Effectful.Environment (Environment)
 import Effectful.Error.Static (Error, runErrorNoCallStack)
 import Effectful.FileSystem (FileSystem, createDirectoryIfMissing)
 import Effectful.Process (Process)
@@ -46,6 +47,7 @@ startTask ::
   , Log (RichMessage IO) :> es
   , IOE :> es
   , FileSystem :> es
+  , Environment :> es
   , HasCallStack
   , Show err
   , ER.Reader LogContext :> es
@@ -62,6 +64,7 @@ startTask ::
     , FileSystem :> es1
     , ER.Reader LogContext :> es1
     , Error err :> es1
+    , Environment :> es1
     ) =>
     (forall es2. (Log (RichMessage IO) :> es2, ER.Reader LogContext :> es2, IOE :> es2) => Severity -> Text -> Eff es2 ()) ->
     Eff es1 ()


### PR DESCRIPTION
> [!NOTE]
> This PR description was initially generated by an LLM.

Fixes #244 by configuring git operations to use non-interactive SSH mode, preventing indefinite hangs when cloning/fetching repositories where the SSH host is not in `~/.ssh/known_hosts`.

Resolves #244 


## User-Facing Changes

- **Repository refresh no longer hangs** when SSH host verification is required
- New SSH hosts (e.g., first-time GitHub access) are automatically accepted and added to `known_hosts`
- Users with custom `GIT_SSH_COMMAND` environment variables will have their settings preserved and merged with the non-interactive options
- Error messages from git operations now properly surface in the UI instead of causing indefinite "Refreshing..." states

## Developer Notes

### Implementation Details

- Added `withNonInteractiveSSH` helper in `Effectful.Git.Core` that:
  - Configures SSH with `BatchMode=yes` (disables interactive prompts)
  - Configures SSH with `StrictHostKeyChecking=accept-new` (auto-accepts new hosts, rejects changed keys for security)
  - Reads current environment via `Effectful.Environment` effect
  - Merges with existing user `GIT_SSH_COMMAND` if present
  - Preserves all environment variables (PATH, HOME, etc.)

- Updated git command builders to return `Eff es CreateProcess` instead of pure `CreateProcess`:
  - `cloneAllBranches` in `Mirror.hs`
  - `fetchAllBranches` in `Mirror.hs` 
  - `cloneAtCommit` in `Clone.hs`

- Added `Environment` effect to the application stack (`AppStack`) and all relevant effect handlers

### Architecture

The solution uses the `Effectful.Environment` effect for proper environment handling rather than raw IO, maintaining the effectful architecture and enabling testability. The full environment must be passed to `CreateProcess.env` since the `process` library doesn't support "inherit + override" semantics.

### Security Considerations

- `StrictHostKeyChecking=accept-new` only auto-accepts **new** unknown hosts
- Changed/different host keys are still rejected (prevents MITM attacks)
- This matches the security model of manual SSH host verification