### PR TITLE
Implement soft-delete for branches with visual indicators

### DIFF
--- a/packages/git-effectful/src/Effectful/Git/Mirror.hs
+++ b/packages/git-effectful/src/Effectful/Git/Mirror.hs
@@ -199,7 +199,7 @@ cloneAllBranches url path =
       , path
       ]
 
--- | Return the `CreateProcess` to fetch all branches with force
+-- | Return the `CreateProcess` to fetch all branches with force and prune deleted branches
 fetchAllBranches :: (Environment :> es) => Eff es CreateProcess
 fetchAllBranches =
   withNonInteractiveSSH $
@@ -207,6 +207,7 @@ fetchAllBranches =
       git
       [ "fetch"
       , "--force"
+      , "--prune"
       , "origin"
       , "+refs/heads/*:refs/remotes/origin/*"
       ]

--- a/packages/vira/src/Vira/State/Type.hs
+++ b/packages/vira/src/Vira/State/Type.hs
@@ -47,6 +47,8 @@ data Branch = Branch
   -- ^ The name of the branch
   , headCommit :: Commit
   -- ^ The commit at the head of the branch
+  , deleted :: Bool
+  -- ^ Whether this branch has been deleted from the remote
   }
   deriving stock (Generic, Show, Typeable, Data, Eq, Ord)
 
@@ -178,7 +180,7 @@ $(deriveSafeCopy 0 'base ''JobResult)
 $(deriveSafeCopy 0 'base ''JobStatus)
 $(deriveSafeCopy 0 'base ''JobId)
 $(deriveSafeCopy 0 'base ''Job)
-$(deriveSafeCopy 0 'base ''Branch)
+$(deriveSafeCopy 1 'base ''Branch)
 $(deriveSafeCopy 0 'base ''BadgeState)
 $(deriveSafeCopy 0 'base ''BranchDetails)
 $(deriveSafeCopy 0 'base ''Repo)
@@ -188,4 +190,4 @@ The version is automatically used by the --auto-reset-state feature to detect sc
 When enabled, auto-reset will remove ViraState/ and workspace/*/jobs directories on mismatch.
 Run `vira info` to see the current schema version.
 -}
-$(deriveSafeCopy 2 'base ''ViraState)
+$(deriveSafeCopy 3 'base ''ViraState)

--- a/packages/vira/src/Vira/Web/Pages/BranchPage.hs
+++ b/packages/vira/src/Vira/Web/Pages/BranchPage.hs
@@ -46,15 +46,25 @@ viewHandler repoName branchName = do
 viewBranch :: St.Repo -> BranchDetails -> [St.Job] -> AppHtml ()
 viewBranch repo branchDetails jobs = do
   -- Branch header with build and refresh buttons
+  let branchTitle =
+        toString repo.name
+          <> " → "
+          <> toString branchDetails.branch.branchName
+          <> if branchDetails.branch.deleted then " (deleted)" else ""
   W.viraPageHeaderWithIcon_
     (toHtmlRaw Icon.git_branch)
-    (toText $ toString repo.name <> " → " <> toString branchDetails.branch.branchName)
+    (toText branchTitle)
     ( div_ [class_ "flex items-center justify-between"] $ do
         div_ [class_ "flex items-center space-x-3 text-gray-600 dark:text-gray-300 min-w-0 flex-1"] $ do
           span_ [class_ "text-sm shrink-0"] "Latest commit:"
           div_ [class_ "flex items-center space-x-2 min-w-0"] $ do
             div_ [class_ "w-4 h-4 flex items-center justify-center shrink-0"] $ toHtmlRaw Icon.git_commit
             div_ [class_ "min-w-0"] $ W.viraCommitInfo_ branchDetails.branch.headCommit.id
+          -- Deleted badge
+          when branchDetails.branch.deleted $
+            span_ [class_ "inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300"] $ do
+              div_ [class_ "w-3 h-3 mr-1 flex items-center justify-center"] $ toHtmlRaw Icon.alert_triangle
+              "Branch deleted from remote"
           -- Out of date badge
           whenJust branchDetails.badgeState $ \case
             OutOfDate ->

--- a/packages/vira/src/Vira/Web/Widgets/JobsListing.hs
+++ b/packages/vira/src/Vira/Web/Widgets/JobsListing.hs
@@ -170,10 +170,25 @@ viraBranchDetailsRow_ showRepo details = do
           div_ [class_ "w-4 h-4 flex items-center justify-center text-purple-700 dark:text-purple-200 shrink-0"] $ toHtmlRaw Icon.book_2
           span_ [class_ "text-sm font-semibold text-purple-900 dark:text-purple-100"] $ toHtml $ toString details.branch.repoName
 
-      -- Branch tag - blue theme, flat left edge when repo shown
-      a_ [href_ branchUrl, class_ $ "flex items-center gap-1 px-3 py-1 bg-blue-100 dark:bg-blue-900 border border-blue-300 dark:border-blue-700 shadow-sm hover:opacity-70 transition-opacity" <> if showRepo then " rounded-r-full border-l-0" else " rounded-full"] $ do
-        div_ [class_ "w-4 h-4 flex items-center justify-center text-blue-700 dark:text-blue-200"] $ toHtmlRaw Icon.git_branch
-        span_ [class_ "text-sm font-semibold text-blue-900 dark:text-blue-100"] $ toHtml $ toString details.branch.branchName
+      -- Branch tag - blue theme (or red if deleted), flat left edge when repo shown
+      let branchClasses =
+            if details.branch.deleted
+              then "flex items-center gap-1 px-3 py-1 bg-red-100 dark:bg-red-900 border border-red-300 dark:border-red-700 shadow-sm hover:opacity-70 transition-opacity"
+              else "flex items-center gap-1 px-3 py-1 bg-blue-100 dark:bg-blue-900 border border-blue-300 dark:border-blue-700 shadow-sm hover:opacity-70 transition-opacity"
+          branchClasses' = branchClasses <> if showRepo then " rounded-r-full border-l-0" else " rounded-full"
+          branchIconColor =
+            if details.branch.deleted
+              then "w-4 h-4 flex items-center justify-center text-red-700 dark:text-red-200"
+              else "w-4 h-4 flex items-center justify-center text-blue-700 dark:text-blue-200"
+          branchTextColor =
+            if details.branch.deleted
+              then "text-sm font-semibold text-red-900 dark:text-red-100"
+              else "text-sm font-semibold text-blue-900 dark:text-blue-100"
+      a_ [href_ branchUrl, class_ branchClasses'] $ do
+        div_ [class_ branchIconColor] $ toHtmlRaw Icon.git_branch
+        span_ [class_ branchTextColor] $ toHtml $ toString details.branch.branchName
+        when details.branch.deleted $
+          span_ [class_ "text-xs text-red-700 dark:text-red-300 ml-1"] "(deleted)"
 
     -- Main row - clickable, single line layout with gray background and border
     a_

--- a/packages/vira/static/tailwind.css
+++ b/packages/vira/static/tailwind.css
@@ -398,6 +398,9 @@
   .mb-8 {
     margin-bottom: calc(var(--spacing) * 8);
   }
+  .ml-1 {
+    margin-left: calc(var(--spacing) * 1);
+  }
   .ml-2 {
     margin-left: calc(var(--spacing) * 2);
   }
@@ -1663,6 +1666,11 @@
       background-color: var(--color-purple-900);
     }
   }
+  .dark\:bg-red-900 {
+    @media (prefers-color-scheme: dark) {
+      background-color: var(--color-red-900);
+    }
+  }
   .dark\:bg-red-900\/20 {
     @media (prefers-color-scheme: dark) {
       background-color: color-mix(in srgb, oklch(39.6% 0.141 25.723) 20%, transparent);
@@ -1816,6 +1824,11 @@
   .dark\:text-purple-200 {
     @media (prefers-color-scheme: dark) {
       color: var(--color-purple-200);
+    }
+  }
+  .dark\:text-red-100 {
+    @media (prefers-color-scheme: dark) {
+      color: var(--color-red-100);
     }
   }
   .dark\:text-red-200 {

--- a/packages/vira/test/Vira/CI/ConfigurationSpec.hs
+++ b/packages/vira/test/Vira/CI/ConfigurationSpec.hs
@@ -28,6 +28,7 @@ testBranchStaging =
           , author = "Test Author"
           , authorEmail = "test@example.com"
           }
+    , deleted = False
     }
 
 testContextStaging :: ViraContext


### PR DESCRIPTION
This PR implements soft-delete for branches that are removed from the remote repository, preserving their job history while clearly marking them as deleted in the UI.

<img width="689" height="735" alt="image" src="https://github.com/user-attachments/assets/78752ca5-6496-4bde-8e29-5ea966261b1d" />


## User-Facing Changes

- Branches deleted from remote are now marked with a red "deleted" indicator instead of disappearing
- Branch tags show in red with "(deleted)" label on index and repo pages
- Branch page header displays "(deleted)" suffix and "Branch deleted from remote" badge
- All job history for deleted branches is preserved and remains visible
- Refreshing a repository now properly detects and marks deleted branches

## Developer Notes

- **State schema**: Added `deleted :: Bool` field to Branch type (bumped Branch SafeCopy 0→1, ViraState schema 2→3)
- **Acid-state**: `setRepoBranchesA` now performs soft-delete - marks old branches as deleted while keeping jobs intact
- **Git mirror**: Added `--prune` flag to `git fetch` to actually remove deleted remote-tracking branches from mirror
- **UI components**: Updated `viraBranchDetailsRow_` and BranchPage to conditionally style deleted branches with red theme
- **Test fixtures**: Updated to include `deleted = False` for existing branches

Builds on #253 (repo deletion cleanup).