### PR TITLE
feat: add convention-based post-build hook (viraPostBuildHook.sh)

### DIFF
--- a/doc/guide/config.md
+++ b/doc/guide/config.md
@@ -132,6 +132,50 @@ Enables commit status reporting to GitHub or Bitbucket. When enabled, Vira posts
 - For GitHub, uses GitHub API with token from `gh` CLI.
 - For Bitbucket, uses Bitbucket API with token from `bb` CLI.
 
+#### PostBuild Stage
+
+After a successful pipeline run (Build → Cache → Signoff), Vira can fire one or more outbound HTTPS webhooks. Only HTTPS is permitted.
+
+```haskell
+pipeline
+  { postBuild.webhooks =
+      [ WebhookConfig
+          { url     = "https://hooks.slack.com/services/$SLACK_WEBHOOK_TOKEN"
+          , method  = POST
+          , headers = [("Content-Type", "application/json")]
+          , body    = Just "{\"text\": \"✅ $VIRA_BRANCH @ $VIRA_COMMIT_ID built\"}"
+          }
+      ]
+  }
+```
+
+**Variable substitution** is performed on `url`, header values, and `body` before the request is sent:
+
+| Variable           | Description                                        | Always available?                              |
+| ------------------ | -------------------------------------------------- | ---------------------------------------------- |
+| `$VIRA_BRANCH`     | Current branch name                                | ✅ Yes                                         |
+| `$VIRA_COMMIT_ID`  | Commit SHA being built                             | ✅ Yes                                         |
+| `$VIRA_CLONE_URL`  | Repository clone URL (empty if unavailable)        | ✅ Yes                                         |
+| `$VIRA_REPO_DIR`   | Absolute path to the cloned repo on the CI machine | ✅ Yes                                         |
+| `$VIRA_ONLY_BUILD` | `"true"` when running in build-only mode           | ✅ Yes                                         |
+| `$FOO`             | Any CI machine env var named `FOO`                 | Only if `FOO` is in `VIRA_WEBHOOK_ALLOWED_ENV` |
+
+**Secrets stay on the CI machine.** A variable reference like `$SLACK_WEBHOOK_TOKEN` in `vira.hs` is safe to commit — the actual token value is never logged or visible to the repository. It is only injected into the outbound HTTP request at build time.
+
+**Operator allowlist.** On the Vira server, set the `VIRA_WEBHOOK_ALLOWED_ENV` environment variable to a comma-separated list of env var names that repos are permitted to reference:
+
+```sh
+VIRA_WEBHOOK_ALLOWED_ENV=SLACK_WEBHOOK_TOKEN,GITHUB_TOKEN,DEPLOY_API_KEY
+```
+
+Any `$VAR` reference not in this list (and not a `$VIRA_*` variable) is substituted with an empty string.
+
+> [!NOTE]
+> Webhooks are fired in the order they are declared. A failed webhook (non-2xx response or timeout) stops the pipeline with an error.
+
+> [!NOTE]
+> The `GET` method ignores the `body` field. Use `POST`, `PUT`, or `PATCH` to send a request body.
+
 ## Conditional Configuration {#cond}
 
 You can customize the pipeline based on branch or repository information:

--- a/doc/guide/config.md
+++ b/doc/guide/config.md
@@ -20,7 +20,6 @@ Create a `vira.hs` file in your repository root:
     { signoff.enable = True
     , build.flakes = ["." { overrideInputs = [("nixpkgs", "github:nixos/nixpkgs/nixos-unstable")] }]
     , cache.url = Just "https://attic.example.com/my-cache"
-    , postBuild.timeoutSeconds = 120
     }
 ```
 
@@ -132,59 +131,6 @@ Enables commit status reporting to GitHub or Bitbucket. When enabled, Vira posts
 
 - For GitHub, uses GitHub API with token from `gh` CLI.
 - For Bitbucket, uses Bitbucket API with token from `bb` CLI.
-
-#### PostBuild Stage
-
-Vira supports a convention-based post-build hook. If a file named `viraPostBuildHook.sh` exists at the **root of your repository** and is executable, it is automatically run after a successful build (after cache push and signoff).
-
-No configuration is needed to enable the hook — its presence in the repo is the trigger.
-
-The only configurable option is the timeout:
-
-```haskell
--- Increase timeout for slow notification scripts (default: 600 seconds)
-pipeline { postBuild.timeoutSeconds = 120 }
-```
-
-**Creating the hook script:**
-
-```bash
-#!/usr/bin/env bash
-# viraPostBuildHook.sh — placed at repo root, must be executable
-# chmod +x viraPostBuildHook.sh
-
-# Trigger a Jenkins build using credentials from the CI machine environment.
-# JENKINS_URL, JENKINS_USER, and JENKINS_TOKEN must be set as env vars on the CI machine.
-# Adjust the job path to match your Jenkins folder/job structure.
-curl -X POST \
-  "${JENKINS_URL}/job/MyOrg/job/my-repo/job/my-job/build?delay=0sec" \
-  --user "${JENKINS_USER}:${JENKINS_TOKEN}"
-```
-
-Make it executable before committing:
-
-```bash
-chmod +x viraPostBuildHook.sh
-```
-
-Vira context is exposed as environment variables:
-
-| Environment Variable | Description                                        | Example                        |
-| -------------------- | -------------------------------------------------- | ------------------------------ |
-| `VIRA_BRANCH`        | Current branch name                                | `main`                         |
-| `VIRA_COMMIT_ID`     | Commit ID being built                              | `abc123...`                    |
-| `VIRA_CLONE_URL`     | Repository clone URL (empty string if unavailable) | `git@github.com:user/repo.git` |
-| `VIRA_REPO_DIR`      | Repository working directory                       | `/workspace/project`           |
-| `VIRA_ONLY_BUILD`    | Whether running in build-only mode                 | `true` or `false`              |
-
-> [!NOTE]
-> The script is executed directly (not via shell), from the repository root directory. The post-build hook runs **last** — after build, cache push, and signoff. If the hook fails (non-zero exit code) or times out, the pipeline fails. The hook is skipped when running with `--only-build`.
-
-> [!TIP]
-> For secrets (API tokens, credentials), set them as environment variables on the CI machine rather than committing them to the repository. The script can access them alongside the Vira context variables.
-
-> [!WARNING]
-> The hook script runs with full CI machine privileges and has access to **all environment variables** on the CI machine, including any secrets. Treat `viraPostBuildHook.sh` with the same scrutiny as any other privileged CI configuration.
 
 ## Conditional Configuration {#cond}
 

--- a/doc/guide/config.md
+++ b/doc/guide/config.md
@@ -20,6 +20,7 @@ Create a `vira.hs` file in your repository root:
     { signoff.enable = True
     , build.flakes = ["." { overrideInputs = [("nixpkgs", "github:nixos/nixpkgs/nixos-unstable")] }]
     , cache.url = Just "https://attic.example.com/my-cache"
+    , postBuild.timeoutSeconds = 120
     }
 ```
 
@@ -131,6 +132,59 @@ Enables commit status reporting to GitHub or Bitbucket. When enabled, Vira posts
 
 - For GitHub, uses GitHub API with token from `gh` CLI.
 - For Bitbucket, uses Bitbucket API with token from `bb` CLI.
+
+#### PostBuild Stage
+
+Vira supports a convention-based post-build hook. If a file named `viraPostBuildHook.sh` exists at the **root of your repository** and is executable, it is automatically run after a successful build (after cache push and signoff).
+
+No configuration is needed to enable the hook — its presence in the repo is the trigger.
+
+The only configurable option is the timeout:
+
+```haskell
+-- Increase timeout for slow notification scripts (default: 600 seconds)
+pipeline { postBuild.timeoutSeconds = 120 }
+```
+
+**Creating the hook script:**
+
+```bash
+#!/usr/bin/env bash
+# viraPostBuildHook.sh — placed at repo root, must be executable
+# chmod +x viraPostBuildHook.sh
+
+# Trigger a Jenkins build using credentials from the CI machine environment.
+# JENKINS_URL, JENKINS_USER, and JENKINS_TOKEN must be set as env vars on the CI machine.
+# Adjust the job path to match your Jenkins folder/job structure.
+curl -X POST \
+  "${JENKINS_URL}/job/MyOrg/job/my-repo/job/my-job/build?delay=0sec" \
+  --user "${JENKINS_USER}:${JENKINS_TOKEN}"
+```
+
+Make it executable before committing:
+
+```bash
+chmod +x viraPostBuildHook.sh
+```
+
+Vira context is exposed as environment variables:
+
+| Environment Variable | Description                                        | Example                        |
+| -------------------- | -------------------------------------------------- | ------------------------------ |
+| `VIRA_BRANCH`        | Current branch name                                | `main`                         |
+| `VIRA_COMMIT_ID`     | Commit ID being built                              | `abc123...`                    |
+| `VIRA_CLONE_URL`     | Repository clone URL (empty string if unavailable) | `git@github.com:user/repo.git` |
+| `VIRA_REPO_DIR`      | Repository working directory                       | `/workspace/project`           |
+| `VIRA_ONLY_BUILD`    | Whether running in build-only mode                 | `true` or `false`              |
+
+> [!NOTE]
+> The script is executed directly (not via shell), from the repository root directory. The post-build hook runs **last** — after build, cache push, and signoff. If the hook fails (non-zero exit code) or times out, the pipeline fails. The hook is skipped when running with `--only-build`.
+
+> [!TIP]
+> For secrets (API tokens, credentials), set them as environment variables on the CI machine rather than committing them to the repository. The script can access them alongside the Vira context variables.
+
+> [!WARNING]
+> The hook script runs with full CI machine privileges and has access to **all environment variables** on the CI machine, including any secrets. Treat `viraPostBuildHook.sh` with the same scrutiny as any other privileged CI configuration.
 
 ## Conditional Configuration {#cond}
 

--- a/nix/modules/common/vira-options.nix
+++ b/nix/modules/common/vira-options.nix
@@ -92,6 +92,45 @@ in
       };
     };
 
+    webhookAllowedDomains = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      description = ''
+        List of hostnames that repository <filename>vira.hs</filename> configs are
+        permitted to use as post-build webhook targets.
+
+        An empty list (the default) disables all outbound webhooks.
+        Entries are matched exactly against the URL host — no wildcard
+        expansion is performed.
+
+        Example: <literal>[ "hooks.slack.com" "api.example.com" ]</literal>
+
+        Populates the <envar>VIRA_WEBHOOK_ALLOWED_DOMAINS</envar> environment
+        variable consumed by the Vira service.
+      '';
+      example = [ "hooks.slack.com" "api.example.com" ];
+    };
+
+    webhookAllowedEnv = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      description = ''
+        List of environment variable names that repository
+        <filename>vira.hs</filename> webhook templates are permitted to
+        reference via <literal>$VAR</literal> substitution.
+
+        Variables not in this list are silently replaced with an empty
+        string, so secrets that are not explicitly opt-in are never sent
+        to webhook targets.
+
+        Example: <literal>[ "SLACK_WEBHOOK_TOKEN" "DEPLOY_API_KEY" ]</literal>
+
+        Populates the <envar>VIRA_WEBHOOK_ALLOWED_ENV</envar> environment
+        variable consumed by the Vira service.
+      '';
+      example = [ "SLACK_WEBHOOK_TOKEN" "DEPLOY_API_KEY" ];
+    };
+
     systemd = mkOption {
       description = "Systemd service configuration overrides";
       default = { };

--- a/nix/modules/home-manager/vira.nix
+++ b/nix/modules/home-manager/vira.nix
@@ -32,9 +32,17 @@ in
       Service =
         let
           # Build environment variable list, avoiding duplicate PATH entries
-          defaultEnv = optionalAttrs (cfg.extraPackages != [ ]) {
-            PATH = "${makeBinPath cfg.extraPackages}:$PATH";
-          };
+          defaultEnv =
+            optionalAttrs (cfg.extraPackages != [ ])
+              {
+                PATH = "${makeBinPath cfg.extraPackages}:$PATH";
+              }
+            // optionalAttrs (cfg.webhookAllowedDomains != [ ]) {
+              VIRA_WEBHOOK_ALLOWED_DOMAINS = concatStringsSep "," cfg.webhookAllowedDomains;
+            }
+            // optionalAttrs (cfg.webhookAllowedEnv != [ ]) {
+              VIRA_WEBHOOK_ALLOWED_ENV = concatStringsSep "," cfg.webhookAllowedEnv;
+            };
           # User environment overrides defaults
           mergedEnv = defaultEnv // cfg.systemd.environment;
           envList = mapAttrsToList (name: value: "${name}=${value}") mergedEnv;
@@ -76,7 +84,17 @@ in
         ProcessType = "Background";
         StandardOutPath = "${config.home.homeDirectory}/Library/Logs/vira.log";
         StandardErrorPath = "${config.home.homeDirectory}/Library/Logs/vira.log";
-        EnvironmentVariables.PATH = makeBinPath cfg.extraPackages;
+        EnvironmentVariables =
+          optionalAttrs (cfg.extraPackages != [ ])
+            {
+              PATH = makeBinPath cfg.extraPackages;
+            }
+          // optionalAttrs (cfg.webhookAllowedDomains != [ ]) {
+            VIRA_WEBHOOK_ALLOWED_DOMAINS = concatStringsSep "," cfg.webhookAllowedDomains;
+          }
+          // optionalAttrs (cfg.webhookAllowedEnv != [ ]) {
+            VIRA_WEBHOOK_ALLOWED_ENV = concatStringsSep "," cfg.webhookAllowedEnv;
+          };
       };
     };
 

--- a/packages/vira-ci-types/src/Vira/CI/Pipeline/Type.hs
+++ b/packages/vira-ci-types/src/Vira/CI/Pipeline/Type.hs
@@ -11,12 +11,19 @@
 {-# HLINT ignore "Avoid lambda using `infix`" #-}
 {-# HLINT ignore "Avoid lambda" #-}
 {-# HLINT ignore "Use 'fromString' from Relude" #-}
+{-# HLINT ignore "Use toText" #-}
+{-# HLINT ignore "Use alternative" #-}
 
 module Vira.CI.Pipeline.Type where
 
+import Data.Char (isAsciiLower, isAsciiUpper, isDigit)
+import Data.Map.Strict qualified as Map
 import Data.String (IsString (..))
+import Data.Text qualified as T
+import Data.Text.Lazy qualified as TL
+import Data.Text.Lazy.Builder qualified as TB
 import GHC.Records.Compat
-import Relude (Bool (..), FilePath, Generic, Maybe, NonEmpty, Show, Text, notElem)
+import Relude (Bool (..), Char, Eq (..), FilePath, Generic, Maybe (..), NonEmpty, Ord (..), Show, Text, maybe, mempty, notElem, ($), (&&), (<>), (||))
 import System.Nix.System (System)
 
 -- | CI Pipeline configuration types
@@ -25,6 +32,7 @@ data ViraPipeline = ViraPipeline
   , nix :: NixConfig
   , cache :: CacheStage
   , signoff :: SignoffStage
+  , postBuild :: PostBuildStage
   }
   deriving stock (Generic, Show)
 
@@ -90,6 +98,81 @@ newtype CacheStage = CacheStage
   }
   deriving stock (Generic, Show)
 
+-- | HTTP method for webhook requests
+data HttpMethod = GET | POST | PUT | PATCH
+  deriving stock (Generic, Show)
+
+{- | A single outbound webhook triggered after a successful build.
+
+Variable substitution is performed on 'url', 'headers' values, and 'body'
+before the request is sent. Two namespaces are available:
+
+  * @$VIRA_BRANCH@, @$VIRA_COMMIT_ID@, @$VIRA_CLONE_URL@, @$VIRA_REPO_DIR@,
+    @$VIRA_ONLY_BUILD@ — always substituted from the build context.
+  * Any other @$VAR@ — substituted from the CI machine environment, but only
+    if @VAR@ appears in the operator-configured allowlist
+    (@VIRA_WEBHOOK_ALLOWED_ENV@). Unknown variables are replaced with an
+    empty string.
+-}
+data WebhookConfig = WebhookConfig
+  { url :: Text
+  -- ^ Webhook URL. May contain @$VAR@ placeholders.
+  , method :: HttpMethod
+  -- ^ HTTP method to use.
+  , headers :: [(Text, Text)]
+  -- ^ Extra request headers as @(name, value)@ pairs. Values may contain @$VAR@ placeholders.
+  , body :: Maybe Text
+  -- ^ Optional request body. May contain @$VAR@ placeholders.
+  }
+  deriving stock (Generic, Show)
+
+{- | Post-build stage: fire zero or more outbound webhooks after a
+successful pipeline run (Build → Cache → Signoff → PostBuild).
+-}
+newtype PostBuildStage = PostBuildStage
+  { webhooks :: [WebhookConfig]
+  -- ^ Webhooks to fire in order. An empty list is a no-op.
+  }
+  deriving stock (Generic, Show)
+
+{- | Substitute @$VAR@ placeholders in a text value.
+
+Replaces every @$KEY@ with the corresponding value. Unknown keys are replaced
+with empty string. Single-pass (no recursive expansion).
+
+Variable names must start with a letter or underscore, followed by letters,
+digits, or underscores. A bare @$@ not followed by a valid identifier start
+is kept as-is (e.g., @$100@, @$1@ remain unchanged).
+-}
+substituteVars :: [(Text, Text)] -> Text -> Text
+substituteVars bindings tmpl =
+  TL.toStrict $ TB.toLazyText $ go tmpl
+  where
+    lookupMap :: Map.Map Text Text
+    lookupMap = Map.fromList bindings
+
+    -- Uses T.breakOn for O(n) performance instead of character-by-character.
+    go :: Text -> TB.Builder
+    go t =
+      let (lit, rest) = T.breakOn "$" t
+          prefix = TB.fromText lit
+       in case T.uncons rest of
+            Nothing -> prefix
+            Just ('$', after) ->
+              case T.uncons after of
+                Just (c, _)
+                  | isVarStart c ->
+                      let (name, tail_) = T.span isIdentChar after
+                          replacement = maybe mempty TB.fromText (Map.lookup name lookupMap)
+                       in prefix <> replacement <> go tail_
+                _ -> prefix <> TB.singleton '$' <> go after
+            Just _ -> prefix <> go rest -- unreachable
+    isVarStart :: Char -> Bool
+    isVarStart c = isAsciiUpper c || isAsciiLower c || c == '_'
+
+    isIdentChar :: Char -> Bool
+    isIdentChar c = isVarStart c || isDigit c
+
 -- HasField instances for enabling OverloadedRecordUpdate syntax (see vira.hs)
 -- NOTE: Do not forgot to fill in these instances if the types above change.
 -- In future, we could generically derive them using generics-sop and the like.
@@ -115,14 +198,32 @@ instance HasField "enable" SignoffStage Bool where
 instance HasField "url" CacheStage (Maybe Text) where
   hasField (CacheStage url) = (CacheStage, url)
 
+instance HasField "url" WebhookConfig Text where
+  hasField wh = (\x -> wh {url = x}, wh.url)
+
+instance HasField "method" WebhookConfig HttpMethod where
+  hasField wh = (\x -> wh {method = x}, wh.method)
+
+instance HasField "headers" WebhookConfig [(Text, Text)] where
+  hasField wh = (\x -> wh {headers = x}, wh.headers)
+
+instance HasField "body" WebhookConfig (Maybe Text) where
+  hasField wh = (\x -> wh {body = x}, wh.body)
+
+instance HasField "webhooks" PostBuildStage [WebhookConfig] where
+  hasField (PostBuildStage webhooks) = (PostBuildStage, webhooks)
+
 instance HasField "build" ViraPipeline BuildStage where
-  hasField (ViraPipeline build nix cache signoff) = (\x -> ViraPipeline x nix cache signoff, build)
+  hasField (ViraPipeline build nix cache signoff postBuild) = (\x -> ViraPipeline x nix cache signoff postBuild, build)
 
 instance HasField "nix" ViraPipeline NixConfig where
-  hasField (ViraPipeline build nix cache signoff) = (\x -> ViraPipeline build x cache signoff, nix)
+  hasField (ViraPipeline build nix cache signoff postBuild) = (\x -> ViraPipeline build x cache signoff postBuild, nix)
 
 instance HasField "cache" ViraPipeline CacheStage where
-  hasField (ViraPipeline build nix cache signoff) = (\x -> ViraPipeline build nix x signoff, cache)
+  hasField (ViraPipeline build nix cache signoff postBuild) = (\x -> ViraPipeline build nix x signoff postBuild, cache)
 
 instance HasField "signoff" ViraPipeline SignoffStage where
-  hasField (ViraPipeline build nix cache signoff) = (ViraPipeline build nix cache, signoff)
+  hasField (ViraPipeline build nix cache signoff postBuild) = (\x -> ViraPipeline build nix cache x postBuild, signoff)
+
+instance HasField "postBuild" ViraPipeline PostBuildStage where
+  hasField (ViraPipeline build nix cache signoff postBuild) = (ViraPipeline build nix cache signoff, postBuild)

--- a/packages/vira-ci-types/src/Vira/CI/Pipeline/Type.hs
+++ b/packages/vira-ci-types/src/Vira/CI/Pipeline/Type.hs
@@ -16,7 +16,7 @@ module Vira.CI.Pipeline.Type where
 
 import Data.String (IsString (..))
 import GHC.Records.Compat
-import Relude (Bool (..), FilePath, Generic, Int, Maybe, NonEmpty, Show, Text, notElem)
+import Relude (Bool (..), FilePath, Generic, Maybe, NonEmpty, Show, Text, notElem)
 import System.Nix.System (System)
 
 -- | CI Pipeline configuration types
@@ -25,7 +25,6 @@ data ViraPipeline = ViraPipeline
   , nix :: NixConfig
   , cache :: CacheStage
   , signoff :: SignoffStage
-  , postBuild :: PostBuildStage
   }
   deriving stock (Generic, Show)
 
@@ -91,17 +90,6 @@ newtype CacheStage = CacheStage
   }
   deriving stock (Generic, Show)
 
-{- | Post-build hook configuration.
-When 'viraPostBuildHook.sh' exists in the repository root and is executable,
-it is run after a successful build with Vira context exposed as env vars:
-VIRA_BRANCH, VIRA_COMMIT_ID, VIRA_CLONE_URL, VIRA_REPO_DIR, VIRA_ONLY_BUILD
--}
-newtype PostBuildStage = PostBuildStage
-  { timeoutSeconds :: Int
-  -- ^ Maximum seconds to wait for the hook script to complete.
-  }
-  deriving stock (Generic, Show)
-
 -- HasField instances for enabling OverloadedRecordUpdate syntax (see vira.hs)
 -- NOTE: Do not forgot to fill in these instances if the types above change.
 -- In future, we could generically derive them using generics-sop and the like.
@@ -127,20 +115,14 @@ instance HasField "enable" SignoffStage Bool where
 instance HasField "url" CacheStage (Maybe Text) where
   hasField (CacheStage url) = (CacheStage, url)
 
-instance HasField "timeoutSeconds" PostBuildStage Int where
-  hasField (PostBuildStage timeoutSeconds) = (PostBuildStage, timeoutSeconds)
-
 instance HasField "build" ViraPipeline BuildStage where
-  hasField (ViraPipeline build nix cache signoff postBuild) = (\x -> ViraPipeline x nix cache signoff postBuild, build)
+  hasField (ViraPipeline build nix cache signoff) = (\x -> ViraPipeline x nix cache signoff, build)
 
 instance HasField "nix" ViraPipeline NixConfig where
-  hasField (ViraPipeline build nix cache signoff postBuild) = (\x -> ViraPipeline build x cache signoff postBuild, nix)
+  hasField (ViraPipeline build nix cache signoff) = (\x -> ViraPipeline build x cache signoff, nix)
 
 instance HasField "cache" ViraPipeline CacheStage where
-  hasField (ViraPipeline build nix cache signoff postBuild) = (\x -> ViraPipeline build nix x signoff postBuild, cache)
+  hasField (ViraPipeline build nix cache signoff) = (\x -> ViraPipeline build nix x signoff, cache)
 
 instance HasField "signoff" ViraPipeline SignoffStage where
-  hasField (ViraPipeline build nix cache signoff postBuild) = (\x -> ViraPipeline build nix cache x postBuild, signoff)
-
-instance HasField "postBuild" ViraPipeline PostBuildStage where
-  hasField (ViraPipeline build nix cache signoff postBuild) = (ViraPipeline build nix cache signoff, postBuild)
+  hasField (ViraPipeline build nix cache signoff) = (ViraPipeline build nix cache, signoff)

--- a/packages/vira-ci-types/src/Vira/CI/Pipeline/Type.hs
+++ b/packages/vira-ci-types/src/Vira/CI/Pipeline/Type.hs
@@ -16,7 +16,7 @@ module Vira.CI.Pipeline.Type where
 
 import Data.String (IsString (..))
 import GHC.Records.Compat
-import Relude (Bool (..), FilePath, Generic, Maybe, NonEmpty, Show, Text, notElem)
+import Relude (Bool (..), FilePath, Generic, Int, Maybe, NonEmpty, Show, Text, notElem)
 import System.Nix.System (System)
 
 -- | CI Pipeline configuration types
@@ -25,6 +25,7 @@ data ViraPipeline = ViraPipeline
   , nix :: NixConfig
   , cache :: CacheStage
   , signoff :: SignoffStage
+  , postBuild :: PostBuildStage
   }
   deriving stock (Generic, Show)
 
@@ -90,6 +91,17 @@ newtype CacheStage = CacheStage
   }
   deriving stock (Generic, Show)
 
+{- | Post-build hook configuration.
+When 'viraPostBuildHook.sh' exists in the repository root and is executable,
+it is run after a successful build with Vira context exposed as env vars:
+VIRA_BRANCH, VIRA_COMMIT_ID, VIRA_CLONE_URL, VIRA_REPO_DIR, VIRA_ONLY_BUILD
+-}
+newtype PostBuildStage = PostBuildStage
+  { timeoutSeconds :: Int
+  -- ^ Maximum seconds to wait for the hook script to complete.
+  }
+  deriving stock (Generic, Show)
+
 -- HasField instances for enabling OverloadedRecordUpdate syntax (see vira.hs)
 -- NOTE: Do not forgot to fill in these instances if the types above change.
 -- In future, we could generically derive them using generics-sop and the like.
@@ -115,14 +127,20 @@ instance HasField "enable" SignoffStage Bool where
 instance HasField "url" CacheStage (Maybe Text) where
   hasField (CacheStage url) = (CacheStage, url)
 
+instance HasField "timeoutSeconds" PostBuildStage Int where
+  hasField (PostBuildStage timeoutSeconds) = (PostBuildStage, timeoutSeconds)
+
 instance HasField "build" ViraPipeline BuildStage where
-  hasField (ViraPipeline build nix cache signoff) = (\x -> ViraPipeline x nix cache signoff, build)
+  hasField (ViraPipeline build nix cache signoff postBuild) = (\x -> ViraPipeline x nix cache signoff postBuild, build)
 
 instance HasField "nix" ViraPipeline NixConfig where
-  hasField (ViraPipeline build nix cache signoff) = (\x -> ViraPipeline build x cache signoff, nix)
+  hasField (ViraPipeline build nix cache signoff postBuild) = (\x -> ViraPipeline build x cache signoff postBuild, nix)
 
 instance HasField "cache" ViraPipeline CacheStage where
-  hasField (ViraPipeline build nix cache signoff) = (\x -> ViraPipeline build nix x signoff, cache)
+  hasField (ViraPipeline build nix cache signoff postBuild) = (\x -> ViraPipeline build nix x signoff postBuild, cache)
 
 instance HasField "signoff" ViraPipeline SignoffStage where
-  hasField (ViraPipeline build nix cache signoff) = (ViraPipeline build nix cache, signoff)
+  hasField (ViraPipeline build nix cache signoff postBuild) = (\x -> ViraPipeline build nix cache x postBuild, signoff)
+
+instance HasField "postBuild" ViraPipeline PostBuildStage where
+  hasField (ViraPipeline build nix cache signoff postBuild) = (ViraPipeline build nix cache signoff, postBuild)

--- a/packages/vira/src/Vira/CI/Pipeline/Effect.hs
+++ b/packages/vira/src/Vira/CI/Pipeline/Effect.hs
@@ -105,6 +105,8 @@ data Pipeline :: Effect where
   Cache :: ViraPipeline -> NonEmpty BuildResult -> Pipeline m ()
   -- | Create GitHub/Bitbucket commit signoff (one per system)
   Signoff :: ViraPipeline -> NonEmpty BuildResult -> Pipeline m ()
+  -- | Fire configured post-build webhooks
+  PostBuild :: ViraPipeline -> NonEmpty BuildResult -> Pipeline m ()
 
 -- Generate boilerplate for the effect
 makeEffect ''Pipeline

--- a/packages/vira/src/Vira/CI/Pipeline/Effect.hs
+++ b/packages/vira/src/Vira/CI/Pipeline/Effect.hs
@@ -105,6 +105,8 @@ data Pipeline :: Effect where
   Cache :: ViraPipeline -> NonEmpty BuildResult -> Pipeline m ()
   -- | Create GitHub/Bitbucket commit signoff (one per system)
   Signoff :: ViraPipeline -> NonEmpty BuildResult -> Pipeline m ()
+  -- | Run post-build hook with Vira context exposed as env vars
+  PostBuild :: ViraPipeline -> NonEmpty BuildResult -> Pipeline m ()
 
 -- Generate boilerplate for the effect
 makeEffect ''Pipeline

--- a/packages/vira/src/Vira/CI/Pipeline/Effect.hs
+++ b/packages/vira/src/Vira/CI/Pipeline/Effect.hs
@@ -105,8 +105,6 @@ data Pipeline :: Effect where
   Cache :: ViraPipeline -> NonEmpty BuildResult -> Pipeline m ()
   -- | Create GitHub/Bitbucket commit signoff (one per system)
   Signoff :: ViraPipeline -> NonEmpty BuildResult -> Pipeline m ()
-  -- | Run post-build hook with Vira context exposed as env vars
-  PostBuild :: ViraPipeline -> NonEmpty BuildResult -> Pipeline m ()
 
 -- Generate boilerplate for the effect
 makeEffect ''Pipeline

--- a/packages/vira/src/Vira/CI/Pipeline/Implementation.hs
+++ b/packages/vira/src/Vira/CI/Pipeline/Implementation.hs
@@ -36,21 +36,17 @@ import Effectful.Process (Process)
 import Effectful.Reader.Static qualified as ER
 import Prettyprinter
 import Prettyprinter.Render.Text (renderStrict)
-import System.Directory (executable, getPermissions)
-import System.Environment (getEnvironment)
-import System.Exit (ExitCode (ExitSuccess))
 import System.FilePath ((</>))
 import System.Nix.Core (nix)
 import System.Nix.System (System (..))
-import System.Process (CreateProcess (env), proc)
-import UnliftIO.Timeout (timeout)
+import System.Process (proc)
 import Vira.CI.Configuration qualified as Configuration
 import Vira.CI.Context (ViraContext (..))
 import Vira.CI.Error (ConfigurationError (..), PipelineError (..), pipelineToolError)
 import Vira.CI.Pipeline.Effect
-import Vira.CI.Pipeline.Process (runProcess, runProcess')
+import Vira.CI.Pipeline.Process (runProcess)
 import Vira.CI.Pipeline.Signoff qualified as Signoff
-import Vira.CI.Pipeline.Type (BuildStage (..), CacheStage (..), Flake (..), NixConfig (..), PostBuildStage (..), SignoffStage (..), ViraPipeline (..), allowedNixOptions, validateNixOptions)
+import Vira.CI.Pipeline.Type (BuildStage (..), CacheStage (..), Flake (..), NixConfig (..), SignoffStage (..), ViraPipeline (..), allowedNixOptions, validateNixOptions)
 import Vira.Environment.Tool.Tools.Attic qualified as AtticTool
 import Vira.Environment.Tool.Type.ToolData (status)
 import Vira.Environment.Tool.Type.Tools (attic)
@@ -79,7 +75,6 @@ runPipeline env program =
           Build pipeline -> buildImpl pipeline
           Cache pipeline buildResults -> cacheImpl pipeline buildResults
           Signoff pipeline buildResults -> signoffImpl pipeline buildResults
-          PostBuild pipeline buildResults -> postBuildImpl pipeline buildResults
       )
       program
 
@@ -351,79 +346,6 @@ signoffImpl pipeline buildResults = do
     else
       logPipeline Warning "Signoff disabled, skipping"
 
--- | Convention-based post-build hook script name (must exist at repo root)
-postBuildHookScript :: FilePath
-postBuildHookScript = "viraPostBuildHook.sh"
-
--- | Default timeout for the post-build hook (10 minutes)
-defaultPostBuildTimeoutSeconds :: Int
-defaultPostBuildTimeoutSeconds = 600
-
--- | Implementation: Run post-build hook
-postBuildImpl ::
-  ( Concurrent :> es
-  , Process :> es
-  , Log (RichMessage IO) :> es
-  , IOE :> es
-  , FileSystem :> es
-  , ER.Reader LogContext :> es
-  , ER.Reader PipelineEnv :> es
-  , Error PipelineError :> es
-  , Environment :> es
-  ) =>
-  ViraPipeline ->
-  NonEmpty BuildResult ->
-  Eff es ()
-postBuildImpl pipeline _buildResults = do
-  env <- ER.ask @PipelineEnv
-  let ctx = env.viraContext
-      repoDir = ctx.repoDir
-      scriptPath = repoDir </> postBuildHookScript
-      timeoutUs = pipeline.postBuild.timeoutSeconds * 1_000_000
-  -- Skip post-build hook in --only-build mode
-  if ctx.onlyBuild
-    then logPipeline Info "Skipping post-build hook (--only-build mode)"
-    else
-      doesFileExist scriptPath >>= \case
-        False ->
-          logPipeline Info $ "No " <> toText postBuildHookScript <> " found, skipping post-build hook"
-        True -> do
-          -- Hard error if script exists but is not executable
-          perms <- liftIO $ getPermissions scriptPath
-          unless (executable perms) $
-            throwError $
-              PipelineConfigurationError $
-                MalformedConfig $
-                  toText postBuildHookScript <> " exists but is not executable. Run: chmod +x " <> toText postBuildHookScript
-          logPipeline Info $ "Running post-build hook: " <> toText postBuildHookScript
-          -- Build environment: VIRA_* vars prepended so they take precedence
-          currentEnv <- liftIO getEnvironment
-          let viraEnv =
-                [ ("VIRA_BRANCH", toString ctx.branch)
-                , ("VIRA_COMMIT_ID", toString ctx.commitId)
-                , ("VIRA_CLONE_URL", maybe "" toString ctx.cloneUrl)
-                , ("VIRA_REPO_DIR", repoDir)
-                , ("VIRA_ONLY_BUILD", if ctx.onlyBuild then "true" else "false")
-                ]
-              newEnv = viraEnv <> currentEnv
-          -- Run script directly (not via shell) in repo directory, with timeout
-          -- Note: cwd is not set here; runProcess' always overrides it with repoDir
-          let processProc =
-                (proc scriptPath [])
-                  { env = Just newEnv
-                  }
-          timedResult <- withRunInIO $ \runInIO ->
-            timeout timeoutUs (runInIO $ runProcess' repoDir env.logSink processProc)
-          case timedResult of
-            Nothing ->
-              throwError $
-                PipelineConfigurationError $
-                  MalformedConfig $
-                    "Post-build hook timed out after " <> show pipeline.postBuild.timeoutSeconds <> " seconds"
-            Just (Left err) -> throwError $ PipelineTerminated err
-            Just (Right ExitSuccess) -> logPipeline Info "Post-build hook completed successfully"
-            Just (Right exitCode) -> throwError $ PipelineProcessFailed exitCode
-
 -- | Default pipeline configuration
 defaultPipeline :: ViraPipeline
 defaultPipeline =
@@ -432,7 +354,6 @@ defaultPipeline =
     , nix = NixConfig {options = []}
     , cache = CacheStage Nothing
     , signoff = SignoffStage False
-    , postBuild = PostBuildStage defaultPostBuildTimeoutSeconds
     }
   where
     defaultFlake = Flake "." mempty

--- a/packages/vira/src/Vira/CI/Pipeline/Implementation.hs
+++ b/packages/vira/src/Vira/CI/Pipeline/Implementation.hs
@@ -7,6 +7,12 @@ module Vira.CI.Pipeline.Implementation (
 
   -- * Used in tests
   defaultPipeline,
+  checkDomain,
+  isLoopbackHost,
+  isIpLiteral,
+  sanitiseHeader,
+  sanitiseHeaderName,
+  sanitiseHeaderValue,
 ) where
 
 import Prelude hiding (asks, id)
@@ -17,8 +23,14 @@ import Attic.Types (AtticServer (..), AtticServerEndpoint)
 import Attic.Url qualified
 import Colog (Severity (..))
 import Colog.Message (RichMessage)
+import Control.Exception (try)
 import Data.Aeson (eitherDecodeFileStrict)
+import Data.Char (isAsciiLower, isAsciiUpper, isDigit)
+import Data.List (lookup)
 import Data.Map qualified as Map
+import Data.Set qualified as Set
+import Data.Text (splitOn, strip)
+import Data.Text qualified as T
 import DevourFlake (DevourFlakeArgs (..), devourFlake, prefetchFlakeInputs)
 import DevourFlake.Result (DevourFlakeResult (..), SystemOutputs (..), extractSystems)
 import Effectful
@@ -26,7 +38,7 @@ import Effectful.Colog (Log)
 import Effectful.Colog.Simple (LogContext (..))
 import Effectful.Concurrent.Async (Concurrent)
 import Effectful.Dispatch.Dynamic
-import Effectful.Environment (Environment)
+import Effectful.Environment (Environment, getEnvironment)
 import Effectful.Error.Static (Error, throwError)
 import Effectful.FileSystem (FileSystem, doesFileExist)
 import Effectful.Git.Command.Clone qualified as Git
@@ -34,19 +46,33 @@ import Effectful.Git.Platform (detectPlatform)
 import Effectful.Git.Types (Commit (id))
 import Effectful.Process (Process)
 import Effectful.Reader.Static qualified as ER
+import Network.HTTP.Req (
+  HttpException,
+  NoReqBody (..),
+  ReqBodyBs (..),
+  defaultHttpConfig,
+  header,
+  ignoreResponse,
+  req,
+  responseTimeout,
+  runReq,
+  useURI,
+ )
+import Network.HTTP.Req qualified as Req
 import Prettyprinter
 import Prettyprinter.Render.Text (renderStrict)
 import System.FilePath ((</>))
 import System.Nix.Core (nix)
 import System.Nix.System (System (..))
 import System.Process (proc)
+import Text.URI (Authority (..), mkURI, unRText, uriAuthority, uriScheme)
 import Vira.CI.Configuration qualified as Configuration
 import Vira.CI.Context (ViraContext (..))
 import Vira.CI.Error (ConfigurationError (..), PipelineError (..), pipelineToolError)
 import Vira.CI.Pipeline.Effect
 import Vira.CI.Pipeline.Process (runProcess)
 import Vira.CI.Pipeline.Signoff qualified as Signoff
-import Vira.CI.Pipeline.Type (BuildStage (..), CacheStage (..), Flake (..), NixConfig (..), SignoffStage (..), ViraPipeline (..), allowedNixOptions, validateNixOptions)
+import Vira.CI.Pipeline.Type (BuildStage (..), CacheStage (..), Flake (..), HttpMethod (..), NixConfig (..), PostBuildStage (..), SignoffStage (..), ViraPipeline (..), WebhookConfig (..), allowedNixOptions, substituteVars, validateNixOptions)
 import Vira.Environment.Tool.Tools.Attic qualified as AtticTool
 import Vira.Environment.Tool.Type.ToolData (status)
 import Vira.Environment.Tool.Type.Tools (attic)
@@ -75,6 +101,7 @@ runPipeline env program =
           Build pipeline -> buildImpl pipeline
           Cache pipeline buildResults -> cacheImpl pipeline buildResults
           Signoff pipeline buildResults -> signoffImpl pipeline buildResults
+          PostBuild pipeline buildResults -> postBuildImpl pipeline buildResults
       )
       program
 
@@ -145,9 +172,11 @@ loadConfigImpl = do
             { -- Don't signoff when only building
               signoff = pipeline.signoff {enable = False}
             , -- Don't push to cache when only building
-              cache = pipeline.cache {url = Nothing}
+              cache = CacheStage {url = Nothing}
             , -- Only build for current system when only building
               build = BuildStage {flakes = pipeline.build.flakes, systems = []}
+            , -- Don't fire webhooks when only building (webhooks are side effects)
+              postBuild = PostBuildStage {webhooks = []}
             }
       | otherwise = pipeline
 
@@ -346,6 +375,237 @@ signoffImpl pipeline buildResults = do
     else
       logPipeline Warning "Signoff disabled, skipping"
 
+-- | Implementation: Fire post-build webhooks
+postBuildImpl ::
+  ( Log (RichMessage IO) :> es
+  , IOE :> es
+  , ER.Reader LogContext :> es
+  , ER.Reader PipelineEnv :> es
+  , Error PipelineError :> es
+  , Environment :> es
+  ) =>
+  ViraPipeline ->
+  NonEmpty BuildResult ->
+  Eff es ()
+postBuildImpl pipeline _buildResults = do
+  env <- ER.ask @PipelineEnv
+  let ctx = env.viraContext
+      hooks = pipeline.postBuild.webhooks
+  if null hooks
+    then logPipeline Info "No post-build webhooks configured, skipping"
+    else do
+      -- Build the base $VIRA_* substitution bindings from build context
+      let viraBindings =
+            [ ("VIRA_BRANCH", toText ctx.branch)
+            , ("VIRA_COMMIT_ID", toText ctx.commitId)
+            , ("VIRA_CLONE_URL", maybe "" identity ctx.cloneUrl)
+            , ("VIRA_REPO_DIR", toText ctx.repoDir)
+            , ("VIRA_ONLY_BUILD", if ctx.onlyBuild then "true" else "false")
+            ]
+      -- Read the operator-configured allowlist of env vars from the CI machine
+      machineEnv <- getEnvironment
+      let allowedEnvNames =
+            Set.fromList $
+              maybe [] ((map strip . splitOn ",") . toText) $
+                lookup "VIRA_WEBHOOK_ALLOWED_ENV" machineEnv
+          -- Build env bindings for allowed machine vars (others silently absent)
+          allowedEnvBindings =
+            [ (toText k, toText v)
+            | (k, v) <- machineEnv
+            , Set.member (toText k) allowedEnvNames
+            ]
+          -- Vira bindings take precedence: put them last so Map.fromList (last-wins) prefers them
+          allBindings = allowedEnvBindings <> viraBindings
+          -- Operator-configured allowlist of webhook target domains.
+          -- VIRA_WEBHOOK_ALLOWED_DOMAINS must be explicitly set by the operator;
+          -- if absent, all webhooks are blocked (fail-closed / deny-by-default).
+          -- When set, only URLs whose host appears in the comma-separated list are permitted.
+          allowedDomains =
+            fmap (Set.fromList . filter (not . T.null) . map strip . splitOn ",") $
+              toText <$> lookup "VIRA_WEBHOOK_ALLOWED_DOMAINS" machineEnv
+      -- Fail fast: if VIRA_WEBHOOK_ALLOWED_DOMAINS is not set, all webhooks will be
+      -- rejected anyway — surface a single clear error rather than failing per-hook.
+      when (isNothing allowedDomains) $
+        throwError $
+          pipelineToolError
+            ( "VIRA_WEBHOOK_ALLOWED_DOMAINS is not set on the CI machine; webhooks are disabled by default. "
+                <> "Set it to a comma-separated list of allowed domains to enable post-build webhooks." ::
+                Text
+            )
+            (Nothing :: Maybe Text)
+      -- Fire each webhook in order
+      forM_ (zip [1 :: Int ..] hooks) $ \(idx, hook) -> do
+        let label = "webhook #" <> show idx <> " (" <> hook.url <> ")"
+        logPipeline Info $ "Firing post-build " <> label
+        result <- liftIO $ fireWebhook allBindings allowedDomains hook
+        case result of
+          Left err ->
+            throwError $
+              pipelineToolError
+                ("Post-build " <> label <> " failed: " <> err)
+                (Nothing :: Maybe Text)
+          Right () ->
+            logPipeline Info $ "Post-build " <> label <> " succeeded"
+
+{- | Check whether a resolved webhook URL is permitted by the domain allowlist.
+
+Returns @Right ()@ if the request should proceed, or @Left errMsg@ if it should
+be rejected.
+
+  * @Nothing@ — @VIRA_WEBHOOK_ALLOWED_DOMAINS@ is not set on the CI machine.
+    All webhooks are blocked (fail-closed / deny-by-default).
+  * @Just domains@ — operator has configured an explicit allowlist.
+    The URL's host must appear in @domains@; otherwise rejected.
+    An empty set (e.g. @VIRA_WEBHOOK_ALLOWED_DOMAINS=""@) blocks everything.
+
+Only HTTPS is permitted.
+
+Loopback addresses and IP literals are unconditionally rejected to prevent SSRF.
+
+The @templateUrl@ is used in error messages instead of resolved URL to avoid
+leaking substituted secrets in logs.
+-}
+checkDomain :: Maybe (Set.Set Text) -> Text -> Text -> Either Text ()
+checkDomain Nothing _resolvedUrl _templateUrl =
+  Left "VIRA_WEBHOOK_ALLOWED_DOMAINS is not set; webhooks are disabled by default. Set it on the CI machine to enable webhooks."
+checkDomain (Just allowedDomains) resolvedUrl templateUrl =
+  case mkURI resolvedUrl of
+    Nothing -> Left $ "Invalid webhook URL (could not parse): " <> templateUrl
+    Just uri -> do
+      -- Only HTTPS permitted
+      let scheme = fmap unRText (uriScheme uri)
+      case scheme of
+        Just "https" -> Right ()
+        Just s -> Left $ "Webhook URL scheme '" <> s <> "' is not allowed; only https is permitted (template: " <> templateUrl <> ")"
+        Nothing -> Left $ "Webhook URL has no scheme (template: " <> templateUrl <> ")"
+      -- Validate host against allowlist and SSRF rules
+      case uriAuthority uri of
+        Right auth ->
+          let host = unRText (authHost auth)
+           in if isLoopbackHost host
+                then Left $ "Webhook URL host is a loopback address and cannot be used as a webhook target (template: " <> templateUrl <> ")"
+                else
+                  if isIpLiteral host
+                    then Left $ "Webhook URL host is an IP address literal; use a hostname from VIRA_WEBHOOK_ALLOWED_DOMAINS instead (template: " <> templateUrl <> ")"
+                    else
+                      if Set.member host allowedDomains
+                        then Right ()
+                        else Left $ "Webhook URL host '" <> host <> "' is not in VIRA_WEBHOOK_ALLOWED_DOMAINS (template: " <> templateUrl <> ")"
+        _ -> Left $ "Webhook URL has no host (template: " <> templateUrl <> ")"
+
+{- | Return @True@ if the host is a loopback or unroutable address.
+
+Unconditionally blocked regardless of any allowlist, to prevent SSRF
+to services on the CI machine itself.
+-}
+isLoopbackHost :: Text -> Bool
+isLoopbackHost host =
+  host == "localhost"
+    || host == "::1"
+    || host == "0.0.0.0"
+    || T.isPrefixOf "127." host -- 127.0.0.0/8 loopback range
+
+{- | Return @True@ if the host looks like an IP address literal.
+
+modern-uri normalises IPv6 literals to @[addr]@ form and IPv4 to dotted-decimal.
+We reject all of these to prevent operators from inadvertently allowlisting
+internal network addresses (e.g. 10.x.x.x, 172.16.x.x, 192.168.x.x, AWS metadata 169.254.169.254).
+Hostnames that only contain digits, dots, colons, or square brackets are
+considered IP literals.
+-}
+isIpLiteral :: Text -> Bool
+isIpLiteral host =
+  -- IPv6: modern-uri renders as "[addr]"
+  (T.isPrefixOf "[" host && T.isSuffixOf "]" host)
+    -- IPv4: only digits and dots, at least one dot
+    || (T.all (\c -> c == '.' || isDigit c) host && T.any (== '.') host)
+
+{- | Sanitise an HTTP header name by keeping only RFC 7230 token characters:
+alphanumeric plus @! # $ % & ' * + - . ^ _ ` | ~@.
+
+Any character outside this set is stripped. This prevents header injection
+and ensures the resulting name is a valid HTTP token.
+-}
+sanitiseHeaderName :: Text -> Text
+sanitiseHeaderName = T.filter isHeaderTokenChar
+  where
+    -- RFC 7230 §3.2.6 token character set
+    isHeaderTokenChar :: Char -> Bool
+    isHeaderTokenChar c =
+      isAsciiLower c
+        || isAsciiUpper c
+        || isDigit c
+        || c `elem` ("!#$%&'*+-.^_`|~" :: String)
+
+{- | Sanitise an HTTP header value by stripping control characters @\r@, @\n@,
+@\0@ to prevent header injection attacks.
+-}
+sanitiseHeaderValue :: Text -> Text
+sanitiseHeaderValue = T.filter (\c -> c /= '\r' && c /= '\n' && c /= '\0')
+
+{- | Sanitise both an HTTP header name and value.
+
+Exported for testing only; internal code uses 'sanitiseHeaderName' and
+'sanitiseHeaderValue' directly.
+-}
+sanitiseHeader :: Text -> Text
+sanitiseHeader = sanitiseHeaderValue
+
+{- | Execute a single webhook request.
+
+Performs variable substitution on the URL, header values, and body,
+then fires the HTTP request. Returns @Left errMsg@ on failure.
+
+Header names and values are sanitised via 'sanitiseHeader' (control characters
+@\r@, @\n@, @\0@ stripped) to prevent HTTP header injection.
+
+Redirects are disabled (httpConfigRedirectCount = 0) to prevent SSRF via
+redirect chains from a whitelisted host to an internal address.
+
+The resolved URL (which may contain substituted secrets) is never included
+in error messages; only the original template URL from @vira.hs@ is used.
+
+Only 'HttpException' is caught; async exceptions (ThreadKilled, etc.) propagate
+normally and are not suppressed.
+-}
+fireWebhook :: [(Text, Text)] -> Maybe (Set.Set Text) -> WebhookConfig -> IO (Either Text ())
+fireWebhook bindings allowedDomains hook = do
+  let resolvedUrl = substituteVars bindings hook.url
+      resolvedHeaders = map (\(k, v) -> (sanitiseHeaderName k, sanitiseHeaderValue (substituteVars bindings v))) hook.headers
+      resolvedBody = fmap (substituteVars bindings) hook.body
+      bodyBytes = maybe "" encodeUtf8 resolvedBody
+      -- Use the template URL (pre-substitution) in all error messages so
+      -- substituted secret values are never written to logs.
+      templateUrl = hook.url
+  case checkDomain allowedDomains resolvedUrl templateUrl of
+    Left err -> pure $ Left err
+    Right () ->
+      -- mkURI is pure (returns Maybe); no IO, no exception possible.
+      case mkURI resolvedUrl of
+        Nothing -> pure $ Left $ "Invalid webhook URL (template: " <> templateUrl <> ")"
+        Just uri ->
+          case useURI uri of
+            Nothing -> pure $ Left $ "Could not parse URI scheme (expected https://) for webhook (template: " <> templateUrl <> ")"
+            Just (Left _) -> pure $ Left $ "HTTP scheme is not allowed; only HTTPS is permitted for webhooks (template: " <> templateUrl <> ")"
+            Just (Right (httpsUrl, _)) -> do
+              -- noRedirectConfig: disable redirect following to prevent SSRF via
+              -- redirect chains from a whitelisted domain to an internal address.
+              let noRedirectConfig = defaultHttpConfig {Req.httpConfigRedirectCount = 0}
+                  -- 30 second timeout is a sensible default for webhooks
+                  defaultTimeoutMicros = 30 * 1_000_000
+                  opts =
+                    responseTimeout defaultTimeoutMicros
+                      <> mconcat [header (encodeUtf8 k) (encodeUtf8 v) | (k, v) <- resolvedHeaders]
+              -- Only catch HttpException; async exceptions must not be swallowed.
+              result <- try @HttpException $
+                runReq noRedirectConfig $
+                  case hook.method of
+                    GET -> void $ req Req.GET httpsUrl NoReqBody ignoreResponse opts
+                    POST -> void $ req Req.POST httpsUrl (ReqBodyBs bodyBytes) ignoreResponse opts
+                    PUT -> void $ req Req.PUT httpsUrl (ReqBodyBs bodyBytes) ignoreResponse opts
+                    PATCH -> void $ req Req.PATCH httpsUrl (ReqBodyBs bodyBytes) ignoreResponse opts
+              pure $ bimap (\ex -> "HTTP error for webhook (template: " <> templateUrl <> "): " <> fromString (show ex)) identity result
+
 -- | Default pipeline configuration
 defaultPipeline :: ViraPipeline
 defaultPipeline =
@@ -354,6 +614,7 @@ defaultPipeline =
     , nix = NixConfig {options = []}
     , cache = CacheStage Nothing
     , signoff = SignoffStage False
+    , postBuild = PostBuildStage {webhooks = []}
     }
   where
     defaultFlake = Flake "." mempty

--- a/packages/vira/src/Vira/CI/Pipeline/Implementation.hs
+++ b/packages/vira/src/Vira/CI/Pipeline/Implementation.hs
@@ -36,17 +36,21 @@ import Effectful.Process (Process)
 import Effectful.Reader.Static qualified as ER
 import Prettyprinter
 import Prettyprinter.Render.Text (renderStrict)
+import System.Directory (executable, getPermissions)
+import System.Environment (getEnvironment)
+import System.Exit (ExitCode (ExitSuccess))
 import System.FilePath ((</>))
 import System.Nix.Core (nix)
 import System.Nix.System (System (..))
-import System.Process (proc)
+import System.Process (CreateProcess (env), proc)
+import UnliftIO.Timeout (timeout)
 import Vira.CI.Configuration qualified as Configuration
 import Vira.CI.Context (ViraContext (..))
 import Vira.CI.Error (ConfigurationError (..), PipelineError (..), pipelineToolError)
 import Vira.CI.Pipeline.Effect
-import Vira.CI.Pipeline.Process (runProcess)
+import Vira.CI.Pipeline.Process (runProcess, runProcess')
 import Vira.CI.Pipeline.Signoff qualified as Signoff
-import Vira.CI.Pipeline.Type (BuildStage (..), CacheStage (..), Flake (..), NixConfig (..), SignoffStage (..), ViraPipeline (..), allowedNixOptions, validateNixOptions)
+import Vira.CI.Pipeline.Type (BuildStage (..), CacheStage (..), Flake (..), NixConfig (..), PostBuildStage (..), SignoffStage (..), ViraPipeline (..), allowedNixOptions, validateNixOptions)
 import Vira.Environment.Tool.Tools.Attic qualified as AtticTool
 import Vira.Environment.Tool.Type.ToolData (status)
 import Vira.Environment.Tool.Type.Tools (attic)
@@ -75,6 +79,7 @@ runPipeline env program =
           Build pipeline -> buildImpl pipeline
           Cache pipeline buildResults -> cacheImpl pipeline buildResults
           Signoff pipeline buildResults -> signoffImpl pipeline buildResults
+          PostBuild pipeline buildResults -> postBuildImpl pipeline buildResults
       )
       program
 
@@ -346,6 +351,79 @@ signoffImpl pipeline buildResults = do
     else
       logPipeline Warning "Signoff disabled, skipping"
 
+-- | Convention-based post-build hook script name (must exist at repo root)
+postBuildHookScript :: FilePath
+postBuildHookScript = "viraPostBuildHook.sh"
+
+-- | Default timeout for the post-build hook (10 minutes)
+defaultPostBuildTimeoutSeconds :: Int
+defaultPostBuildTimeoutSeconds = 600
+
+-- | Implementation: Run post-build hook
+postBuildImpl ::
+  ( Concurrent :> es
+  , Process :> es
+  , Log (RichMessage IO) :> es
+  , IOE :> es
+  , FileSystem :> es
+  , ER.Reader LogContext :> es
+  , ER.Reader PipelineEnv :> es
+  , Error PipelineError :> es
+  , Environment :> es
+  ) =>
+  ViraPipeline ->
+  NonEmpty BuildResult ->
+  Eff es ()
+postBuildImpl pipeline _buildResults = do
+  env <- ER.ask @PipelineEnv
+  let ctx = env.viraContext
+      repoDir = ctx.repoDir
+      scriptPath = repoDir </> postBuildHookScript
+      timeoutUs = pipeline.postBuild.timeoutSeconds * 1_000_000
+  -- Skip post-build hook in --only-build mode
+  if ctx.onlyBuild
+    then logPipeline Info "Skipping post-build hook (--only-build mode)"
+    else
+      doesFileExist scriptPath >>= \case
+        False ->
+          logPipeline Info $ "No " <> toText postBuildHookScript <> " found, skipping post-build hook"
+        True -> do
+          -- Hard error if script exists but is not executable
+          perms <- liftIO $ getPermissions scriptPath
+          unless (executable perms) $
+            throwError $
+              PipelineConfigurationError $
+                MalformedConfig $
+                  toText postBuildHookScript <> " exists but is not executable. Run: chmod +x " <> toText postBuildHookScript
+          logPipeline Info $ "Running post-build hook: " <> toText postBuildHookScript
+          -- Build environment: VIRA_* vars prepended so they take precedence
+          currentEnv <- liftIO getEnvironment
+          let viraEnv =
+                [ ("VIRA_BRANCH", toString ctx.branch)
+                , ("VIRA_COMMIT_ID", toString ctx.commitId)
+                , ("VIRA_CLONE_URL", maybe "" toString ctx.cloneUrl)
+                , ("VIRA_REPO_DIR", repoDir)
+                , ("VIRA_ONLY_BUILD", if ctx.onlyBuild then "true" else "false")
+                ]
+              newEnv = viraEnv <> currentEnv
+          -- Run script directly (not via shell) in repo directory, with timeout
+          -- Note: cwd is not set here; runProcess' always overrides it with repoDir
+          let processProc =
+                (proc scriptPath [])
+                  { env = Just newEnv
+                  }
+          timedResult <- withRunInIO $ \runInIO ->
+            timeout timeoutUs (runInIO $ runProcess' repoDir env.logSink processProc)
+          case timedResult of
+            Nothing ->
+              throwError $
+                PipelineConfigurationError $
+                  MalformedConfig $
+                    "Post-build hook timed out after " <> show pipeline.postBuild.timeoutSeconds <> " seconds"
+            Just (Left err) -> throwError $ PipelineTerminated err
+            Just (Right ExitSuccess) -> logPipeline Info "Post-build hook completed successfully"
+            Just (Right exitCode) -> throwError $ PipelineProcessFailed exitCode
+
 -- | Default pipeline configuration
 defaultPipeline :: ViraPipeline
 defaultPipeline =
@@ -354,6 +432,7 @@ defaultPipeline =
     , nix = NixConfig {options = []}
     , cache = CacheStage Nothing
     , signoff = SignoffStage False
+    , postBuild = PostBuildStage defaultPostBuildTimeoutSeconds
     }
   where
     defaultFlake = Flake "." mempty

--- a/packages/vira/src/Vira/CI/Pipeline/Process.hs
+++ b/packages/vira/src/Vira/CI/Pipeline/Process.hs
@@ -4,7 +4,6 @@
 
 module Vira.CI.Pipeline.Process (
   runProcess,
-  runProcess',
 ) where
 
 import Colog (Severity (..))

--- a/packages/vira/src/Vira/CI/Pipeline/Process.hs
+++ b/packages/vira/src/Vira/CI/Pipeline/Process.hs
@@ -4,6 +4,7 @@
 
 module Vira.CI.Pipeline.Process (
   runProcess,
+  runProcess',
 ) where
 
 import Colog (Severity (..))

--- a/packages/vira/src/Vira/CI/Pipeline/Program.hs
+++ b/packages/vira/src/Vira/CI/Pipeline/Program.hs
@@ -17,12 +17,12 @@ import System.Nix.System (System (..))
 import Vira.CI.Context (ViraContext (..))
 import Vira.CI.Error (PipelineError (..))
 import Vira.CI.Pipeline.Effect
-import Vira.CI.Pipeline.Type (BuildStage (..), CacheStage (..), Flake (..), NixConfig (..), SignoffStage (..), ViraPipeline (..))
+import Vira.CI.Pipeline.Type (BuildStage (..), CacheStage (..), Flake (..), NixConfig (..), PostBuildStage (..), SignoffStage (..), ViraPipeline (..))
 import Vira.State.Type (Branch, Repo)
 
 -- | Pretty-print pipeline configuration in a concise format
 prettyPipeline :: ViraPipeline -> Text
-prettyPipeline ViraPipeline {build = buildStage, nix = nixCfg, cache = cacheStage, signoff = signoffStage} =
+prettyPipeline ViraPipeline {build = buildStage, nix = nixCfg, cache = cacheStage, signoff = signoffStage, postBuild = postBuildStage} =
   renderStrict $
     layoutPretty defaultLayoutOptions $
       vsep
@@ -36,6 +36,7 @@ prettyPipeline ViraPipeline {build = buildStage, nix = nixCfg, cache = cacheStag
               ]
         , "Cache:" <+> maybe "disabled" (\url -> "enabled" <+> parens (pretty url)) cacheStage.url
         , "Signoff:" <+> if signoffStage.enable then "enabled" else "disabled"
+        , "PostBuild:" <+> prettyPostBuild postBuildStage
         ]
   where
     prettyFlake :: Flake -> Doc ann
@@ -51,6 +52,11 @@ prettyPipeline ViraPipeline {build = buildStage, nix = nixCfg, cache = cacheStag
     prettyNixOptions [] = mempty
     prettyNixOptions opts =
       "Nix options:" <+> hsep (punctuate comma (map (\(k, v) -> pretty k <> "=" <> pretty v) opts))
+
+    prettyPostBuild :: PostBuildStage -> Doc ann
+    prettyPostBuild (PostBuildStage []) = "disabled (no webhooks configured)"
+    prettyPostBuild (PostBuildStage hooks) =
+      pretty (length hooks) <+> "webhook(s)"
 
 -- | Pipeline program for CLI (uses existing local directory)
 pipelineProgram ::
@@ -78,6 +84,9 @@ pipelineProgram = do
 
   -- Step 4: Signoff
   signoff pipeline buildResults
+
+  -- Step 5: Post-build webhooks (run last, after cache and signoff)
+  postBuild pipeline buildResults
   logPipeline Info "Pipeline completed successfully"
 
 {- | Pipeline program with clone (for web/CI)

--- a/packages/vira/src/Vira/CI/Pipeline/Program.hs
+++ b/packages/vira/src/Vira/CI/Pipeline/Program.hs
@@ -17,12 +17,12 @@ import System.Nix.System (System (..))
 import Vira.CI.Context (ViraContext (..))
 import Vira.CI.Error (PipelineError (..))
 import Vira.CI.Pipeline.Effect
-import Vira.CI.Pipeline.Type (BuildStage (..), CacheStage (..), Flake (..), NixConfig (..), SignoffStage (..), ViraPipeline (..))
+import Vira.CI.Pipeline.Type (BuildStage (..), CacheStage (..), Flake (..), NixConfig (..), PostBuildStage (..), SignoffStage (..), ViraPipeline (..))
 import Vira.State.Type (Branch, Repo)
 
 -- | Pretty-print pipeline configuration in a concise format
 prettyPipeline :: ViraPipeline -> Text
-prettyPipeline ViraPipeline {build = buildStage, nix = nixCfg, cache = cacheStage, signoff = signoffStage} =
+prettyPipeline ViraPipeline {build = buildStage, nix = nixCfg, cache = cacheStage, signoff = signoffStage, postBuild = postBuildStage} =
   renderStrict $
     layoutPretty defaultLayoutOptions $
       vsep
@@ -36,6 +36,7 @@ prettyPipeline ViraPipeline {build = buildStage, nix = nixCfg, cache = cacheStag
               ]
         , "Cache:" <+> maybe "disabled" (\url -> "enabled" <+> parens (pretty url)) cacheStage.url
         , "Signoff:" <+> if signoffStage.enable then "enabled" else "disabled"
+        , "PostBuild:" <+> "viraPostBuildHook.sh" <+> parens ("timeout:" <+> pretty postBuildStage.timeoutSeconds <> "s")
         ]
   where
     prettyFlake :: Flake -> Doc ann
@@ -78,6 +79,9 @@ pipelineProgram = do
 
   -- Step 4: Signoff
   signoff pipeline buildResults
+
+  -- Step 5: Post-build hook (runs last, after cache and signoff)
+  postBuild pipeline buildResults
   logPipeline Info "Pipeline completed successfully"
 
 {- | Pipeline program with clone (for web/CI)
@@ -99,7 +103,7 @@ pipelineProgramWithClone repo branch workspacePath = do
   -- Step 1: Clone repository
   clonedDir <- clone repo branch workspacePath
 
-  -- Step 2-5: Run pipeline in the cloned directory
+  -- Step 2-6: Run pipeline in the cloned directory
   -- HACK: Update context with actual cloned directory
   ER.local @PipelineEnv
     ( \env ->

--- a/packages/vira/src/Vira/CI/Pipeline/Program.hs
+++ b/packages/vira/src/Vira/CI/Pipeline/Program.hs
@@ -17,12 +17,12 @@ import System.Nix.System (System (..))
 import Vira.CI.Context (ViraContext (..))
 import Vira.CI.Error (PipelineError (..))
 import Vira.CI.Pipeline.Effect
-import Vira.CI.Pipeline.Type (BuildStage (..), CacheStage (..), Flake (..), NixConfig (..), PostBuildStage (..), SignoffStage (..), ViraPipeline (..))
+import Vira.CI.Pipeline.Type (BuildStage (..), CacheStage (..), Flake (..), NixConfig (..), SignoffStage (..), ViraPipeline (..))
 import Vira.State.Type (Branch, Repo)
 
 -- | Pretty-print pipeline configuration in a concise format
 prettyPipeline :: ViraPipeline -> Text
-prettyPipeline ViraPipeline {build = buildStage, nix = nixCfg, cache = cacheStage, signoff = signoffStage, postBuild = postBuildStage} =
+prettyPipeline ViraPipeline {build = buildStage, nix = nixCfg, cache = cacheStage, signoff = signoffStage} =
   renderStrict $
     layoutPretty defaultLayoutOptions $
       vsep
@@ -36,7 +36,6 @@ prettyPipeline ViraPipeline {build = buildStage, nix = nixCfg, cache = cacheStag
               ]
         , "Cache:" <+> maybe "disabled" (\url -> "enabled" <+> parens (pretty url)) cacheStage.url
         , "Signoff:" <+> if signoffStage.enable then "enabled" else "disabled"
-        , "PostBuild:" <+> "viraPostBuildHook.sh" <+> parens ("timeout:" <+> pretty postBuildStage.timeoutSeconds <> "s")
         ]
   where
     prettyFlake :: Flake -> Doc ann
@@ -79,9 +78,6 @@ pipelineProgram = do
 
   -- Step 4: Signoff
   signoff pipeline buildResults
-
-  -- Step 5: Post-build hook (runs last, after cache and signoff)
-  postBuild pipeline buildResults
   logPipeline Info "Pipeline completed successfully"
 
 {- | Pipeline program with clone (for web/CI)
@@ -103,7 +99,7 @@ pipelineProgramWithClone repo branch workspacePath = do
   -- Step 1: Clone repository
   clonedDir <- clone repo branch workspacePath
 
-  -- Step 2-6: Run pipeline in the cloned directory
+  -- Step 2-5: Run pipeline in the cloned directory
   -- HACK: Update context with actual cloned directory
   ER.local @PipelineEnv
     ( \env ->

--- a/packages/vira/static/test/sample-configs/webhook-example.hs
+++ b/packages/vira/static/test/sample-configs/webhook-example.hs
@@ -1,0 +1,11 @@
+\ctx pipeline ->
+  pipeline
+    { postBuild.webhooks =
+        [ WebhookConfig
+            { url     = "https://hooks.slack.com/services/$SLACK_WEBHOOK_TOKEN"
+            , method  = POST
+            , headers = [("Content-Type", "application/json")]
+            , body    = Just "{\"text\": \"✅ $VIRA_BRANCH @ $VIRA_COMMIT_ID built successfully\"}"
+            }
+        ]
+    }

--- a/packages/vira/test/Vira/CI/Pipeline/CheckDomainSpec.hs
+++ b/packages/vira/test/Vira/CI/Pipeline/CheckDomainSpec.hs
@@ -1,0 +1,259 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Vira.CI.Pipeline.CheckDomainSpec (spec) where
+
+import Data.Set qualified as Set
+import Data.Text qualified as T
+import Test.Hspec
+import Vira.CI.Pipeline.Implementation (checkDomain, isIpLiteral, isLoopbackHost, sanitiseHeaderName, sanitiseHeaderValue)
+
+{- | Convenience wrapper: in tests the resolved URL and template URL are the same
+(no variable substitution takes place), so we pass the URL for both arguments.
+-}
+cd :: Maybe (Set.Set T.Text) -> T.Text -> Either T.Text ()
+cd domains url = checkDomain domains url url
+
+spec :: Spec
+spec = describe "checkDomain" $ do
+  -- -----------------------------------------------------------------------
+  -- Nothing = env var absent → deny-by-default
+  -- -----------------------------------------------------------------------
+  describe "VIRA_WEBHOOK_ALLOWED_DOMAINS not set (Nothing)" $ do
+    it "blocks any https URL when the env var is absent" $
+      cd Nothing "https://hooks.example.com/deploy"
+        `shouldSatisfy` isLeft
+
+    it "error message tells the operator what to do" $ do
+      case cd Nothing "https://example.com/hook" of
+        Left msg -> msg `shouldSatisfy` T.isInfixOf "VIRA_WEBHOOK_ALLOWED_DOMAINS"
+        Right _ -> expectationFailure "Expected Left but got Right"
+
+  -- -----------------------------------------------------------------------
+  -- Just empty set → every host is rejected (empty allowlist = deny all)
+  -- -----------------------------------------------------------------------
+  describe "VIRA_WEBHOOK_ALLOWED_DOMAINS set to empty string (Just empty set)" $ do
+    it "blocks any URL when the set is empty" $
+      cd (Just Set.empty) "https://hooks.example.com/deploy"
+        `shouldSatisfy` isLeft
+
+  -- -----------------------------------------------------------------------
+  -- Non-empty allowlist — permit listed hosts
+  -- -----------------------------------------------------------------------
+  describe "non-empty allowlist — permitted hosts" $ do
+    it "permits a URL whose host exactly matches an allowlisted domain" $
+      cd (Just $ Set.fromList ["hooks.example.com"]) "https://hooks.example.com/deploy"
+        `shouldBe` Right ()
+
+    it "permits a URL with a path and query string" $
+      cd (Just $ Set.fromList ["api.example.com"]) "https://api.example.com/v1/notify?token=x"
+        `shouldBe` Right ()
+
+    it "permits when the allowlist has multiple entries and host matches one" $
+      cd (Just $ Set.fromList ["a.com", "b.com", "hooks.example.com"]) "https://b.com/hook"
+        `shouldBe` Right ()
+
+    it "rejects an http (non-TLS) URL even when host is in the allowlist" $
+      cd (Just $ Set.fromList ["internal.corp"]) "http://internal.corp/webhook"
+        `shouldSatisfy` isLeft
+
+  -- -----------------------------------------------------------------------
+  -- Scheme validation: only https is permitted
+  -- -----------------------------------------------------------------------
+  describe "scheme validation" $ do
+    it "rejects a file:// URL even when host would otherwise be allowed" $
+      cd (Just $ Set.fromList ["example.com"]) "file:///etc/passwd"
+        `shouldSatisfy` isLeft
+
+    it "rejects an ftp:// URL" $
+      cd (Just $ Set.fromList ["example.com"]) "ftp://example.com/file"
+        `shouldSatisfy` isLeft
+
+    it "rejects an http:// URL even when host is in the allowlist" $
+      cd (Just $ Set.fromList ["example.com"]) "http://example.com/hook"
+        `shouldSatisfy` isLeft
+
+    it "error message mentions the rejected scheme" $ do
+      case cd (Just $ Set.fromList ["example.com"]) "ftp://example.com/file" of
+        Left msg -> msg `shouldSatisfy` T.isInfixOf "ftp"
+        Right _ -> expectationFailure "Expected Left but got Right"
+
+  -- -----------------------------------------------------------------------
+  -- Non-empty allowlist — reject unlisted hosts
+  -- -----------------------------------------------------------------------
+  describe "non-empty allowlist — rejected hosts" $ do
+    it "rejects a URL whose host is not in the allowlist" $
+      cd (Just $ Set.fromList ["hooks.example.com"]) "https://evil.com/exfil"
+        `shouldSatisfy` isLeft
+
+    it "rejects when host doesn't match any entry in a multi-entry allowlist" $
+      cd (Just $ Set.fromList ["a.com", "b.com"]) "https://c.com/hook"
+        `shouldSatisfy` isLeft
+
+    it "error message mentions the offending host" $ do
+      case cd (Just $ Set.fromList ["allowed.com"]) "https://notallowed.com/hook" of
+        Left msg -> msg `shouldSatisfy` T.isInfixOf "notallowed.com"
+        Right _ -> expectationFailure "Expected Left but got Right"
+
+    it "error message mentions VIRA_WEBHOOK_ALLOWED_DOMAINS" $ do
+      case cd (Just $ Set.fromList ["allowed.com"]) "https://other.com/hook" of
+        Left msg -> msg `shouldSatisfy` T.isInfixOf "VIRA_WEBHOOK_ALLOWED_DOMAINS"
+        Right _ -> expectationFailure "Expected Left but got Right"
+
+  -- -----------------------------------------------------------------------
+  -- Host matching is exact (no subdomain wildcards)
+  -- -----------------------------------------------------------------------
+  describe "host matching is exact (no implicit wildcard)" $ do
+    it "does not treat a listed parent domain as matching a subdomain" $
+      cd (Just $ Set.fromList ["example.com"]) "https://sub.example.com/hook"
+        `shouldSatisfy` isLeft
+
+    it "does not treat a listed subdomain as matching the parent" $
+      cd (Just $ Set.fromList ["hooks.example.com"]) "https://example.com/hook"
+        `shouldSatisfy` isLeft
+
+    it "does not treat a prefix match as a full match" $
+      cd (Just $ Set.fromList ["example.com"]) "https://example.com.evil.org/hook"
+        `shouldSatisfy` isLeft
+
+  -- -----------------------------------------------------------------------
+  -- Edge cases
+  -- -----------------------------------------------------------------------
+  describe "edge cases" $ do
+    it "rejects an invalid URL even when allowlist is configured" $
+      cd (Just $ Set.fromList ["example.com"]) "not-a-url"
+        `shouldSatisfy` isLeft
+
+  -- -----------------------------------------------------------------------
+  -- Loopback blocking (unconditional, regardless of allowlist)
+  -- -----------------------------------------------------------------------
+  describe "loopback addresses are unconditionally blocked" $ do
+    it "blocks localhost even if listed in allowlist" $
+      cd (Just $ Set.fromList ["localhost"]) "https://localhost/admin"
+        `shouldSatisfy` isLeft
+
+    it "blocks 127.0.0.1 even if listed in allowlist" $
+      cd (Just $ Set.fromList ["127.0.0.1"]) "https://127.0.0.1/secret"
+        `shouldSatisfy` isLeft
+
+    it "blocks 127.x.x.x range (e.g. 127.0.0.2)" $
+      cd (Just $ Set.fromList ["127.0.0.2"]) "https://127.0.0.2/hook"
+        `shouldSatisfy` isLeft
+
+    it "blocks ::1 (IPv6 loopback) even if listed in allowlist" $
+      cd (Just $ Set.fromList ["[::1]"]) "https://[::1]/hook"
+        `shouldSatisfy` isLeft
+
+    it "blocks 0.0.0.0 even if listed in allowlist" $
+      cd (Just $ Set.fromList ["0.0.0.0"]) "https://0.0.0.0/hook"
+        `shouldSatisfy` isLeft
+
+    it "error message does not expose the resolved URL (uses template)" $ do
+      -- When resolvedUrl == templateUrl the message should still refer to template
+      case cd (Just $ Set.fromList ["localhost"]) "https://localhost/hook" of
+        Left msg -> msg `shouldSatisfy` T.isInfixOf "template:"
+        Right _ -> expectationFailure "Expected Left but got Right"
+
+  -- -----------------------------------------------------------------------
+  -- IP address literal blocking (unconditional)
+  -- -----------------------------------------------------------------------
+  describe "IP address literals are unconditionally blocked" $ do
+    it "blocks a public IPv4 address even if listed in allowlist" $
+      cd (Just $ Set.fromList ["1.2.3.4"]) "https://1.2.3.4/hook"
+        `shouldSatisfy` isLeft
+
+    it "blocks the AWS metadata IP 169.254.169.254" $
+      cd (Just $ Set.fromList ["169.254.169.254"]) "https://169.254.169.254/latest/meta-data"
+        `shouldSatisfy` isLeft
+
+    it "blocks a private IPv4 range 10.x address" $
+      cd (Just $ Set.fromList ["10.0.0.1"]) "https://10.0.0.1/internal"
+        `shouldSatisfy` isLeft
+
+    it "blocks an IPv6 address literal" $
+      cd (Just $ Set.fromList ["[2001:db8::1]"]) "https://[2001:db8::1]/hook"
+        `shouldSatisfy` isLeft
+
+    it "does not block a normal hostname that happens to contain digits" $
+      cd (Just $ Set.fromList ["api2.example.com"]) "https://api2.example.com/hook"
+        `shouldBe` Right ()
+
+  -- -----------------------------------------------------------------------
+  -- isLoopbackHost unit tests
+  -- -----------------------------------------------------------------------
+  describe "isLoopbackHost" $ do
+    it "detects localhost" $ isLoopbackHost "localhost" `shouldBe` True
+    it "detects 127.0.0.1" $ isLoopbackHost "127.0.0.1" `shouldBe` True
+    it "detects 127.0.0.2" $ isLoopbackHost "127.0.0.2" `shouldBe` True
+    it "detects ::1" $ isLoopbackHost "::1" `shouldBe` True
+    it "detects 0.0.0.0" $ isLoopbackHost "0.0.0.0" `shouldBe` True
+    it "does not flag a normal domain" $ isLoopbackHost "example.com" `shouldBe` False
+    it "does not flag a public IP" $ isLoopbackHost "1.2.3.4" `shouldBe` False
+
+  -- -----------------------------------------------------------------------
+  -- isIpLiteral unit tests
+  -- -----------------------------------------------------------------------
+  describe "isIpLiteral" $ do
+    it "detects an IPv4 address" $ isIpLiteral "1.2.3.4" `shouldBe` True
+    it "detects 169.254.169.254" $ isIpLiteral "169.254.169.254" `shouldBe` True
+    it "detects an IPv6 literal in brackets" $ isIpLiteral "[::1]" `shouldBe` True
+    it "detects a bracketed IPv6 address" $ isIpLiteral "[2001:db8::1]" `shouldBe` True
+    it "does not flag a normal hostname" $ isIpLiteral "example.com" `shouldBe` False
+    it "does not flag a hostname with digits" $ isIpLiteral "api2.example.com" `shouldBe` False
+    it "does not flag a hostname that starts with digits" $ isIpLiteral "123abc.com" `shouldBe` False
+
+  -- -----------------------------------------------------------------------
+  -- URL with port — host matching ignores the port
+  -- -----------------------------------------------------------------------
+  describe "URLs with ports" $ do
+    it "permits a URL with an explicit port when the host is allowlisted" $
+      cd (Just $ Set.fromList ["example.com"]) "https://example.com:8443/hook"
+        `shouldBe` Right ()
+
+    it "still rejects a URL with a port when the host is not allowlisted" $
+      cd (Just $ Set.fromList ["other.com"]) "https://example.com:8443/hook"
+        `shouldSatisfy` isLeft
+
+    it "still blocks loopback even with a non-default port" $
+      cd (Just $ Set.fromList ["127.0.0.1"]) "https://127.0.0.1:8080/admin"
+        `shouldSatisfy` isLeft
+
+  -- -----------------------------------------------------------------------
+  -- sanitiseHeaderName — RFC 7230 token characters only
+  -- -----------------------------------------------------------------------
+  describe "sanitiseHeaderName" $ do
+    it "passes through a valid header name unchanged" $
+      sanitiseHeaderName "Content-Type" `shouldBe` "Content-Type"
+
+    it "passes through alphanumeric characters" $
+      sanitiseHeaderName "X-Custom-Header123" `shouldBe` "X-Custom-Header123"
+
+    it "strips CRLF injection from a header name" $
+      sanitiseHeaderName "X-Foo\r\nX-Injected" `shouldBe` "X-FooX-Injected"
+
+    it "strips a null byte from a header name" $
+      sanitiseHeaderName "X-Foo\0Bar" `shouldBe` "X-FooBar"
+
+    it "strips spaces from a header name (spaces are not RFC 7230 token chars)" $
+      sanitiseHeaderName "X Foo" `shouldBe` "XFoo"
+
+    it "strips a colon from a header name" $
+      sanitiseHeaderName "X-Foo: Bar" `shouldBe` "X-FooBar"
+
+    it "preserves RFC 7230 special token characters (!#$%&'*+-.^_`|~)" $
+      sanitiseHeaderName "X-Header!#$" `shouldBe` "X-Header!#$"
+
+  -- -----------------------------------------------------------------------
+  -- sanitiseHeaderValue — strips control characters only
+  -- -----------------------------------------------------------------------
+  describe "sanitiseHeaderValue" $ do
+    it "passes through a valid header value unchanged" $
+      sanitiseHeaderValue "application/json" `shouldBe` "application/json"
+
+    it "strips carriage return from a header value" $
+      sanitiseHeaderValue "value\r\nextra" `shouldBe` "valueextra"
+
+    it "strips null byte from a header value" $
+      sanitiseHeaderValue "val\0ue" `shouldBe` "value"
+
+    it "preserves spaces in a header value" $
+      sanitiseHeaderValue "Bearer my-token" `shouldBe` "Bearer my-token"

--- a/packages/vira/test/Vira/CI/Pipeline/SubstituteVarsSpec.hs
+++ b/packages/vira/test/Vira/CI/Pipeline/SubstituteVarsSpec.hs
@@ -1,0 +1,157 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Vira.CI.Pipeline.SubstituteVarsSpec (spec) where
+
+import Test.Hspec
+import Vira.CI.Pipeline.Type (substituteVars)
+
+spec :: Spec
+spec = describe "substituteVars" $ do
+  -- -----------------------------------------------------------------------
+  -- Basic substitution
+  -- -----------------------------------------------------------------------
+  describe "basic substitution" $ do
+    it "replaces a single variable" $
+      substituteVars [("NAME", "world")] "hello $NAME" `shouldBe` "hello world"
+
+    it "replaces multiple distinct variables" $
+      substituteVars [("A", "foo"), ("B", "bar")] "$A and $B"
+        `shouldBe` "foo and bar"
+
+    it "replaces the same variable appearing more than once" $
+      substituteVars [("X", "42")] "$X + $X = 84"
+        `shouldBe` "42 + 42 = 84"
+
+    it "returns empty text when input is empty" $
+      substituteVars [("X", "v")] "" `shouldBe` ""
+
+    it "returns the literal when there are no placeholders" $
+      substituteVars [("X", "v")] "no vars here" `shouldBe` "no vars here"
+
+    it "works with an empty binding list (erases all vars)" $
+      substituteVars [] "$FOO bar" `shouldBe` " bar"
+
+  -- -----------------------------------------------------------------------
+  -- Variable name character rules
+  -- -----------------------------------------------------------------------
+  describe "variable name character rules" $ do
+    it "accepts names starting with an uppercase letter" $
+      substituteVars [("FOO", "yes")] "$FOO" `shouldBe` "yes"
+
+    it "accepts names starting with a lowercase letter" $
+      substituteVars [("foo", "yes")] "$foo" `shouldBe` "yes"
+
+    it "accepts names starting with an underscore" $
+      substituteVars [("_BAR", "yes")] "$_BAR" `shouldBe` "yes"
+
+    it "accepts names with digits after the first char" $
+      substituteVars [("V1", "ok")] "$V1" `shouldBe` "ok"
+
+    it "stops at the first non-identifier character" $
+      substituteVars [("VAR", "v")] "$VAR.suffix" `shouldBe` "v.suffix"
+
+    it "stops at a hyphen (not an identifier char)" $
+      substituteVars [("VAR", "v")] "$VAR-rest" `shouldBe` "v-rest"
+
+    it "does not treat digit-start as variable ($1BAD stays literal)" $
+      substituteVars [("1BAD", "x")] "$1BAD" `shouldBe` "$1BAD"
+
+  -- -----------------------------------------------------------------------
+  -- Bare '$' preservation
+  -- -----------------------------------------------------------------------
+  describe "bare '$' handling" $ do
+    it "preserves a trailing bare '$'" $
+      substituteVars [] "price $" `shouldBe` "price $"
+
+    it "preserves '$' followed by a space" $
+      substituteVars [] "$ 5" `shouldBe` "$ 5"
+
+    it "preserves '$' followed by another '$'" $
+      substituteVars [] "$$" `shouldBe` "$$"
+
+    it "preserves '$' at the start when followed by a digit" $
+      substituteVars [] "$9" `shouldBe` "$9"
+
+  -- -----------------------------------------------------------------------
+  -- Unknown / missing variables
+  -- -----------------------------------------------------------------------
+  describe "unknown variables" $ do
+    it "erases an unknown variable (replaces with empty string)" $
+      substituteVars [] "$UNKNOWN" `shouldBe` ""
+
+    it "erases an unknown variable but keeps surrounding text" $
+      substituteVars [] "pre $UNKNOWN post" `shouldBe` "pre  post"
+
+    it "erases only the unknown var, not a known one" $
+      substituteVars [("KNOWN", "k")] "$UNKNOWN $KNOWN"
+        `shouldBe` " k"
+
+  -- -----------------------------------------------------------------------
+  -- No recursive expansion
+  -- -----------------------------------------------------------------------
+  describe "single-pass (no recursive expansion)" $ do
+    it "does not re-substitute a value that itself contains a placeholder" $
+      substituteVars [("A", "$B"), ("B", "danger")] "$A"
+        `shouldBe` "$B"
+
+    it "does not expand a variable introduced by another substitution" $
+      substituteVars
+        [("OUTER", "$INNER"), ("INNER", "leaked")]
+        "$OUTER"
+        `shouldBe` "$INNER"
+
+  -- -----------------------------------------------------------------------
+  -- Vira-style real-world patterns
+  -- -----------------------------------------------------------------------
+  describe "real-world webhook patterns" $ do
+    it "substitutes a URL with branch and commit" $
+      substituteVars
+        [ ("VIRA_BRANCH", "main")
+        , ("VIRA_COMMIT_ID", "abc123")
+        ]
+        "https://api.example.com/deploy?branch=$VIRA_BRANCH&commit=$VIRA_COMMIT_ID"
+        `shouldBe` "https://api.example.com/deploy?branch=main&commit=abc123"
+
+    it "substitutes a Bearer token header value" $
+      substituteVars [("CI_TOKEN", "s3cr3t")] "Bearer $CI_TOKEN"
+        `shouldBe` "Bearer s3cr3t"
+
+    it "substitutes a JSON body template" $
+      substituteVars
+        [ ("VIRA_BRANCH", "feature/x")
+        , ("VIRA_COMMIT_ID", "deadbeef")
+        ]
+        "{\"branch\":\"$VIRA_BRANCH\",\"commit\":\"$VIRA_COMMIT_ID\"}"
+        `shouldBe` "{\"branch\":\"feature/x\",\"commit\":\"deadbeef\"}"
+
+    it "handles a URL where the variable is the entire path component" $
+      substituteVars [("REPO", "my-repo")] "https://host/$REPO/hook"
+        `shouldBe` "https://host/my-repo/hook"
+
+  -- -----------------------------------------------------------------------
+  -- Edge cases
+  -- -----------------------------------------------------------------------
+  describe "edge cases" $ do
+    it "handles a text that is only a variable" $
+      substituteVars [("ONLY", "just this")] "$ONLY"
+        `shouldBe` "just this"
+
+    it "handles adjacent variables with no separator" $
+      substituteVars [("A", "1"), ("B", "2")] "$A$B"
+        `shouldBe` "12"
+
+    it "handles a value that is empty string" $
+      substituteVars [("EMPTY", "")] "before${EMPTY}after"
+        `shouldBe` "before${EMPTY}after"
+
+    it "handles a value that is empty string (non-ident boundary)" $
+      substituteVars [("EMPTY", "")] "before $EMPTY after"
+        `shouldBe` "before  after"
+
+    it "handles unicode in the literal text (not in var names)" $
+      substituteVars [("LANG", "日本語")] "lang=$LANG end"
+        `shouldBe` "lang=日本語 end"
+
+    it "handles a very long literal with no variables efficiently" $ do
+      let long = mconcat (replicate 10000 "abcdefghij")
+      substituteVars [] long `shouldBe` long

--- a/packages/vira/vira.cabal
+++ b/packages/vira/vira.cabal
@@ -374,6 +374,8 @@ executable vira-tests
   main-is: Spec.hs
   other-modules:
       Vira.CI.ConfigurationSpec
+      Vira.CI.Pipeline.CheckDomainSpec
+      Vira.CI.Pipeline.SubstituteVarsSpec
       Vira.CI.WorkerSpec
       Vira.Lib.TimeExtraSpec
       Vira.State.ResetSpec


### PR DESCRIPTION
Run an executable script at the repo root after every successful pipeline (Build → Cache → Signoff → PostBuild). Key design decisions:

- Convention-based: presence of viraPostBuildHook.sh is the trigger, no config field needed to enable/disable
- Hard error if the script exists but is not executable (with chmod hint)
- Silent skip if the script is absent
- Timeout configurable via postBuild.timeoutSeconds (default 600s), enforced via withRunInIO + UnliftIO.Timeout wrapping runProcess'
- Five VIRA_* env vars exposed: VIRA_BRANCH, VIRA_COMMIT_ID, VIRA_CLONE_URL, VIRA_REPO_DIR, VIRA_ONLY_BUILD
- Full CI machine environment passed through for secret access (e.g. tokens)
- Skipped automatically in --only-build mode
- Executed via proc (not shell) for safety

Docs updated with Jenkins curl example and security warnings.