### PR TITLE
Add --only-build flag to control cache and signoff during vira ci

### DIFF
--- a/doc/guide/cli.md
+++ b/doc/guide/cli.md
@@ -11,25 +11,53 @@ Vira provides a command-line interface for running CI pipelines locally and mana
 Run the CI pipeline in any directory:
 
 ```bash
-vira ci [DIRECTORY]
+vira ci [DIRECTORY] [OPTIONS]
 ```
 
 If no directory is specified, runs in the current directory. The directory must be a git repository.
 
-### CLI Mode Restrictions {#build-only}
+### Options {#ci-opts}
 
-When running CI via the command line, only the build stage will run and for current system only.
+- `--only-build` / `-b` - Skip cache and signoff stages, only run build for current system
 
-This behavior is enforced automatically, regardless of what [[config|`vira.hs`]] specifies.
+### Default Behavior {#default}
+
+By default, `vira ci` respects the [[config|`vira.hs`]] configuration for all stages:
+
+- Runs build, cache, and signoff stages as configured
+- Enables creating per-system signoffs (e.g., `vira/x86_64-linux`) during local development
+- Pushes to cache if configured
+
+### Build-Only Mode {#build-only}
+
+Use the `--only-build` flag for quick local testing without side effects:
+
+```bash
+# Only build, skip cache and signoff
+vira ci --only-build
+
+# Short form
+vira ci -b
+```
+
+When `--only-build` is used:
+
+- Only runs the build stage
+- Ignores `build.systems` from config (uses current system only)
+- Skips cache push even if configured
+- Skips signoff creation even if configured
 
 ### Example
 
 ```bash
-# Run CI in current directory
+# Run CI with full configuration (build, cache, signoff)
 vira ci
 
 # Run CI in specific directory
 vira ci /path/to/repo
+
+# Quick build-only mode
+vira ci -b
 ```
 
 ## Export/Import State {#import-export}

--- a/doc/guide/config.md
+++ b/doc/guide/config.md
@@ -30,6 +30,8 @@ The configuration uses Haskell's `OverloadedRecordUpdate` syntax for modifying t
 The configuration function receives two parameters:
 
 - `ctx` - The Vira context containing repository and branch information
+  - `ctx.branch` - Current branch name
+  - `ctx.onlyBuild` - True when running in build-only mode (e.g., `vira ci --only-build`)
 - `pipeline` - The default pipeline configuration to customize
 
 All of [relude](https://hackage.haskell.org/package/relude)'s functions are made available in scope.

--- a/packages/vira-ci-types/src/Vira/CI/Context.hs
+++ b/packages/vira-ci-types/src/Vira/CI/Context.hs
@@ -23,13 +23,13 @@ and focused on what users actually need for conditional logic in vira.hs files.
 -}
 data ViraContext = ViraContext
   { branch :: BranchName
-  , -- Whether running in CLI mode (vs web/CI mode)
-    cli :: Bool
+  , -- Skip cache and signoff stages when True
+    onlyBuild :: Bool
   }
 
 -- HasField instances for ViraContext
 instance HasField "branch" ViraContext BranchName where
-  hasField (ViraContext branch cli) = (\x -> ViraContext x cli, branch)
+  hasField (ViraContext branch onlyBuild) = (\x -> ViraContext x onlyBuild, branch)
 
-instance HasField "cli" ViraContext Bool where
-  hasField (ViraContext branch cli) = (\x -> ViraContext branch x, cli)
+instance HasField "onlyBuild" ViraContext Bool where
+  hasField (ViraContext branch onlyBuild) = (\x -> ViraContext branch x, onlyBuild)

--- a/packages/vira/src/Vira/App/CLI.hs
+++ b/packages/vira/src/Vira/App/CLI.hs
@@ -69,7 +69,7 @@ data Command
   | ExportCommand
   | ImportCommand
   | InfoCommand
-  | CICommand (Maybe FilePath)
+  | CICommand (Maybe FilePath) Bool
   deriving stock (Show)
 
 -- | Complete CLI configuration
@@ -198,6 +198,11 @@ ciCommandParser =
           ( metavar "DIRECTORY"
               <> help "Directory to run CI in (defaults to current directory)"
           )
+      )
+    <*> switch
+      ( long "only-build"
+          <> short 'b'
+          <> help "Skip cache and signoff stages, only run build"
       )
 
 -- | Parser for commands

--- a/packages/vira/src/Vira/CI/Pipeline/Effect.hs
+++ b/packages/vira/src/Vira/CI/Pipeline/Effect.hs
@@ -34,7 +34,7 @@ data PipelineEnv = PipelineEnv
   , tools :: Tools
   -- ^ Available CI 'Vira.Environment.Tool.Type.Tools.Tools'
   , viraContext :: ViraContext
-  -- ^ 'ViraContext' (branch, CLI flag)
+  -- ^ 'ViraContext' (branch, onlyBuild flag)
   , logger :: PipelineLogger
   -- ^ 'PipelineLogger' function for pipeline messages
   }
@@ -87,7 +87,7 @@ pipelineEnvFromRemote branchName workspacePath tools logger =
   PipelineEnv
     { outputLog = Just $ workspacePath </> "output.log"
     , tools = tools
-    , viraContext = ViraContext {branch = branchName, cli = False}
+    , viraContext = ViraContext {branch = branchName, onlyBuild = False}
     , logger = PipelineLogger logger
     }
 

--- a/packages/vira/src/Vira/CI/Pipeline/Implementation.hs
+++ b/packages/vira/src/Vira/CI/Pipeline/Implementation.hs
@@ -136,16 +136,16 @@ loadConfigImpl repoDir = do
       logPipeline Info "No vira.hs found - using default pipeline"
       pure $ patchPipelineForCli env.viraContext defaultPipeline
   where
-    -- When running in CLI mode, restrict to current system and disable cache/signoff
+    -- When onlyBuild is enabled, restrict to current system and disable cache/signoff
     patchPipelineForCli :: ViraContext -> ViraPipeline -> ViraPipeline
     patchPipelineForCli ctx pipeline
-      | ctx.cli =
+      | ctx.onlyBuild =
           pipeline
-            { -- Don't signoff when running in CLI
+            { -- Don't signoff when only building
               signoff = pipeline.signoff {enable = False}
-            , -- Don't push to cache when running in CLI
+            , -- Don't push to cache when only building
               cache = pipeline.cache {url = Nothing}
-            , -- Only build for current system in CLI mode
+            , -- Only build for current system when only building
               build = BuildStage {flakes = pipeline.build.flakes, systems = []}
             }
       | otherwise = pipeline

--- a/packages/vira/test/Vira/CI/ConfigurationSpec.hs
+++ b/packages/vira/test/Vira/CI/ConfigurationSpec.hs
@@ -35,7 +35,7 @@ testContextStaging :: ViraContext
 testContextStaging =
   ViraContext
     { branch = testBranchStaging.branchName
-    , cli = False
+    , onlyBuild = False
     }
 
 spec :: Spec


### PR DESCRIPTION
Adds `--only-build` (`-b`) flag to `vira ci` command to control pipeline behavior during local development.

By default, `vira ci` now respects vira.hs configuration for all stages (build, cache, signoff), enabling per-system signoffs like `vira/x86_64-linux` for local commits. The new `--only-build` flag provides an escape hatch for quick local builds without side effects - it skips cache push and signoff creation, and builds only the current system.

This makes local development more flexible: developers can create signoffs when needed, or run quick builds when testing changes.

Closes #273