### PR TITLE
fix: support local Git repos without remote

### DIFF
--- a/packages/git-effectful/src/Effectful/Git/Command/Remote.hs
+++ b/packages/git-effectful/src/Effectful/Git/Command/Remote.hs
@@ -3,6 +3,7 @@
 Provides git remote commands for querying remote repository information.
 -}
 module Effectful.Git.Command.Remote (
+  getRemotes,
   getRemoteUrl,
 ) where
 
@@ -13,18 +14,34 @@ import Effectful (Eff, IOE, (:>))
 import Effectful.Colog (Log)
 import Effectful.Colog.Simple (LogContext, log)
 import Effectful.Colog.Simple.Process (withLogCommand)
-import Effectful.Error.Static (Error)
 import Effectful.Git.Core (git)
 import Effectful.Process (Process, proc, readCreateProcess)
 import Effectful.Reader.Static qualified as ER
 
+-- | List all configured remote names for a repository.
+getRemotes ::
+  ( Log (RichMessage IO) :> es
+  , ER.Reader LogContext :> es
+  , Process :> es
+  , IOE :> es
+  ) =>
+  -- | Repository directory
+  FilePath ->
+  Eff es [Text]
+getRemotes repoDir = do
+  let cmd = proc git ["-C", repoDir, "remote"]
+  output <- withLogCommand cmd $ do
+    log Debug "Listing git remotes"
+    readCreateProcess cmd ""
+  pure $ lines $ T.strip $ toText output
+
 {- | Get the URL for a git remote
 
 Gets the URL for the specified remote (typically "origin") in the given repository directory.
+Returns 'Nothing' if the remote does not exist.
 -}
 getRemoteUrl ::
-  ( Error Text :> es
-  , Log (RichMessage IO) :> es
+  ( Log (RichMessage IO) :> es
   , ER.Reader LogContext :> es
   , Process :> es
   , IOE :> es
@@ -33,10 +50,16 @@ getRemoteUrl ::
   FilePath ->
   -- | Remote name (typically "origin")
   Text ->
-  Eff es Text
+  Eff es (Maybe Text)
 getRemoteUrl repoDir remoteName = do
-  let cmd = proc git ["-C", repoDir, "remote", "get-url", toString remoteName]
-  output <- withLogCommand cmd $ do
-    log Debug $ "Running git remote get-url " <> remoteName
-    readCreateProcess cmd ""
-  pure $ T.strip $ toText output
+  remotes <- getRemotes repoDir
+  if remoteName `elem` remotes
+    then do
+      let urlCmd = proc git ["-C", repoDir, "remote", "get-url", toString remoteName]
+      output <- withLogCommand urlCmd $ do
+        log Debug $ "Running git remote get-url " <> remoteName
+        readCreateProcess urlCmd ""
+      pure $ Just $ T.strip $ toText output
+    else do
+      log Debug $ "Remote '" <> remoteName <> "' not found"
+      pure Nothing

--- a/packages/vira-ci-types/src/Vira/CI/Context.hs
+++ b/packages/vira-ci-types/src/Vira/CI/Context.hs
@@ -27,8 +27,8 @@ data ViraContext = ViraContext
     onlyBuild :: Bool
   , -- Commit ID being built
     commitId :: CommitID
-  , -- Repository clone URL (for platform detection)
-    cloneUrl :: Text
+  , -- Repository clone URL (for platform detection), Nothing when no remote is configured
+    cloneUrl :: Maybe Text
   , -- Repository working directory
     -- HACK: See Program.hs:pipelineProgramWithClone for `ER.local` hack.
     repoDir :: FilePath
@@ -44,7 +44,7 @@ instance HasField "onlyBuild" ViraContext Bool where
 instance HasField "commitId" ViraContext CommitID where
   hasField (ViraContext branch onlyBuild commitId cloneUrl repoDir) = (\x -> ViraContext branch onlyBuild x cloneUrl repoDir, commitId)
 
-instance HasField "cloneUrl" ViraContext Text where
+instance HasField "cloneUrl" ViraContext (Maybe Text) where
   hasField (ViraContext branch onlyBuild commitId cloneUrl repoDir) = (\x -> ViraContext branch onlyBuild commitId x repoDir, cloneUrl)
 
 instance HasField "repoDir" ViraContext FilePath where

--- a/packages/vira/src/Vira/App/Run.hs
+++ b/packages/vira/src/Vira/App/Run.hs
@@ -149,7 +149,7 @@ runVira = do
           -- Check for dirty working directory unless --only-build is set
           unless onlyBuild $ do
             when status.dirty $ throwError "Working directory has uncommitted changes or untracked files. Use --only-build to run CI anyway."
-          -- Get remote URL for creating Repo
+          -- Get remote URL (Nothing if no remote configured)
           remoteUrl <- getRemoteUrl dir "origin"
           -- Get current commit hash
           commitId <- getCurrentCommit dir

--- a/packages/vira/src/Vira/CI/Pipeline/Implementation.hs
+++ b/packages/vira/src/Vira/CI/Pipeline/Implementation.hs
@@ -317,25 +317,32 @@ signoffImpl ::
 signoffImpl pipeline buildResults = do
   env <- ER.ask @PipelineEnv
   let commitId = env.viraContext.commitId
-      cloneUrl = env.viraContext.cloneUrl
+      mCloneUrl = env.viraContext.cloneUrl
       repoDir = env.viraContext.repoDir
   if pipeline.signoff.enable
     then do
-      -- Extract unique systems from all build results
-      let systems = extractSystems $ fmap (.devourResult) (toList buildResults)
-          signoffNames = fmap (\system -> "vira/" <> toString system) (toList systems)
-      case nonEmpty signoffNames of
-        Nothing -> throwError $ DevourFlakeMalformedOutput "build results" "No systems found in build results"
-        Just names -> do
-          -- Detect platform based on clone URL
-          case detectPlatform cloneUrl of
-            Nothing ->
-              throwError $
-                pipelineToolError
-                  ("Signoff enabled but could not detect platform from clone URL: " <> cloneUrl <> ". Must be GitHub or Bitbucket.")
-                  (Nothing :: Maybe Text)
-            Just platform -> do
-              Signoff.performSignoff commitId platform repoDir names
+      case mCloneUrl of
+        Nothing ->
+          throwError $
+            pipelineToolError
+              ("Signoff enabled but no remote URL is available. Add an 'origin' remote or disable signoff." :: Text)
+              (Nothing :: Maybe Text)
+        Just cloneUrl -> do
+          -- Extract unique systems from all build results
+          let systems = extractSystems $ fmap (.devourResult) (toList buildResults)
+              signoffNames = fmap (\system -> "vira/" <> toString system) (toList systems)
+          case nonEmpty signoffNames of
+            Nothing -> throwError $ DevourFlakeMalformedOutput "build results" "No systems found in build results"
+            Just names -> do
+              -- Detect platform based on clone URL
+              case detectPlatform cloneUrl of
+                Nothing ->
+                  throwError $
+                    pipelineToolError
+                      ("Signoff enabled but could not detect platform from clone URL: " <> cloneUrl <> ". Must be GitHub or Bitbucket.")
+                      (Nothing :: Maybe Text)
+                Just platform -> do
+                  Signoff.performSignoff commitId platform repoDir names
     else
       logPipeline Warning "Signoff disabled, skipping"
 

--- a/packages/vira/src/Vira/CI/Worker.hs
+++ b/packages/vira/src/Vira/CI/Worker.hs
@@ -160,7 +160,7 @@ startJob job = do
   -- Start task
   st <- ask @ViraRuntimeState
   tools <- Tool.refreshTools
-  let ctx = ViraContext job.branch False branch.headCommit.id repo.cloneUrl job.jobWorkingDir
+  let ctx = ViraContext job.branch False branch.headCommit.id (Just repo.cloneUrl) job.jobWorkingDir
   (logSink, broadcast, closeLogSink) <- Supervisor.createTaskLogSink job.jobWorkingDir "output.log"
   let logFn = Pipeline.logPipeline' Pipeline.workspaceContextKeys logSink
   Supervisor.startTask

--- a/packages/vira/test/Vira/CI/ConfigurationSpec.hs
+++ b/packages/vira/test/Vira/CI/ConfigurationSpec.hs
@@ -37,7 +37,7 @@ testContextStaging =
     { branch = testBranchStaging.branchName
     , onlyBuild = False
     , commitId = testBranchStaging.headCommit.id
-    , cloneUrl = "https://example.com/test-repo.git"
+    , cloneUrl = Just "https://example.com/test-repo.git"
     , repoDir = "/tmp/test-repo"
     }
 


### PR DESCRIPTION
Fixes #299

## Changes

- `getRemoteUrl` now returns `Maybe Text` by listing remotes first via `git remote`, then fetching URL only if the remote exists
- Extract `getRemotes` function for listing configured remote names
- `ViraContext.cloneUrl` changed from `Text` to `Maybe Text`
- `signoffImpl` handles missing URL with a clear error when signoff is enabled
- Worker wraps `repo.cloneUrl` in `Just` (web path always has URL)