### PR TITLE
Schedule immediate refresh when adding repository

### DIFF
--- a/packages/vira/src/Vira/Web/Pages/RegistryPage.hs
+++ b/packages/vira/src/Vira/Web/Pages/RegistryPage.hs
@@ -17,6 +17,8 @@ import Servant hiding (throwError)
 import Servant.API.ContentTypes.Lucid (HTML)
 import Servant.Server.Generic (AsServer)
 import Vira.App qualified as App
+import Vira.Refresh qualified as Refresh
+import Vira.Refresh.Type (RefreshPriority (Now))
 import Vira.State.Acid qualified as St
 import Vira.State.Type (Repo (..))
 import Vira.Web.LinkTo.Type qualified as LinkTo
@@ -74,6 +76,8 @@ handleAddRepo repo = do
     Nothing -> do
       App.update $ St.AddNewRepoA repo
       log Info $ "Added repository " <> toText repo.name
+      -- Schedule immediate refresh for new repo
+      Refresh.scheduleRepoRefresh (one repo.name) Now
       -- Redirect to the newly created repository page
       newRepoUrl <- getLinkUrl $ LinkTo.Repo repo.name
       pure $ addHeader newRepoUrl "Ok"


### PR DESCRIPTION
When users add a new repository, schedule a refresh job immediately instead of waiting for the periodic scheduler.

## User-Facing Changes

- New repositories now sync automatically right after being added
- Users see repository content immediately when navigating to the repo page
- No more waiting up to 5 minutes for the first sync

## Developer Notes

- Added `Refresh.scheduleRepoRefresh` call in `handleAddRepo` with `Now` priority
- Uses same mechanism as manual refresh button in RepoPage
- Worker picks up high-priority refresh jobs immediately