### PR TITLE
feat: add --local flag to vira ci with CIMode sum type

### DIFF
--- a/doc/guide/cli.md
+++ b/doc/guide/cli.md
@@ -18,7 +18,10 @@ If no directory is specified, runs in the current directory. The directory must 
 
 ### Options {#ci-opts}
 
-- `--only-build` / `-b` - Skip cache and signoff stages, only run build for current system
+- `--local` / `-l` - Build only for the current system, run all stages
+- `--only-build` / `-b` - Build only for the current system, skip cache and signoff stages
+
+These flags are mutually exclusive.
 
 ### Default Behavior {#default}
 
@@ -26,15 +29,31 @@ By default, `vira ci` respects the [[config|`vira.hs`]] configuration for all st
 
 - Fails if working directory has uncommitted changes or untracked files
 - Runs build, cache, and signoff stages as configured
+- Builds for all configured `build.systems`
 - Enables creating per-system signoffs (e.g., `vira/x86_64-linux`) during local development
 - Pushes to cache if configured
 
-### Build-Only Mode {#build-only}
+### Local Mode {#local}
 
-Use the `--only-build` flag for quick local testing without side effects:
+Use `--local` to build only for the current system while still running all pipeline stages (cache, signoff). This is useful when remote builders are unreliable and you want to complete CI locally — for example, SSH into a machine and run `vira ci --local` to finish CI for that system all the way through signoff.
 
 ```bash
-# Only build, skip cache and signoff
+vira ci --local
+
+# Short form
+vira ci -l
+```
+
+When `--local` is used:
+
+- Ignores `build.systems` from config (uses current system only)
+- Runs all stages: build, cache, and signoff
+
+### Build-Only Mode {#build-only}
+
+Use `--only-build` for quick local testing without side effects:
+
+```bash
 vira ci --only-build
 
 # Short form
@@ -49,16 +68,19 @@ When `--only-build` is used:
 - Skips cache push even if configured
 - Skips signoff creation even if configured
 
-### Example
+### Examples
 
 ```bash
-# Run CI with full configuration (build, cache, signoff)
+# Run full CI (all systems, all stages)
 vira ci
 
 # Run CI in specific directory
 vira ci /path/to/repo
 
-# Quick build-only mode
+# Local system only, all stages (skip remote builders)
+vira ci -l
+
+# Quick build-only mode (no cache, no signoff)
 vira ci -b
 ```
 

--- a/doc/guide/config.md
+++ b/doc/guide/config.md
@@ -31,7 +31,7 @@ The configuration function receives two parameters:
 
 - `ctx` - The Vira context containing repository and branch information
   - `ctx.branch` - Current branch name
-  - `ctx.onlyBuild` - True when running in build-only mode (e.g., `vira ci --only-build`)
+  - `ctx.ciMode` - The CI mode: `FullBuild`, `LocalBuild`, or `BuildOnly`
 - `pipeline` - The default pipeline configuration to customize
 
 All of [relude](https://hackage.haskell.org/package/relude)'s functions are made available in scope.

--- a/packages/vira-ci-types/src/Vira/CI/Context.hs
+++ b/packages/vira-ci-types/src/Vira/CI/Context.hs
@@ -7,10 +7,21 @@
 
 module Vira.CI.Context (
   ViraContext (..),
+  CIMode (..),
 ) where
 
 import Effectful.Git (BranchName, CommitID)
 import GHC.Records.Compat
+
+-- | CLI mode for pipeline execution
+data CIMode
+  = -- | Build all configured systems, run all stages
+    FullBuild
+  | -- | Build current system only, run all stages
+    LocalBuild
+  | -- | Build current system only, skip cache and signoff
+    BuildOnly
+  deriving stock (Show, Eq)
 
 {- | Essential context information for pipeline execution.
 
@@ -23,8 +34,7 @@ Note: Fields use simple types (BranchName, CommitID) rather than full objects
 -}
 data ViraContext = ViraContext
   { branch :: BranchName
-  , -- Skip cache and signoff stages when True
-    onlyBuild :: Bool
+  , ciMode :: CIMode
   , -- Commit ID being built
     commitId :: CommitID
   , -- Repository clone URL (for platform detection), Nothing when no remote is configured
@@ -36,16 +46,16 @@ data ViraContext = ViraContext
 
 -- HasField instances for ViraContext
 instance HasField "branch" ViraContext BranchName where
-  hasField (ViraContext branch onlyBuild commitId cloneUrl repoDir) = (\x -> ViraContext x onlyBuild commitId cloneUrl repoDir, branch)
+  hasField (ViraContext branch ciMode commitId cloneUrl repoDir) = (\x -> ViraContext x ciMode commitId cloneUrl repoDir, branch)
 
-instance HasField "onlyBuild" ViraContext Bool where
-  hasField (ViraContext branch onlyBuild commitId cloneUrl repoDir) = (\x -> ViraContext branch x commitId cloneUrl repoDir, onlyBuild)
+instance HasField "ciMode" ViraContext CIMode where
+  hasField (ViraContext branch ciMode commitId cloneUrl repoDir) = (\x -> ViraContext branch x commitId cloneUrl repoDir, ciMode)
 
 instance HasField "commitId" ViraContext CommitID where
-  hasField (ViraContext branch onlyBuild commitId cloneUrl repoDir) = (\x -> ViraContext branch onlyBuild x cloneUrl repoDir, commitId)
+  hasField (ViraContext branch ciMode commitId cloneUrl repoDir) = (\x -> ViraContext branch ciMode x cloneUrl repoDir, commitId)
 
 instance HasField "cloneUrl" ViraContext (Maybe Text) where
-  hasField (ViraContext branch onlyBuild commitId cloneUrl repoDir) = (\x -> ViraContext branch onlyBuild commitId x repoDir, cloneUrl)
+  hasField (ViraContext branch ciMode commitId cloneUrl repoDir) = (\x -> ViraContext branch ciMode commitId x repoDir, cloneUrl)
 
 instance HasField "repoDir" ViraContext FilePath where
-  hasField (ViraContext branch onlyBuild commitId cloneUrl repoDir) = (\x -> ViraContext branch onlyBuild commitId cloneUrl x, repoDir)
+  hasField (ViraContext branch ciMode commitId cloneUrl repoDir) = (\x -> ViraContext branch ciMode commitId cloneUrl x, repoDir)

--- a/packages/vira/src/Vira/App/CLI.hs
+++ b/packages/vira/src/Vira/App/CLI.hs
@@ -22,6 +22,7 @@ import Options.Applicative hiding (command)
 import Options.Applicative qualified as OA
 import Paths_vira qualified
 import Vira.CI.AutoBuild.Type (AutoBuildNewBranches (..))
+import Vira.CI.Context (CIMode (..))
 import Prelude hiding (Reader, reader, runReader)
 
 -- | Global CLI Settings
@@ -69,7 +70,7 @@ data Command
   | ExportCommand
   | ImportCommand
   | InfoCommand
-  | CICommand (Maybe FilePath) Bool
+  | CICommand (Maybe FilePath) CIMode
   deriving stock (Show)
 
 -- | Complete CLI configuration
@@ -199,11 +200,10 @@ ciCommandParser =
               <> help "Directory to run CI in (defaults to current directory)"
           )
       )
-    <*> switch
-      ( long "only-build"
-          <> short 'b'
-          <> help "Skip cache and signoff stages, only run build"
-      )
+    <*> ( flag' BuildOnly (long "only-build" <> short 'b' <> help "Skip cache and signoff stages, only run build")
+            <|> flag' LocalBuild (long "local" <> short 'l' <> help "Build only for the current system")
+            <|> pure FullBuild
+        )
 
 -- | Parser for commands
 commandParser :: Parser Command

--- a/packages/vira/src/Vira/App/Run.hs
+++ b/packages/vira/src/Vira/App/Run.hs
@@ -35,7 +35,7 @@ import Vira.App.CLI qualified as CLI
 import Vira.App.InstanceInfo (InstanceInfo (..), getInstanceInfo, platform)
 import Vira.CI.AutoBuild qualified as AutoBuild
 import Vira.CI.Cleanup.Daemon qualified as CleanupDaemon
-import Vira.CI.Context (ViraContext (..))
+import Vira.CI.Context (CIMode (..), ViraContext (..))
 import Vira.CI.Pipeline qualified as Pipeline
 import Vira.CI.Pipeline.Program qualified as Program
 import Vira.CI.Worker qualified as Worker
@@ -78,7 +78,7 @@ runVira = do
         ExportCommand -> runExport globalSettings
         ImportCommand -> runImport globalSettings
         InfoCommand -> runInfo
-        CICommand mDir onlyBuild -> runCI globalSettings mDir onlyBuild
+        CICommand mDir ciMode -> runCI globalSettings mDir ciMode
 
     runWebServer :: GlobalSettings -> WebSettings -> IO ()
     runWebServer globalSettings webSettings = do
@@ -137,8 +137,8 @@ runVira = do
       putTextLn $ "Platform: " <> platform instanceInfo
       putTextLn $ "Schema version: " <> show viraDbVersion
 
-    runCI :: GlobalSettings -> Maybe FilePath -> Bool -> IO ()
-    runCI gs mDir onlyBuild = do
+    runCI :: GlobalSettings -> Maybe FilePath -> CIMode -> IO ()
+    runCI gs mDir ciMode = do
       dir <- maybe getCurrentDirectory makeAbsolute mDir
       -- Throw Terminated on Ctrl+C so Process.hs cleanup logic can terminate nix processes
       exitCode <- withTerminationHandler Terminated $ App.runAppCLI gs $ do
@@ -146,14 +146,14 @@ runVira = do
           exists <- liftIO $ doesDirectoryExist dir
           unless exists $ throwError $ "Repository directory does not exist: " <> toText dir
           status <- gitStatusPorcelain dir
-          -- Check for dirty working directory unless --only-build is set
-          unless onlyBuild $ do
+          -- Check for dirty working directory unless in BuildOnly mode
+          unless (ciMode == BuildOnly) $ do
             when status.dirty $ throwError "Working directory has uncommitted changes or untracked files. Use --only-build to run CI anyway."
           -- Get remote URL (Nothing if no remote configured)
           remoteUrl <- getRemoteUrl dir "origin"
           -- Get current commit hash
           commitId <- getCurrentCommit dir
-          let ctx = ViraContext status.branch onlyBuild commitId remoteUrl dir
+          let ctx = ViraContext status.branch ciMode commitId remoteUrl dir
           tools <- Tool.getAllTools
           let env = Pipeline.pipelineEnvFromCLI gs.logLevel Pipeline.workspaceContextKeys tools ctx
           runErrorNoCallStack (Pipeline.runPipeline env Program.pipelineProgram) >>= \case

--- a/packages/vira/src/Vira/App/Run.hs
+++ b/packages/vira/src/Vira/App/Run.hs
@@ -159,10 +159,10 @@ runVira = do
           runErrorNoCallStack (Pipeline.runPipeline env Program.pipelineProgram) >>= \case
             Left (err :: Pipeline.PipelineError) -> do
               log Error $ show err
-              log Error "CI pipeline failed"
+              log Error $ "CI pipeline failed (" <> show ciMode <> ")"
               pure $ ExitFailure 2
             Right () -> do
-              log Info "CI pipeline succeeded"
+              log Info $ "CI pipeline succeeded (" <> show ciMode <> ")"
               pure ExitSuccess
         case result of
           Left err -> do

--- a/packages/vira/src/Vira/CI/Pipeline/Effect.hs
+++ b/packages/vira/src/Vira/CI/Pipeline/Effect.hs
@@ -27,7 +27,7 @@ data PipelineEnv = PipelineEnv
   , tools :: Tools
   -- ^ Available CI 'Vira.Environment.Tool.Type.Tools.Tools'
   , viraContext :: ViraContext
-  -- ^ 'ViraContext' (branch, onlyBuild flag)
+  -- ^ 'ViraContext' (branch, ciMode, etc.)
   , logSink :: Sink Text
   -- ^ 'LogSink.Sink' for all output (ViraLog JSON + subprocess raw output)
   , excludeContextKeys :: [Text]

--- a/packages/vira/src/Vira/CI/Pipeline/Implementation.hs
+++ b/packages/vira/src/Vira/CI/Pipeline/Implementation.hs
@@ -41,7 +41,7 @@ import System.Nix.Core (nix)
 import System.Nix.System (System (..))
 import System.Process (proc)
 import Vira.CI.Configuration qualified as Configuration
-import Vira.CI.Context (ViraContext (..))
+import Vira.CI.Context (CIMode (..), ViraContext (..))
 import Vira.CI.Error (ConfigurationError (..), PipelineError (..), pipelineToolError)
 import Vira.CI.Pipeline.Effect
 import Vira.CI.Pipeline.Process (runProcess)
@@ -137,19 +137,19 @@ loadConfigImpl = do
       logPipeline Info "No vira.hs found - using default pipeline"
       pure $ patchPipelineForCli env.viraContext defaultPipeline
   where
-    -- When onlyBuild is enabled, restrict to current system and disable cache/signoff
     patchPipelineForCli :: ViraContext -> ViraPipeline -> ViraPipeline
-    patchPipelineForCli ctx pipeline
-      | ctx.onlyBuild =
-          pipeline
-            { -- Don't signoff when only building
-              signoff = pipeline.signoff {enable = False}
-            , -- Don't push to cache when only building
-              cache = pipeline.cache {url = Nothing}
-            , -- Only build for current system when only building
-              build = BuildStage {flakes = pipeline.build.flakes, systems = []}
-            }
-      | otherwise = pipeline
+    patchPipelineForCli ctx pipeline = case ctx.ciMode of
+      FullBuild -> pipeline
+      LocalBuild ->
+        pipeline
+          { build = BuildStage {flakes = pipeline.build.flakes, systems = []}
+          }
+      BuildOnly ->
+        pipeline
+          { signoff = pipeline.signoff {enable = False}
+          , cache = pipeline.cache {url = Nothing}
+          , build = BuildStage {flakes = pipeline.build.flakes, systems = []}
+          }
 
 -- | Implementation: Build flakes
 buildImpl ::

--- a/packages/vira/src/Vira/CI/Worker.hs
+++ b/packages/vira/src/Vira/CI/Worker.hs
@@ -34,7 +34,7 @@ import System.Exit (ExitCode (..))
 import Vira.App.AcidState qualified as App
 import Vira.App.Stack (AppStack)
 import Vira.App.Type (ViraRuntimeState (jobWorker, supervisor))
-import Vira.CI.Context (ViraContext (..))
+import Vira.CI.Context (CIMode (..), ViraContext (..))
 import Vira.CI.Pipeline qualified as Pipeline
 import Vira.CI.Pipeline.Program qualified as Program
 import Vira.CI.Worker.Type (JobWorkerState (..))
@@ -160,7 +160,7 @@ startJob job = do
   -- Start task
   st <- ask @ViraRuntimeState
   tools <- Tool.refreshTools
-  let ctx = ViraContext job.branch False branch.headCommit.id (Just repo.cloneUrl) job.jobWorkingDir
+  let ctx = ViraContext job.branch FullBuild branch.headCommit.id (Just repo.cloneUrl) job.jobWorkingDir
   (logSink, broadcast, closeLogSink) <- Supervisor.createTaskLogSink job.jobWorkingDir "output.log"
   let logFn = Pipeline.logPipeline' Pipeline.workspaceContextKeys logSink
   Supervisor.startTask

--- a/packages/vira/test/Vira/CI/ConfigurationSpec.hs
+++ b/packages/vira/test/Vira/CI/ConfigurationSpec.hs
@@ -8,7 +8,7 @@ import Effectful.Git (BranchName (..), Commit (..), CommitID (..), RepoName (..)
 import Paths_vira (getDataFileName)
 import Test.Hspec
 import Vira.CI.Configuration
-import Vira.CI.Context (ViraContext (..))
+import Vira.CI.Context (CIMode (..), ViraContext (..))
 import Vira.CI.Pipeline.Implementation (defaultPipeline)
 import Vira.CI.Pipeline.Type (BuildStage (..), Flake (..), NixConfig (..), SignoffStage (..), ViraPipeline (..), validateNixOptions)
 import Vira.State.Type (Branch (..))
@@ -35,7 +35,7 @@ testContextStaging :: ViraContext
 testContextStaging =
   ViraContext
     { branch = testBranchStaging.branchName
-    , onlyBuild = False
+    , ciMode = FullBuild
     , commitId = testBranchStaging.headCommit.id
     , cloneUrl = Just "https://example.com/test-repo.git"
     , repoDir = "/tmp/test-repo"


### PR DESCRIPTION
## Summary
- Add `vira ci --local` / `-l` to build for current system only while still running all pipeline stages — useful when remote builders are unreliable; SSH into a machine and `vira ci -l` to finish CI for that system all the way through signoff
- Replace two boolean fields (`onlyBuild`, `localOnly`) in `ViraContext` with a `CIMode` sum type (`FullBuild`, `LocalBuild`, `BuildOnly`)
- `--only-build` and `--local` are mutually exclusive at the parser level
- Pipeline success/failure log now includes the CI mode

## Test plan
- [x] `nix build` compiles cleanly
- [x] `vira ci --local` builds current system, runs cache + signoff
- [ ] `vira ci --only-build` behaves as before
- [ ] `vira ci` (no flags) builds all configured systems

🤖 Generated with [Claude Code](https://claude.com/claude-code)