### PR TITLE
vira.hs: Rename to `nix.options`

### DIFF
--- a/doc/guide/config.md
+++ b/doc/guide/config.md
@@ -104,16 +104,6 @@ Only the following option keys are allowed:
 
 Using any other key will cause the pipeline to fail with an error.
 
-##### Experimental Features
-
-Enable Nix experimental features via `nix.experimentalFeatures`:
-
-```haskell
-pipeline { nix.experimentalFeatures = ["impure-derivations"] }
-```
-
-Allowed features: `impure-derivations`, `ca-derivations`.
-
 > [!WARNING]
 > Only safe, non-secret options are allowed. Secrets (like `access-tokens`) belong in `nix.conf` on the CI machine, not in `vira.hs`.
 

--- a/doc/guide/config.md
+++ b/doc/guide/config.md
@@ -76,15 +76,15 @@ The `systems` field controls which Nix systems to build for. When set to an empt
 
 ##### Nix Options
 
-Configure Nix `--option` flags for all build commands via `build.nixOptions`:
+Configure Nix `--option` flags for all build commands via `nix.options`:
 
 ```haskell
 -- Use relaxed sandbox for builds that need network access
-pipeline { build.nixOptions = [("sandbox", "relaxed")] }
+pipeline { nix.options = [("sandbox", "relaxed")] }
 
 -- Set multiple options
 pipeline
-  { build.nixOptions =
+  { nix.options =
       [ ("sandbox", "relaxed")
       , ("cores", "4")
       , ("max-jobs", "2")
@@ -103,6 +103,16 @@ Only the following option keys are allowed:
 | `allow-import-from-derivation` | IFD control         | `"true"`      |
 
 Using any other key will cause the pipeline to fail with an error.
+
+##### Experimental Features
+
+Enable Nix experimental features via `nix.experimentalFeatures`:
+
+```haskell
+pipeline { nix.experimentalFeatures = ["impure-derivations"] }
+```
+
+Allowed features: `impure-derivations`, `ca-derivations`.
 
 > [!WARNING]
 > Only safe, non-secret options are allowed. Secrets (like `access-tokens`) belong in `nix.conf` on the CI machine, not in `vira.hs`.

--- a/packages/devour-flake/src/DevourFlake.hs
+++ b/packages/devour-flake/src/DevourFlake.hs
@@ -37,7 +37,6 @@ prefetchFlakeInputs args =
   ["flake", "prefetch-inputs", devourFlakePath]
     ++ overrideInputArgs args
     ++ nixOptionArgs args
-    ++ experimentalFeaturesArgs args
 
 data DevourFlakeArgs = DevourFlakeArgs
   { flakePath :: FilePath
@@ -46,8 +45,6 @@ data DevourFlakeArgs = DevourFlakeArgs
   , overrideInputs :: [(Text, Text)]
   , nixOptions :: [(Text, Text)]
   -- ^ @--option key value@ flags passed to the Nix command
-  , experimentalFeatures :: [Text]
-  -- ^ @--extra-experimental-features@ flags passed to the Nix command
   }
   deriving stock (Eq, Show)
 
@@ -67,14 +64,8 @@ nixOptionArgs :: DevourFlakeArgs -> [String]
 nixOptionArgs args =
   concatMap (\(k, v) -> ["--option", toString k, toString v]) args.nixOptions
 
--- | Generate @--extra-experimental-features@ arguments
-experimentalFeaturesArgs :: DevourFlakeArgs -> [String]
-experimentalFeaturesArgs args =
-  concatMap (\f -> ["--extra-experimental-features", toString f]) args.experimentalFeatures
-
 toCliArgs :: DevourFlakeArgs -> [String]
 toCliArgs args =
   overrideInputArgs args
     ++ nixOptionArgs args
-    ++ experimentalFeaturesArgs args
     ++ maybe ["--no-link"] (\link -> ["--out-link", link]) args.outLink

--- a/packages/devour-flake/src/DevourFlake.hs
+++ b/packages/devour-flake/src/DevourFlake.hs
@@ -34,7 +34,10 @@ devourFlake args =
 -- | Generate arguments to @nix@ for prefetching flake inputs before build
 prefetchFlakeInputs :: (HasCallStack) => DevourFlakeArgs -> [String]
 prefetchFlakeInputs args =
-  ["flake", "prefetch-inputs", devourFlakePath] ++ overrideInputArgs args ++ nixOptionArgs args
+  ["flake", "prefetch-inputs", devourFlakePath]
+    ++ overrideInputArgs args
+    ++ nixOptionArgs args
+    ++ experimentalFeaturesArgs args
 
 data DevourFlakeArgs = DevourFlakeArgs
   { flakePath :: FilePath
@@ -42,7 +45,9 @@ data DevourFlakeArgs = DevourFlakeArgs
   , outLink :: Maybe FilePath
   , overrideInputs :: [(Text, Text)]
   , nixOptions :: [(Text, Text)]
-  -- ^ Arbitrary @--option key value@ flags passed to the Nix command
+  -- ^ @--option key value@ flags passed to the Nix command
+  , experimentalFeatures :: [Text]
+  -- ^ @--extra-experimental-features@ flags passed to the Nix command
   }
   deriving stock (Eq, Show)
 
@@ -62,8 +67,14 @@ nixOptionArgs :: DevourFlakeArgs -> [String]
 nixOptionArgs args =
   concatMap (\(k, v) -> ["--option", toString k, toString v]) args.nixOptions
 
+-- | Generate @--extra-experimental-features@ arguments
+experimentalFeaturesArgs :: DevourFlakeArgs -> [String]
+experimentalFeaturesArgs args =
+  concatMap (\f -> ["--extra-experimental-features", toString f]) args.experimentalFeatures
+
 toCliArgs :: DevourFlakeArgs -> [String]
 toCliArgs args =
   overrideInputArgs args
     ++ nixOptionArgs args
+    ++ experimentalFeaturesArgs args
     ++ maybe ["--no-link"] (\link -> ["--out-link", link]) args.outLink

--- a/packages/vira-ci-types/src/Vira/CI/Pipeline/Type.hs
+++ b/packages/vira-ci-types/src/Vira/CI/Pipeline/Type.hs
@@ -22,6 +22,7 @@ import System.Nix.System (System)
 -- | CI Pipeline configuration types
 data ViraPipeline = ViraPipeline
   { build :: BuildStage
+  , nix :: NixConfig
   , cache :: CacheStage
   , signoff :: SignoffStage
   }
@@ -30,9 +31,18 @@ data ViraPipeline = ViraPipeline
 data BuildStage = BuildStage
   { flakes :: NonEmpty Flake
   , systems :: [System]
-  , nixOptions :: [(Text, Text)]
+  }
+  deriving stock (Generic, Show)
+
+-- | Nix-level configuration (options and experimental features)
+data NixConfig = NixConfig
+  { options :: [(Text, Text)]
   {- ^ Nix @--option key value@ flags. Only whitelisted keys are allowed;
     see 'allowedNixOptions'.
+  -}
+  , experimentalFeatures :: [Text]
+  {- ^ Extra experimental features, e.g. @["impure-derivations"]@.
+    Only whitelisted features are allowed; see 'allowedExperimentalFeatures'.
   -}
   }
   deriving stock (Generic, Show)
@@ -50,12 +60,26 @@ allowedNixOptions =
   , "allow-import-from-derivation" -- IFD control
   ]
 
+-- | Whitelist of experimental features that are safe to enable per-project.
+allowedExperimentalFeatures :: [Text]
+allowedExperimentalFeatures =
+  [ "impure-derivations"
+  , "ca-derivations"
+  ]
+
 {- | Validate that all nix option keys are in the whitelist.
 Returns a list of disallowed keys.
 -}
 validateNixOptions :: [(Text, Text)] -> [Text]
 validateNixOptions opts =
   [k | (k, _) <- opts, k `notElem` allowedNixOptions]
+
+{- | Validate that all experimental features are in the whitelist.
+Returns a list of disallowed features.
+-}
+validateExperimentalFeatures :: [Text] -> [Text]
+validateExperimentalFeatures features =
+  [f | f <- features, f `notElem` allowedExperimentalFeatures]
 
 -- | Configuration for building a flake at a specific path
 data Flake = Flake
@@ -95,13 +119,16 @@ instance HasField "overrideInputs" Flake [(Text, Text)] where
   hasField (Flake path overrideInputs) = (Flake path, overrideInputs)
 
 instance HasField "flakes" BuildStage (NonEmpty Flake) where
-  hasField (BuildStage flakes systems nixOptions) = (\x -> BuildStage x systems nixOptions, flakes)
+  hasField (BuildStage flakes systems) = (\x -> BuildStage x systems, flakes)
 
 instance HasField "systems" BuildStage [System] where
-  hasField (BuildStage flakes systems nixOptions) = (\x -> BuildStage flakes x nixOptions, systems)
+  hasField (BuildStage flakes systems) = (BuildStage flakes, systems)
 
-instance HasField "nixOptions" BuildStage [(Text, Text)] where
-  hasField (BuildStage flakes systems nixOptions) = (BuildStage flakes systems, nixOptions)
+instance HasField "options" NixConfig [(Text, Text)] where
+  hasField (NixConfig options experimentalFeatures) = (\x -> NixConfig x experimentalFeatures, options)
+
+instance HasField "experimentalFeatures" NixConfig [Text] where
+  hasField (NixConfig options experimentalFeatures) = (NixConfig options, experimentalFeatures)
 
 instance HasField "enable" SignoffStage Bool where
   hasField (SignoffStage enable) = (SignoffStage, enable)
@@ -110,10 +137,13 @@ instance HasField "url" CacheStage (Maybe Text) where
   hasField (CacheStage url) = (CacheStage, url)
 
 instance HasField "build" ViraPipeline BuildStage where
-  hasField (ViraPipeline build cache signoff) = (\x -> ViraPipeline x cache signoff, build)
+  hasField (ViraPipeline build nix cache signoff) = (\x -> ViraPipeline x nix cache signoff, build)
+
+instance HasField "nix" ViraPipeline NixConfig where
+  hasField (ViraPipeline build nix cache signoff) = (\x -> ViraPipeline build x cache signoff, nix)
 
 instance HasField "cache" ViraPipeline CacheStage where
-  hasField (ViraPipeline build cache signoff) = (\x -> ViraPipeline build x signoff, cache)
+  hasField (ViraPipeline build nix cache signoff) = (\x -> ViraPipeline build nix x signoff, cache)
 
 instance HasField "signoff" ViraPipeline SignoffStage where
-  hasField (ViraPipeline build cache signoff) = (ViraPipeline build cache, signoff)
+  hasField (ViraPipeline build nix cache signoff) = (ViraPipeline build nix cache, signoff)

--- a/packages/vira-ci-types/src/Vira/CI/Pipeline/Type.hs
+++ b/packages/vira-ci-types/src/Vira/CI/Pipeline/Type.hs
@@ -35,14 +35,10 @@ data BuildStage = BuildStage
   deriving stock (Generic, Show)
 
 -- | Nix-level configuration (options and experimental features)
-data NixConfig = NixConfig
+newtype NixConfig = NixConfig
   { options :: [(Text, Text)]
   {- ^ Nix @--option key value@ flags. Only whitelisted keys are allowed;
     see 'allowedNixOptions'.
-  -}
-  , experimentalFeatures :: [Text]
-  {- ^ Extra experimental features, e.g. @["impure-derivations"]@.
-    Only whitelisted features are allowed; see 'allowedExperimentalFeatures'.
   -}
   }
   deriving stock (Generic, Show)
@@ -60,26 +56,12 @@ allowedNixOptions =
   , "allow-import-from-derivation" -- IFD control
   ]
 
--- | Whitelist of experimental features that are safe to enable per-project.
-allowedExperimentalFeatures :: [Text]
-allowedExperimentalFeatures =
-  [ "impure-derivations"
-  , "ca-derivations"
-  ]
-
 {- | Validate that all nix option keys are in the whitelist.
 Returns a list of disallowed keys.
 -}
 validateNixOptions :: [(Text, Text)] -> [Text]
 validateNixOptions opts =
   [k | (k, _) <- opts, k `notElem` allowedNixOptions]
-
-{- | Validate that all experimental features are in the whitelist.
-Returns a list of disallowed features.
--}
-validateExperimentalFeatures :: [Text] -> [Text]
-validateExperimentalFeatures features =
-  [f | f <- features, f `notElem` allowedExperimentalFeatures]
 
 -- | Configuration for building a flake at a specific path
 data Flake = Flake
@@ -125,10 +107,7 @@ instance HasField "systems" BuildStage [System] where
   hasField (BuildStage flakes systems) = (BuildStage flakes, systems)
 
 instance HasField "options" NixConfig [(Text, Text)] where
-  hasField (NixConfig options experimentalFeatures) = (\x -> NixConfig x experimentalFeatures, options)
-
-instance HasField "experimentalFeatures" NixConfig [Text] where
-  hasField (NixConfig options experimentalFeatures) = (NixConfig options, experimentalFeatures)
+  hasField (NixConfig options) = (NixConfig, options)
 
 instance HasField "enable" SignoffStage Bool where
   hasField (SignoffStage enable) = (SignoffStage, enable)

--- a/packages/vira/src/Vira/CI/Pipeline/Implementation.hs
+++ b/packages/vira/src/Vira/CI/Pipeline/Implementation.hs
@@ -46,7 +46,7 @@ import Vira.CI.Error (ConfigurationError (..), PipelineError (..), pipelineToolE
 import Vira.CI.Pipeline.Effect
 import Vira.CI.Pipeline.Process (runProcess)
 import Vira.CI.Pipeline.Signoff qualified as Signoff
-import Vira.CI.Pipeline.Type (BuildStage (..), CacheStage (..), Flake (..), NixConfig (..), SignoffStage (..), ViraPipeline (..), allowedExperimentalFeatures, allowedNixOptions, validateExperimentalFeatures, validateNixOptions)
+import Vira.CI.Pipeline.Type (BuildStage (..), CacheStage (..), Flake (..), NixConfig (..), SignoffStage (..), ViraPipeline (..), allowedNixOptions, validateNixOptions)
 import Vira.Environment.Tool.Tools.Attic qualified as AtticTool
 import Vira.Environment.Tool.Type.ToolData (status)
 import Vira.Environment.Tool.Type.Tools (attic)
@@ -170,9 +170,6 @@ buildImpl pipeline = do
   case validateNixOptions pipeline.nix.options of
     [] -> pass
     bad -> throwError $ PipelineConfigurationError $ MalformedConfig $ "Disallowed nix options: " <> show bad <> ". Allowed: " <> show allowedNixOptions
-  case validateExperimentalFeatures pipeline.nix.experimentalFeatures of
-    [] -> pass
-    bad -> throwError $ PipelineConfigurationError $ MalformedConfig $ "Disallowed experimental features: " <> show bad <> ". Allowed: " <> show allowedExperimentalFeatures
   -- Build each flake sequentially and return BuildResult for each
   forM pipeline.build.flakes $ \flake ->
     buildFlake pipeline.build.systems pipeline.nix flake
@@ -221,7 +218,6 @@ buildFlake systems nixCfg (Flake flakePath overrideInputs) = do
           , outLink = Just (flakePath </> "result")
           , overrideInputs = overrideInputs
           , nixOptions = nixCfg.options
-          , experimentalFeatures = nixCfg.experimentalFeatures
           }
 
   -- Prefetch flake inputs before building (for devourFlakePath and target flake)
@@ -348,7 +344,7 @@ defaultPipeline :: ViraPipeline
 defaultPipeline =
   ViraPipeline
     { build = BuildStage {flakes = one defaultFlake, systems = []}
-    , nix = NixConfig {options = [], experimentalFeatures = []}
+    , nix = NixConfig {options = []}
     , cache = CacheStage Nothing
     , signoff = SignoffStage False
     }

--- a/packages/vira/src/Vira/CI/Pipeline/Implementation.hs
+++ b/packages/vira/src/Vira/CI/Pipeline/Implementation.hs
@@ -46,7 +46,7 @@ import Vira.CI.Error (ConfigurationError (..), PipelineError (..), pipelineToolE
 import Vira.CI.Pipeline.Effect
 import Vira.CI.Pipeline.Process (runProcess)
 import Vira.CI.Pipeline.Signoff qualified as Signoff
-import Vira.CI.Pipeline.Type (BuildStage (..), CacheStage (..), Flake (..), SignoffStage (..), ViraPipeline (..), allowedNixOptions, validateNixOptions)
+import Vira.CI.Pipeline.Type (BuildStage (..), CacheStage (..), Flake (..), NixConfig (..), SignoffStage (..), ViraPipeline (..), allowedExperimentalFeatures, allowedNixOptions, validateExperimentalFeatures, validateNixOptions)
 import Vira.Environment.Tool.Tools.Attic qualified as AtticTool
 import Vira.Environment.Tool.Type.ToolData (status)
 import Vira.Environment.Tool.Type.Tools (attic)
@@ -147,7 +147,7 @@ loadConfigImpl = do
             , -- Don't push to cache when only building
               cache = pipeline.cache {url = Nothing}
             , -- Only build for current system when only building
-              build = BuildStage {flakes = pipeline.build.flakes, systems = [], nixOptions = pipeline.build.nixOptions}
+              build = BuildStage {flakes = pipeline.build.flakes, systems = []}
             }
       | otherwise = pipeline
 
@@ -167,12 +167,15 @@ buildImpl ::
 buildImpl pipeline = do
   logPipeline Info $ "Building " <> show (length pipeline.build.flakes) <> " flakes"
   -- Validate nix options against whitelist
-  case validateNixOptions pipeline.build.nixOptions of
+  case validateNixOptions pipeline.nix.options of
     [] -> pass
     bad -> throwError $ PipelineConfigurationError $ MalformedConfig $ "Disallowed nix options: " <> show bad <> ". Allowed: " <> show allowedNixOptions
+  case validateExperimentalFeatures pipeline.nix.experimentalFeatures of
+    [] -> pass
+    bad -> throwError $ PipelineConfigurationError $ MalformedConfig $ "Disallowed experimental features: " <> show bad <> ". Allowed: " <> show allowedExperimentalFeatures
   -- Build each flake sequentially and return BuildResult for each
   forM pipeline.build.flakes $ \flake ->
-    buildFlake pipeline.build.systems pipeline.build.nixOptions flake
+    buildFlake pipeline.build.systems pipeline.nix flake
 
 -- | Pretty-print DevourFlakeResult in a concise format
 prettyDevourResult :: FilePath -> DevourFlakeResult -> Text
@@ -205,10 +208,10 @@ buildFlake ::
   , Error PipelineError :> es
   ) =>
   [System] ->
-  [(Text, Text)] ->
+  NixConfig ->
   Flake ->
   Eff es BuildResult
-buildFlake systems nixOpts (Flake flakePath overrideInputs) = do
+buildFlake systems nixCfg (Flake flakePath overrideInputs) = do
   env <- ER.ask @PipelineEnv
   let repoDir = env.viraContext.repoDir
   let args =
@@ -217,7 +220,8 @@ buildFlake systems nixOpts (Flake flakePath overrideInputs) = do
           , systems
           , outLink = Just (flakePath </> "result")
           , overrideInputs = overrideInputs
-          , nixOptions = nixOpts
+          , nixOptions = nixCfg.options
+          , experimentalFeatures = nixCfg.experimentalFeatures
           }
 
   -- Prefetch flake inputs before building (for devourFlakePath and target flake)
@@ -343,7 +347,8 @@ signoffImpl pipeline buildResults = do
 defaultPipeline :: ViraPipeline
 defaultPipeline =
   ViraPipeline
-    { build = BuildStage {flakes = one defaultFlake, systems = [], nixOptions = []}
+    { build = BuildStage {flakes = one defaultFlake, systems = []}
+    , nix = NixConfig {options = [], experimentalFeatures = []}
     , cache = CacheStage Nothing
     , signoff = SignoffStage False
     }

--- a/packages/vira/src/Vira/CI/Pipeline/Program.hs
+++ b/packages/vira/src/Vira/CI/Pipeline/Program.hs
@@ -17,12 +17,12 @@ import System.Nix.System (System (..))
 import Vira.CI.Context (ViraContext (..))
 import Vira.CI.Error (PipelineError (..))
 import Vira.CI.Pipeline.Effect
-import Vira.CI.Pipeline.Type (BuildStage (..), CacheStage (..), Flake (..), SignoffStage (..), ViraPipeline (..))
+import Vira.CI.Pipeline.Type (BuildStage (..), CacheStage (..), Flake (..), NixConfig (..), SignoffStage (..), ViraPipeline (..))
 import Vira.State.Type (Branch, Repo)
 
 -- | Pretty-print pipeline configuration in a concise format
 prettyPipeline :: ViraPipeline -> Text
-prettyPipeline ViraPipeline {build = buildStage, cache = cacheStage, signoff = signoffStage} =
+prettyPipeline ViraPipeline {build = buildStage, nix = nixCfg, cache = cacheStage, signoff = signoffStage} =
   renderStrict $
     layoutPretty defaultLayoutOptions $
       vsep
@@ -32,7 +32,8 @@ prettyPipeline ViraPipeline {build = buildStage, cache = cacheStage, signoff = s
               [ "Flakes:" <+> pretty (NE.length buildStage.flakes) <+> "flake(s)"
               , vsep (map prettyFlake (NE.toList buildStage.flakes))
               , "Systems:" <+> hsep (punctuate comma (map (\(System s) -> pretty s) buildStage.systems))
-              , prettyNixOptions buildStage.nixOptions
+              , prettyNixOptions nixCfg.options
+              , prettyExperimentalFeatures nixCfg.experimentalFeatures
               ]
         , "Cache:" <+> maybe "disabled" (\url -> "enabled" <+> parens (pretty url)) cacheStage.url
         , "Signoff:" <+> if signoffStage.enable then "enabled" else "disabled"
@@ -51,6 +52,11 @@ prettyPipeline ViraPipeline {build = buildStage, cache = cacheStage, signoff = s
     prettyNixOptions [] = mempty
     prettyNixOptions opts =
       "Nix options:" <+> hsep (punctuate comma (map (\(k, v) -> pretty k <> "=" <> pretty v) opts))
+
+    prettyExperimentalFeatures :: [Text] -> Doc ann
+    prettyExperimentalFeatures [] = mempty
+    prettyExperimentalFeatures features =
+      "Experimental features:" <+> hsep (punctuate comma (map pretty features))
 
 -- | Pipeline program for CLI (uses existing local directory)
 pipelineProgram ::

--- a/packages/vira/src/Vira/CI/Pipeline/Program.hs
+++ b/packages/vira/src/Vira/CI/Pipeline/Program.hs
@@ -33,7 +33,6 @@ prettyPipeline ViraPipeline {build = buildStage, nix = nixCfg, cache = cacheStag
               , vsep (map prettyFlake (NE.toList buildStage.flakes))
               , "Systems:" <+> hsep (punctuate comma (map (\(System s) -> pretty s) buildStage.systems))
               , prettyNixOptions nixCfg.options
-              , prettyExperimentalFeatures nixCfg.experimentalFeatures
               ]
         , "Cache:" <+> maybe "disabled" (\url -> "enabled" <+> parens (pretty url)) cacheStage.url
         , "Signoff:" <+> if signoffStage.enable then "enabled" else "disabled"
@@ -52,11 +51,6 @@ prettyPipeline ViraPipeline {build = buildStage, nix = nixCfg, cache = cacheStag
     prettyNixOptions [] = mempty
     prettyNixOptions opts =
       "Nix options:" <+> hsep (punctuate comma (map (\(k, v) -> pretty k <> "=" <> pretty v) opts))
-
-    prettyExperimentalFeatures :: [Text] -> Doc ann
-    prettyExperimentalFeatures [] = mempty
-    prettyExperimentalFeatures features =
-      "Experimental features:" <+> hsep (punctuate comma (map pretty features))
 
 -- | Pipeline program for CLI (uses existing local directory)
 pipelineProgram ::

--- a/packages/vira/static/test/sample-configs/nix-options-example.hs
+++ b/packages/vira/static/test/sample-configs/nix-options-example.hs
@@ -1,9 +1,12 @@
 \ctx pipeline ->
   pipeline
-    { build.nixOptions =
+    { nix.options =
         [ ("sandbox", "relaxed")
         , ("cores", "4")
         , ("max-jobs", "2")
         , ("allow-import-from-derivation", "true")
+        ]
+    , nix.experimentalFeatures =
+        [ "impure-derivations"
         ]
     }

--- a/packages/vira/static/test/sample-configs/nix-options-example.hs
+++ b/packages/vira/static/test/sample-configs/nix-options-example.hs
@@ -6,7 +6,4 @@
         , ("max-jobs", "2")
         , ("allow-import-from-derivation", "true")
         ]
-    , nix.experimentalFeatures =
-        [ "impure-derivations"
-        ]
     }

--- a/packages/vira/test/Vira/CI/ConfigurationSpec.hs
+++ b/packages/vira/test/Vira/CI/ConfigurationSpec.hs
@@ -10,7 +10,7 @@ import Test.Hspec
 import Vira.CI.Configuration
 import Vira.CI.Context (ViraContext (..))
 import Vira.CI.Pipeline.Implementation (defaultPipeline)
-import Vira.CI.Pipeline.Type (BuildStage (..), Flake (..), NixConfig (..), SignoffStage (..), ViraPipeline (..), validateExperimentalFeatures, validateNixOptions)
+import Vira.CI.Pipeline.Type (BuildStage (..), Flake (..), NixConfig (..), SignoffStage (..), ViraPipeline (..), validateNixOptions)
 import Vira.State.Type (Branch (..))
 import Prelude hiding (id)
 
@@ -56,7 +56,7 @@ spec = describe "Vira.CI.Configuration" $ do
           rootFlake.overrideInputs `shouldBe` [("local", "github:boolean-option/false")]
         Left err -> expectationFailure $ "Config application failed: " <> show err
 
-    it "applies nix config correctly" $ do
+    it "applies nix options correctly" $ do
       configPath <- getDataFileName "test/sample-configs/nix-options-example.hs"
       configCode <- decodeUtf8 <$> readFileBS configPath
       result <- applyConfig configCode testContextStaging defaultPipeline
@@ -70,8 +70,6 @@ spec = describe "Vira.CI.Configuration" $ do
                          ] ::
                            [(Text, Text)]
                        )
-          pipeline.nix.experimentalFeatures
-            `shouldBe` (["impure-derivations"] :: [Text])
         Left err -> expectationFailure $ "Config application failed: " <> show err
 
   describe "validateNixOptions" $ do
@@ -85,13 +83,3 @@ spec = describe "Vira.CI.Configuration" $ do
 
     it "returns empty for empty options" $ do
       validateNixOptions [] `shouldBe` []
-
-  describe "validateExperimentalFeatures" $ do
-    it "accepts whitelisted features" $ do
-      validateExperimentalFeatures ["impure-derivations", "ca-derivations"] `shouldBe` []
-
-    it "rejects unknown features" $ do
-      validateExperimentalFeatures ["impure-derivations", "flakes"] `shouldBe` ["flakes"]
-
-    it "returns empty for empty list" $ do
-      validateExperimentalFeatures [] `shouldBe` []

--- a/packages/vira/test/Vira/CI/ConfigurationSpec.hs
+++ b/packages/vira/test/Vira/CI/ConfigurationSpec.hs
@@ -10,7 +10,7 @@ import Test.Hspec
 import Vira.CI.Configuration
 import Vira.CI.Context (ViraContext (..))
 import Vira.CI.Pipeline.Implementation (defaultPipeline)
-import Vira.CI.Pipeline.Type (BuildStage (..), Flake (..), SignoffStage (..), ViraPipeline (..), validateNixOptions)
+import Vira.CI.Pipeline.Type (BuildStage (..), Flake (..), NixConfig (..), SignoffStage (..), ViraPipeline (..), validateExperimentalFeatures, validateNixOptions)
 import Vira.State.Type (Branch (..))
 import Prelude hiding (id)
 
@@ -56,18 +56,22 @@ spec = describe "Vira.CI.Configuration" $ do
           rootFlake.overrideInputs `shouldBe` [("local", "github:boolean-option/false")]
         Left err -> expectationFailure $ "Config application failed: " <> show err
 
-    it "applies nixOptions correctly" $ do
+    it "applies nix config correctly" $ do
       configPath <- getDataFileName "test/sample-configs/nix-options-example.hs"
       configCode <- decodeUtf8 <$> readFileBS configPath
       result <- applyConfig configCode testContextStaging defaultPipeline
       case result of
         Right pipeline -> do
-          pipeline.build.nixOptions
-            `shouldBe` [ ("sandbox", "relaxed")
-                       , ("cores", "4")
-                       , ("max-jobs", "2")
-                       , ("allow-import-from-derivation", "true")
-                       ]
+          pipeline.nix.options
+            `shouldBe` ( [ ("sandbox", "relaxed")
+                         , ("cores", "4")
+                         , ("max-jobs", "2")
+                         , ("allow-import-from-derivation", "true")
+                         ] ::
+                           [(Text, Text)]
+                       )
+          pipeline.nix.experimentalFeatures
+            `shouldBe` (["impure-derivations"] :: [Text])
         Left err -> expectationFailure $ "Config application failed: " <> show err
 
   describe "validateNixOptions" $ do
@@ -81,3 +85,13 @@ spec = describe "Vira.CI.Configuration" $ do
 
     it "returns empty for empty options" $ do
       validateNixOptions [] `shouldBe` []
+
+  describe "validateExperimentalFeatures" $ do
+    it "accepts whitelisted features" $ do
+      validateExperimentalFeatures ["impure-derivations", "ca-derivations"] `shouldBe` []
+
+    it "rejects unknown features" $ do
+      validateExperimentalFeatures ["impure-derivations", "flakes"] `shouldBe` ["flakes"]
+
+    it "returns empty for empty list" $ do
+      validateExperimentalFeatures [] `shouldBe` []

--- a/vira.hs
+++ b/vira.hs
@@ -5,7 +5,7 @@
     isMain = ctx.branch == "main"
   in
   pipeline
-    { build.nixOptions = [("sandbox", "relaxed")]
+    { nix.options = [("sandbox", "relaxed")]
     , build.systems = 
         [ "x86_64-linux"
         , "aarch64-darwin"


### PR DESCRIPTION
Rename `build.nixOptions` to `nix.options`

Because, in future, we can have other nix settings in `nix.*`.