### PR TITLE
perf: cache devShell env — 5.3s to 0.03s

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -13,8 +13,8 @@ if ! cache_valid; then
     mv "$ENV_FILE.tmp" "$ENV_FILE"
 fi
 
-# Watch nix files so direnv reloads when they change
-for f in "${NIX_FILES[@]}"; do
+# Watch all cache key files so direnv reloads when they change
+for f in "${NIX_FILES[@]}" "${CABAL_FILES[@]}"; do
     watch_file "$f"
 done
 

--- a/.envrc
+++ b/.envrc
@@ -2,33 +2,10 @@
 # Cache miss falls back to `nix print-dev-env`. Typical reload: ~0.04s vs ~5.4s.
 # Force re-eval: rm -rf ~/.cache/vira-shell
 
-CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/vira-shell"
+DIR="$(pwd)"
+source ./nix-shell-cache-lib.sh
 
-NIX_FILES=(
-    flake.nix
-    flake.lock
-    nix/modules/flake-parts/devshell.nix
-    nix/modules/flake-parts/haskell.nix
-    nix/modules/flake-parts/pre-commit.nix
-    nix/modules/flake-parts/assets.nix
-    nix/modules/flake-parts/vira-dev.nix
-    nix/modules/flake-parts/hpack-watch.nix
-    nix/modules/flake-parts/tests.nix
-    packages/attic/haskell-module.nix
-    packages/nix-cache-server/haskell-module.nix
-)
-
-CACHE_KEY=$(cat "${NIX_FILES[@]}" 2>/dev/null | { sha256sum 2>/dev/null || shasum -a 256; } | cut -d' ' -f1)
-ENV_FILE="$CACHE_DIR/$CACHE_KEY.sh"
-
-_cache_valid() {
-    [[ -f "$ENV_FILE" ]] || return 1
-    local store_path
-    store_path=$(grep -o '/nix/store/[^/"'"'"']*' "$ENV_FILE" | head -1)
-    [[ -n "$store_path" ]] && [[ -e "$store_path" ]]
-}
-
-if ! _cache_valid; then
+if ! cache_valid; then
     mkdir -p "$CACHE_DIR"
     find "$CACHE_DIR" -maxdepth 1 -type f -not -name "$CACHE_KEY.*" -delete 2>/dev/null || true
     log_status "nix cache miss — evaluating devShell..."

--- a/.envrc
+++ b/.envrc
@@ -41,4 +41,4 @@ for f in "${NIX_FILES[@]}"; do
     watch_file "$f"
 done
 
-source "$ENV_FILE"
+source "$ENV_FILE" > /dev/null

--- a/.envrc
+++ b/.envrc
@@ -9,7 +9,7 @@ if ! cache_valid; then
     mkdir -p "$CACHE_DIR"
     find "$CACHE_DIR" -maxdepth 1 -type f -not -name "$CACHE_KEY.*" -delete 2>/dev/null || true
     log_status "nix cache miss — evaluating devShell..."
-    nix print-dev-env > "$ENV_FILE.tmp"
+    nix print-dev-env --profile "$CACHE_DIR/profile" > "$ENV_FILE.tmp"
     mv "$ENV_FILE.tmp" "$ENV_FILE"
 fi
 

--- a/.envrc
+++ b/.envrc
@@ -1,9 +1,44 @@
-# We are not watching .cabal or .nix to avoid devShell reloading
-# as that will cause Nix rebuilds of the hint-nix stuff.
-#
-# Instead, you should explicitly `direnv reload`.
-# watch_file packages/*/*.cabal nix/modules/flake-parts/*.nix
+# Cached nix develop — sources a cached env dump keyed on nix file hashes.
+# Cache miss falls back to `nix print-dev-env`. Typical reload: ~0.04s vs ~5.4s.
+# Force re-eval: rm -rf ~/.cache/vira-shell
 
-watch_file nix/modules/flake-parts/pre-commit.nix
+CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/vira-shell"
 
-use flake
+NIX_FILES=(
+    flake.nix
+    flake.lock
+    nix/modules/flake-parts/devshell.nix
+    nix/modules/flake-parts/haskell.nix
+    nix/modules/flake-parts/pre-commit.nix
+    nix/modules/flake-parts/assets.nix
+    nix/modules/flake-parts/vira-dev.nix
+    nix/modules/flake-parts/hpack-watch.nix
+    nix/modules/flake-parts/tests.nix
+    packages/attic/haskell-module.nix
+    packages/nix-cache-server/haskell-module.nix
+)
+
+CACHE_KEY=$(cat "${NIX_FILES[@]}" 2>/dev/null | { sha256sum 2>/dev/null || shasum -a 256; } | cut -d' ' -f1)
+ENV_FILE="$CACHE_DIR/$CACHE_KEY.sh"
+
+_cache_valid() {
+    [[ -f "$ENV_FILE" ]] || return 1
+    local store_path
+    store_path=$(grep -o '/nix/store/[^/"'"'"']*' "$ENV_FILE" | head -1)
+    [[ -n "$store_path" ]] && [[ -e "$store_path" ]]
+}
+
+if ! _cache_valid; then
+    mkdir -p "$CACHE_DIR"
+    find "$CACHE_DIR" -maxdepth 1 -type f -not -name "$CACHE_KEY.*" -delete 2>/dev/null || true
+    log_status "nix cache miss — evaluating devShell..."
+    nix print-dev-env > "$ENV_FILE.tmp"
+    mv "$ENV_FILE.tmp" "$ENV_FILE"
+fi
+
+# Watch nix files so direnv reloads when they change
+for f in "${NIX_FILES[@]}"; do
+    watch_file "$f"
+done
+
+source "$ENV_FILE"

--- a/justfile
+++ b/justfile
@@ -93,6 +93,11 @@ hpack:
         hpack $f; \
     done
 
+# Clear the nix devShell cache (forces re-eval on next direnv reload)
+nix-cache-clear:
+    rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}/vira-shell"
+    @echo "Cleared. Next direnv reload will re-evaluate."
+
 # Run the logsink example (Vira CI workflow simulation)
 [group('2. haskell')]
 logsink-example:

--- a/nix-develop-cached
+++ b/nix-develop-cached
@@ -19,7 +19,7 @@ source "$DIR/nix-shell-cache-lib.sh"
 if ! cache_valid; then
     mkdir -p "$CACHE_DIR"
     find "$CACHE_DIR" -maxdepth 1 -type f -not -name "$CACHE_KEY.*" -delete 2>/dev/null || true
-    nix print-dev-env "$DIR" > "$ENV_FILE.tmp" 2>/dev/null
+    nix print-dev-env "$DIR" --profile "$CACHE_DIR/profile" > "$ENV_FILE.tmp" 2>/dev/null
     mv "$ENV_FILE.tmp" "$ENV_FILE"
 fi
 

--- a/nix-develop-cached
+++ b/nix-develop-cached
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# nix-develop-cached — cached nix develop replacement (~0.015s vs ~5.4s)
+# nix-develop-cached — cached nix develop replacement (~0.03s vs ~5.4s)
 #
 # Runs a command inside the flake devShell environment, caching the full
 # `nix print-dev-env` output on first use. Subsequent calls source the
@@ -14,29 +14,7 @@
 set -euo pipefail
 
 DIR="$(cd "$(dirname "$0")" && pwd)"
-CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/vira-shell"
-
-CACHE_KEY=$(cat \
-    "$DIR/flake.nix" \
-    "$DIR/flake.lock" \
-    "$DIR/nix/modules/flake-parts/devshell.nix" \
-    "$DIR/nix/modules/flake-parts/haskell.nix" \
-    "$DIR/nix/modules/flake-parts/pre-commit.nix" \
-    "$DIR/nix/modules/flake-parts/assets.nix" \
-    "$DIR/nix/modules/flake-parts/vira-dev.nix" \
-    "$DIR/nix/modules/flake-parts/hpack-watch.nix" \
-    "$DIR/nix/modules/flake-parts/tests.nix" \
-    "$DIR/packages/attic/haskell-module.nix" \
-    "$DIR/packages/nix-cache-server/haskell-module.nix" \
-    2>/dev/null | { sha256sum 2>/dev/null || shasum -a 256; } | cut -d' ' -f1)
-ENV_FILE="$CACHE_DIR/$CACHE_KEY.sh"
-
-cache_valid() {
-    [[ -f "$ENV_FILE" ]] || return 1
-    local store_path
-    store_path=$(grep -o '/nix/store/[^/"'"'"']*' "$ENV_FILE" | head -1)
-    [[ -n "$store_path" ]] && [[ -e "$store_path" ]]
-}
+source "$DIR/nix-shell-cache-lib.sh"
 
 if ! cache_valid; then
     mkdir -p "$CACHE_DIR"

--- a/nix-develop-cached
+++ b/nix-develop-cached
@@ -28,7 +28,7 @@ CACHE_KEY=$(cat \
     "$DIR/nix/modules/flake-parts/tests.nix" \
     "$DIR/packages/attic/haskell-module.nix" \
     "$DIR/packages/nix-cache-server/haskell-module.nix" \
-    2>/dev/null | sha256sum | cut -d' ' -f1)
+    2>/dev/null | { sha256sum 2>/dev/null || shasum -a 256; } | cut -d' ' -f1)
 ENV_FILE="$CACHE_DIR/$CACHE_KEY.env"
 
 cache_valid() {

--- a/nix-develop-cached
+++ b/nix-develop-cached
@@ -23,5 +23,9 @@ if ! cache_valid; then
     mv "$ENV_FILE.tmp" "$ENV_FILE"
 fi
 
+# Source from project root — shellHook may use relative paths
+ORIG_DIR="$(pwd)"
+cd "$DIR"
 source "$ENV_FILE" > /dev/null
+cd "$ORIG_DIR"
 exec "$@"

--- a/nix-develop-cached
+++ b/nix-develop-cached
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # nix-develop-cached — cached nix develop replacement (~0.015s vs ~5.4s)
 #
-# Runs a command inside the flake devShell environment, caching the full set of
-# exported env vars on first use. Subsequent calls eval the cache and exec
-# directly, skipping nix entirely.
+# Runs a command inside the flake devShell environment, caching the full
+# `nix print-dev-env` output on first use. Subsequent calls source the
+# cache and exec directly, skipping nix entirely.
 #
 # Cache invalidation:
 #   Content hash of nix files + flake.lock. Any byte change → cache miss → re-eval.
@@ -29,21 +29,21 @@ CACHE_KEY=$(cat \
     "$DIR/packages/attic/haskell-module.nix" \
     "$DIR/packages/nix-cache-server/haskell-module.nix" \
     2>/dev/null | { sha256sum 2>/dev/null || shasum -a 256; } | cut -d' ' -f1)
-ENV_FILE="$CACHE_DIR/$CACHE_KEY.env"
+ENV_FILE="$CACHE_DIR/$CACHE_KEY.sh"
 
 cache_valid() {
     [[ -f "$ENV_FILE" ]] || return 1
     local store_path
-    store_path=$(grep '^declare -x PATH=' "$ENV_FILE" | grep -o '/nix/store/[^/:]*' | head -1)
+    store_path=$(grep -o '/nix/store/[^/"'"'"']*' "$ENV_FILE" | head -1)
     [[ -n "$store_path" ]] && [[ -e "$store_path" ]]
 }
 
 if ! cache_valid; then
     mkdir -p "$CACHE_DIR"
     find "$CACHE_DIR" -maxdepth 1 -type f -not -name "$CACHE_KEY.*" -delete 2>/dev/null || true
-    nix develop "$DIR" -c bash -c 'export -p' 2>/dev/null | grep '^declare -x ' > "$ENV_FILE.tmp"
+    nix print-dev-env "$DIR" > "$ENV_FILE.tmp" 2>/dev/null
     mv "$ENV_FILE.tmp" "$ENV_FILE"
 fi
 
-eval "$(cat "$ENV_FILE")"
+source "$ENV_FILE" > /dev/null
 exec "$@"

--- a/nix-develop-cached
+++ b/nix-develop-cached
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# nix-develop-cached — cached nix develop replacement (~0.015s vs ~5.4s)
+#
+# Runs a command inside the flake devShell environment, caching the full set of
+# exported env vars on first use. Subsequent calls eval the cache and exec
+# directly, skipping nix entirely.
+#
+# Cache invalidation:
+#   Content hash of nix files + flake.lock. Any byte change → cache miss → re-eval.
+#
+# Known limitations:
+#   - shellHook side-effects (pre-commit install, symlinks) only run on cache miss.
+#   - Only one store path checked for GC validity. rm cache dir to force re-eval.
+set -euo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/vira-shell"
+
+CACHE_KEY=$(cat \
+    "$DIR/flake.nix" \
+    "$DIR/flake.lock" \
+    "$DIR/nix/modules/flake-parts/devshell.nix" \
+    "$DIR/nix/modules/flake-parts/haskell.nix" \
+    "$DIR/nix/modules/flake-parts/pre-commit.nix" \
+    "$DIR/nix/modules/flake-parts/assets.nix" \
+    "$DIR/nix/modules/flake-parts/vira-dev.nix" \
+    "$DIR/nix/modules/flake-parts/hpack-watch.nix" \
+    "$DIR/nix/modules/flake-parts/tests.nix" \
+    "$DIR/packages/attic/haskell-module.nix" \
+    "$DIR/packages/nix-cache-server/haskell-module.nix" \
+    2>/dev/null | sha256sum | cut -d' ' -f1)
+ENV_FILE="$CACHE_DIR/$CACHE_KEY.env"
+
+cache_valid() {
+    [[ -f "$ENV_FILE" ]] || return 1
+    local store_path
+    store_path=$(grep '^declare -x PATH=' "$ENV_FILE" | grep -o '/nix/store/[^/:]*' | head -1)
+    [[ -n "$store_path" ]] && [[ -e "$store_path" ]]
+}
+
+if ! cache_valid; then
+    mkdir -p "$CACHE_DIR"
+    find "$CACHE_DIR" -maxdepth 1 -type f -not -name "$CACHE_KEY.*" -delete 2>/dev/null || true
+    nix develop "$DIR" -c bash -c 'export -p' 2>/dev/null | grep '^declare -x ' > "$ENV_FILE.tmp"
+    mv "$ENV_FILE.tmp" "$ENV_FILE"
+fi
+
+eval "$(cat "$ENV_FILE")"
+exec "$@"

--- a/nix-shell-cache-lib.sh
+++ b/nix-shell-cache-lib.sh
@@ -7,18 +7,13 @@
 
 CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/vira-shell"
 
+# nixos-unified autowires all .nix files under nix/modules/flake-parts/,
+# so we glob rather than hardcoding to catch new modules automatically.
 NIX_FILES=(
     "$DIR/flake.nix"
     "$DIR/flake.lock"
-    "$DIR/nix/modules/flake-parts/devshell.nix"
-    "$DIR/nix/modules/flake-parts/haskell.nix"
-    "$DIR/nix/modules/flake-parts/pre-commit.nix"
-    "$DIR/nix/modules/flake-parts/assets.nix"
-    "$DIR/nix/modules/flake-parts/vira-dev.nix"
-    "$DIR/nix/modules/flake-parts/hpack-watch.nix"
-    "$DIR/nix/modules/flake-parts/tests.nix"
-    "$DIR/packages/attic/haskell-module.nix"
-    "$DIR/packages/nix-cache-server/haskell-module.nix"
+    "$DIR"/nix/modules/flake-parts/*.nix
+    "$DIR"/packages/*/haskell-module.nix
 )
 
 # Include cabal project file and all package.yaml files in the cache key.

--- a/nix-shell-cache-lib.sh
+++ b/nix-shell-cache-lib.sh
@@ -21,7 +21,15 @@ NIX_FILES=(
     "$DIR/packages/nix-cache-server/haskell-module.nix"
 )
 
-CACHE_KEY=$(cat "${NIX_FILES[@]}" 2>/dev/null | { sha256sum 2>/dev/null || shasum -a 256; } | cut -d' ' -f1)
+# Include cabal project file and all package.yaml files in the cache key.
+# Haskell dependency changes (package.yaml → .cabal) affect the devShell
+# but aren't captured by .nix files alone.
+CABAL_FILES=("$DIR/cabal.project")
+while IFS= read -r -d '' f; do
+    CABAL_FILES+=("$f")
+done < <(find "$DIR/packages" -name "package.yaml" -print0 2>/dev/null)
+
+CACHE_KEY=$(cat "${NIX_FILES[@]}" "${CABAL_FILES[@]}" 2>/dev/null | { sha256sum 2>/dev/null || shasum -a 256; } | cut -d' ' -f1)
 ENV_FILE="$CACHE_DIR/$CACHE_KEY.sh"
 
 cache_valid() {

--- a/nix-shell-cache-lib.sh
+++ b/nix-shell-cache-lib.sh
@@ -1,0 +1,32 @@
+# nix-shell-cache-lib.sh — shared cache key logic for .envrc and nix-develop-cached
+#
+# Sources this to get: CACHE_DIR, CACHE_KEY, ENV_FILE, cache_valid()
+# Expects DIR to be set to the project root before sourcing.
+
+: "${DIR:="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"}"
+
+CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/vira-shell"
+
+NIX_FILES=(
+    "$DIR/flake.nix"
+    "$DIR/flake.lock"
+    "$DIR/nix/modules/flake-parts/devshell.nix"
+    "$DIR/nix/modules/flake-parts/haskell.nix"
+    "$DIR/nix/modules/flake-parts/pre-commit.nix"
+    "$DIR/nix/modules/flake-parts/assets.nix"
+    "$DIR/nix/modules/flake-parts/vira-dev.nix"
+    "$DIR/nix/modules/flake-parts/hpack-watch.nix"
+    "$DIR/nix/modules/flake-parts/tests.nix"
+    "$DIR/packages/attic/haskell-module.nix"
+    "$DIR/packages/nix-cache-server/haskell-module.nix"
+)
+
+CACHE_KEY=$(cat "${NIX_FILES[@]}" 2>/dev/null | { sha256sum 2>/dev/null || shasum -a 256; } | cut -d' ' -f1)
+ENV_FILE="$CACHE_DIR/$CACHE_KEY.sh"
+
+cache_valid() {
+    [[ -f "$ENV_FILE" ]] || return 1
+    local store_path
+    store_path=$(grep -o '/nix/store/[^/"'"'"']*' "$ENV_FILE" | head -1)
+    [[ -n "$store_path" ]] && [[ -e "$store_path" ]]
+}


### PR DESCRIPTION
**DevShell startup drops from ~5.3s to ~0.04s** (or ~0.13s via direnv) by caching the `nix print-dev-env` output keyed on content hashes of all nix/cabal files that influence the devShell.

Eval profiling (Nix 2.32 flamegraph) confirmed that ~4.4s of the 5.3s eval time is haskell-flake's `generic-builder.nix` evaluating derivations for all 15 local Haskell packages — *irreducible within the current flake architecture*. Caching the result is the right lever.

The cache key covers `flake.nix`, `flake.lock`, all autowired flake-parts modules, haskell-module.nix files, `cabal.project`, and every `package.yaml`. A nix profile symlink acts as a GC root so `nix-collect-garbage` won't silently invalidate the cache. Store-path validation catches edge cases.

| Path | Before | After |
|------|--------|-------|
| `./nix-develop-cached ...` | — | **~0.04s** |
| `direnv exec . ...` | ~5.3s | **~0.13s** |
| Cache miss | — | ~5.3s (baseline) |

> `just nix-cache-clear` to force a full re-eval when needed.