### PR TITLE
Aesthetic foundation: Geist fonts + brand-color token scale

### DIFF
--- a/.apm/skills/vira-design/SKILL.md
+++ b/.apm/skills/vira-design/SKILL.md
@@ -17,7 +17,7 @@ Clean, minimal CI/CD application design system emphasizing clarity and functiona
 
 ### Primary Colors
 
-- **Brand accent**: `cyan-600` (primary actions), `cyan-700` (hover states)
+- **Brand accent**: `brand-600` (primary actions), `brand-700` (hover states). The `brand-*` scale is declared in `packages/vira/src/style.css` as a `@theme` alias to Tailwind's cyan today — change those `var(--color-cyan-*)` aliases to shift the brand without touching widget code.
 - **Background**: `gray-50` (page), `white` (cards), `gray-200` (dividers)
   - **Dark mode**: `gray-900` (page), `gray-800` (cards), `gray-700` (dividers)
 

--- a/.apm/skills/vira-design/SKILL.md
+++ b/.apm/skills/vira-design/SKILL.md
@@ -17,7 +17,7 @@ Clean, minimal CI/CD application design system emphasizing clarity and functiona
 
 ### Primary Colors
 
-- **Indigo**: `indigo-600` (primary actions), `indigo-700` (hover states)
+- **Brand accent**: `cyan-600` (primary actions), `cyan-700` (hover states)
 - **Background**: `gray-50` (page), `white` (cards), `gray-200` (dividers)
   - **Dark mode**: `gray-900` (page), `gray-800` (cards), `gray-700` (dividers)
 
@@ -42,8 +42,10 @@ Clean, minimal CI/CD application design system emphasizing clarity and functiona
 
 ### Font Families
 
-- **Sans-serif**: Inter (variable font, 300-700 weights), system-ui fallbacks
-- **Monospace**: JetBrains Mono (for logs, code, and technical values)
+- **Sans-serif**: Geist (variable font, 300-700 weights), system-ui fallbacks
+- **Monospace**: Geist Mono (for logs, code, and technical values)
+
+Tokens are declared as `--font-sans` / `--font-mono` in `packages/vira/src/style.css` (the Tailwind v4 input file). Generated `static/tailwind.css` exposes them via `font-sans` / `font-mono` utility classes — prefer those over hard-coded `font-family` declarations.
 
 ### Size Scale
 

--- a/.claude/skills/vira-design/SKILL.md
+++ b/.claude/skills/vira-design/SKILL.md
@@ -17,7 +17,7 @@ Clean, minimal CI/CD application design system emphasizing clarity and functiona
 
 ### Primary Colors
 
-- **Brand accent**: `cyan-600` (primary actions), `cyan-700` (hover states)
+- **Brand accent**: `brand-600` (primary actions), `brand-700` (hover states). The `brand-*` scale is declared in `packages/vira/src/style.css` as a `@theme` alias to Tailwind's cyan today — change those `var(--color-cyan-*)` aliases to shift the brand without touching widget code.
 - **Background**: `gray-50` (page), `white` (cards), `gray-200` (dividers)
   - **Dark mode**: `gray-900` (page), `gray-800` (cards), `gray-700` (dividers)
 

--- a/.claude/skills/vira-design/SKILL.md
+++ b/.claude/skills/vira-design/SKILL.md
@@ -17,7 +17,7 @@ Clean, minimal CI/CD application design system emphasizing clarity and functiona
 
 ### Primary Colors
 
-- **Indigo**: `indigo-600` (primary actions), `indigo-700` (hover states)
+- **Brand accent**: `cyan-600` (primary actions), `cyan-700` (hover states)
 - **Background**: `gray-50` (page), `white` (cards), `gray-200` (dividers)
   - **Dark mode**: `gray-900` (page), `gray-800` (cards), `gray-700` (dividers)
 
@@ -42,8 +42,10 @@ Clean, minimal CI/CD application design system emphasizing clarity and functiona
 
 ### Font Families
 
-- **Sans-serif**: Inter (variable font, 300-700 weights), system-ui fallbacks
-- **Monospace**: JetBrains Mono (for logs, code, and technical values)
+- **Sans-serif**: Geist (variable font, 300-700 weights), system-ui fallbacks
+- **Monospace**: Geist Mono (for logs, code, and technical values)
+
+Tokens are declared as `--font-sans` / `--font-mono` in `packages/vira/src/style.css` (the Tailwind v4 input file). Generated `static/tailwind.css` exposes them via `font-sans` / `font-mono` utility classes — prefer those over hard-coded `font-family` declarations.
 
 ### Size Scale
 

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,6 +1,6 @@
 lockfile_version: '1'
-generated_at: '2026-04-27T15:57:15.362181+00:00'
-apm_version: 0.9.4
+generated_at: '2026-04-27T16:59:08.161082+00:00'
+apm_version: 0.10.0
 dependencies:
 - repo_url: anthropics/skills
   host: github.com

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-04-27T16:59:08.161082+00:00'
+generated_at: '2026-04-27T17:09:13.200204+00:00'
 apm_version: 0.10.0
 dependencies:
 - repo_url: anthropics/skills

--- a/nix/modules/flake-parts/vira-dev.nix
+++ b/nix/modules/flake-parts/vira-dev.nix
@@ -42,7 +42,7 @@
                 text = ''
                   pwd
                   cd ./packages/vira
-                  exec ${lib.getExe tailwind} -w -o ../static/tailwind.css --cwd ./src
+                  exec ${lib.getExe tailwind} -w -i ./style.css -o ../static/tailwind.css --cwd ./src
                 '';
               };
               is_tty = true;

--- a/packages/vira/src/Vira/Web/Pages/CachePage.hs
+++ b/packages/vira/src/Vira/Web/Pages/CachePage.hs
@@ -61,7 +61,7 @@ viewCache cachePublicKey = do
           Code.viraCodeBlockCopyable (Just "cache-url") cacheUrl
           p_ [class_ "text-sm text-gray-500 dark:text-gray-500 mt-2"] $ do
             "Check cache info: "
-            a_ [href_ "/cache/nix-cache-info", class_ "text-cyan-600 dark:text-cyan-400 hover:underline", target_ "_blank"] "/cache/nix-cache-info"
+            a_ [href_ "/cache/nix-cache-info", class_ "text-brand-600 dark:text-brand-400 hover:underline", target_ "_blank"] "/cache/nix-cache-info"
 
         -- Public key section
         div_ [] $ do

--- a/packages/vira/src/Vira/Web/Pages/CachePage.hs
+++ b/packages/vira/src/Vira/Web/Pages/CachePage.hs
@@ -61,7 +61,7 @@ viewCache cachePublicKey = do
           Code.viraCodeBlockCopyable (Just "cache-url") cacheUrl
           p_ [class_ "text-sm text-gray-500 dark:text-gray-500 mt-2"] $ do
             "Check cache info: "
-            a_ [href_ "/cache/nix-cache-info", class_ "text-indigo-600 dark:text-indigo-400 hover:underline", target_ "_blank"] "/cache/nix-cache-info"
+            a_ [href_ "/cache/nix-cache-info", class_ "text-cyan-600 dark:text-cyan-400 hover:underline", target_ "_blank"] "/cache/nix-cache-info"
 
         -- Public key section
         div_ [] $ do

--- a/packages/vira/src/Vira/Web/Pages/EnvironmentPage.hs
+++ b/packages/vira/src/Vira/Web/Pages/EnvironmentPage.hs
@@ -43,7 +43,7 @@ viewEnvironment = do
     W.viraPageHeaderWithIcon_ (toHtmlRaw Icon.cpu) "Environment" $ do
       div_ [class_ "flex items-center justify-between"] $ do
         p_ [class_ "text-gray-600 dark:text-gray-300"] "User environment under which Vira runs"
-        span_ [class_ "text-cyan-800 dark:text-cyan-300 font-semibold"] User.viewUserInfo
+        span_ [class_ "text-brand-800 dark:text-brand-300 font-semibold"] User.viewUserInfo
 
     -- Tools Section (returns tools data for reuse)
     tools <- Tools.viewTools

--- a/packages/vira/src/Vira/Web/Pages/EnvironmentPage.hs
+++ b/packages/vira/src/Vira/Web/Pages/EnvironmentPage.hs
@@ -43,7 +43,7 @@ viewEnvironment = do
     W.viraPageHeaderWithIcon_ (toHtmlRaw Icon.cpu) "Environment" $ do
       div_ [class_ "flex items-center justify-between"] $ do
         p_ [class_ "text-gray-600 dark:text-gray-300"] "User environment under which Vira runs"
-        span_ [class_ "text-indigo-800 dark:text-indigo-300 font-semibold"] User.viewUserInfo
+        span_ [class_ "text-cyan-800 dark:text-cyan-300 font-semibold"] User.viewUserInfo
 
     -- Tools Section (returns tools data for reuse)
     tools <- Tools.viewTools

--- a/packages/vira/src/Vira/Web/Pages/EnvironmentPage/Tools.hs
+++ b/packages/vira/src/Vira/Web/Pages/EnvironmentPage/Tools.hs
@@ -49,7 +49,7 @@ viewToolCard toolData infoHtml = do
           a_
             [ href_ toolData.url
             , target_ "_blank"
-            , class_ "inline-flex items-center gap-1 hover:text-cyan-600 dark:hover:text-cyan-400"
+            , class_ "inline-flex items-center gap-1 hover:text-brand-600 dark:hover:text-brand-400"
             ]
             $ do
               toHtml toolData.name
@@ -81,7 +81,7 @@ viewToolIcon disp =
 -- | Get display styling for a tool
 mkToolDisplay :: Text -> ToolDisplay
 mkToolDisplay name = case name of
-  "Attic" -> mkDisplay "bg-cyan-100" "text-cyan-600"
+  "Attic" -> mkDisplay "bg-brand-100" "text-brand-600"
   "Bitbucket CLI" -> mkDisplay "bg-blue-100" "text-blue-600"
   "GitHub" -> mkDisplay "bg-green-100" "text-green-600"
   "Git" -> mkDisplay "bg-orange-100" "text-orange-600"

--- a/packages/vira/src/Vira/Web/Pages/EnvironmentPage/Tools.hs
+++ b/packages/vira/src/Vira/Web/Pages/EnvironmentPage/Tools.hs
@@ -49,7 +49,7 @@ viewToolCard toolData infoHtml = do
           a_
             [ href_ toolData.url
             , target_ "_blank"
-            , class_ "inline-flex items-center gap-1 hover:text-indigo-600 dark:hover:text-indigo-400"
+            , class_ "inline-flex items-center gap-1 hover:text-cyan-600 dark:hover:text-cyan-400"
             ]
             $ do
               toHtml toolData.name
@@ -81,7 +81,7 @@ viewToolIcon disp =
 -- | Get display styling for a tool
 mkToolDisplay :: Text -> ToolDisplay
 mkToolDisplay name = case name of
-  "Attic" -> mkDisplay "bg-indigo-100" "text-indigo-600"
+  "Attic" -> mkDisplay "bg-cyan-100" "text-cyan-600"
   "Bitbucket CLI" -> mkDisplay "bg-blue-100" "text-blue-600"
   "GitHub" -> mkDisplay "bg-green-100" "text-green-600"
   "Git" -> mkDisplay "bg-orange-100" "text-orange-600"

--- a/packages/vira/src/Vira/Web/Pages/IndexPage.hs
+++ b/packages/vira/src/Vira/Web/Pages/IndexPage.hs
@@ -101,14 +101,14 @@ viewRecentActivity mNeverBuilt = do
 heroWelcome :: (Monad m) => Text -> Text -> Text -> Text -> HtmlT m ()
 heroWelcome logoUrl reposLink envLink cacheLink = do
   -- Compact hero banner
-  div_ [class_ "bg-indigo-50 dark:bg-indigo-900/20 border-2 border-t-0 border-indigo-200 dark:border-indigo-800 rounded-b-xl p-6 mb-6"] $ do
+  div_ [class_ "bg-cyan-50 dark:bg-cyan-900/20 border-2 border-t-0 border-cyan-200 dark:border-cyan-800 rounded-b-xl p-6 mb-6"] $ do
     -- Logo and title
     div_ [class_ "flex items-center space-x-4 mb-4"] $ do
       img_ [src_ logoUrl, class_ "w-12 h-12"]
       div_ $ do
-        h1_ [class_ "text-2xl font-bold text-indigo-900 dark:text-indigo-100"] $ do
+        h1_ [class_ "text-2xl font-bold text-cyan-900 dark:text-cyan-100"] $ do
           a_ [href_ "http://github.com/juspay/vira", class_ "hover:underline", target_ "_blank"] "Vira"
-        p_ [class_ "text-sm text-indigo-700 dark:text-indigo-300"] $ do
+        p_ [class_ "text-sm text-cyan-700 dark:text-cyan-300"] $ do
           "No-frills CI/CD for "
           a_ [href_ "https://nixos.asia/en/nix-first", class_ "underline hover:no-underline", target_ "blank"] "Nix"
 
@@ -120,6 +120,6 @@ heroWelcome logoUrl reposLink envLink cacheLink = do
   where
     heroButton :: (Monad m) => Text -> ByteString -> Text -> HtmlT m ()
     heroButton url icon label =
-      a_ [href_ url, class_ "flex-1 flex items-center justify-center gap-2 py-2 px-4 bg-indigo-600 dark:bg-indigo-700 text-white font-semibold rounded-lg hover:bg-indigo-700 dark:hover:bg-indigo-600 transition-colors"] $ do
+      a_ [href_ url, class_ "flex-1 flex items-center justify-center gap-2 py-2 px-4 bg-cyan-600 dark:bg-cyan-700 text-white font-semibold rounded-lg hover:bg-cyan-700 dark:hover:bg-cyan-600 transition-colors"] $ do
         div_ [class_ "w-4 h-4 flex items-center justify-center"] $ toHtmlRaw icon
         toHtml label

--- a/packages/vira/src/Vira/Web/Pages/IndexPage.hs
+++ b/packages/vira/src/Vira/Web/Pages/IndexPage.hs
@@ -101,14 +101,14 @@ viewRecentActivity mNeverBuilt = do
 heroWelcome :: (Monad m) => Text -> Text -> Text -> Text -> HtmlT m ()
 heroWelcome logoUrl reposLink envLink cacheLink = do
   -- Compact hero banner
-  div_ [class_ "bg-cyan-50 dark:bg-cyan-900/20 border-2 border-t-0 border-cyan-200 dark:border-cyan-800 rounded-b-xl p-6 mb-6"] $ do
+  div_ [class_ "bg-brand-50 dark:bg-brand-900/20 border-2 border-t-0 border-brand-200 dark:border-brand-800 rounded-b-xl p-6 mb-6"] $ do
     -- Logo and title
     div_ [class_ "flex items-center space-x-4 mb-4"] $ do
       img_ [src_ logoUrl, class_ "w-12 h-12"]
       div_ $ do
-        h1_ [class_ "text-2xl font-bold text-cyan-900 dark:text-cyan-100"] $ do
+        h1_ [class_ "text-2xl font-bold text-brand-900 dark:text-brand-100"] $ do
           a_ [href_ "http://github.com/juspay/vira", class_ "hover:underline", target_ "_blank"] "Vira"
-        p_ [class_ "text-sm text-cyan-700 dark:text-cyan-300"] $ do
+        p_ [class_ "text-sm text-brand-700 dark:text-brand-300"] $ do
           "No-frills CI/CD for "
           a_ [href_ "https://nixos.asia/en/nix-first", class_ "underline hover:no-underline", target_ "blank"] "Nix"
 
@@ -120,6 +120,6 @@ heroWelcome logoUrl reposLink envLink cacheLink = do
   where
     heroButton :: (Monad m) => Text -> ByteString -> Text -> HtmlT m ()
     heroButton url icon label =
-      a_ [href_ url, class_ "flex-1 flex items-center justify-center gap-2 py-2 px-4 bg-cyan-600 dark:bg-cyan-700 text-white font-semibold rounded-lg hover:bg-cyan-700 dark:hover:bg-cyan-600 transition-colors"] $ do
+      a_ [href_ url, class_ "flex-1 flex items-center justify-center gap-2 py-2 px-4 bg-brand-600 dark:bg-brand-700 text-white font-semibold rounded-lg hover:bg-brand-700 dark:hover:bg-brand-600 transition-colors"] $ do
         div_ [class_ "w-4 h-4 flex items-center justify-center"] $ toHtmlRaw icon
         toHtml label

--- a/packages/vira/src/Vira/Web/Pages/IndexPage.hs
+++ b/packages/vira/src/Vira/Web/Pages/IndexPage.hs
@@ -101,7 +101,7 @@ viewRecentActivity mNeverBuilt = do
 heroWelcome :: (Monad m) => Text -> Text -> Text -> Text -> HtmlT m ()
 heroWelcome logoUrl reposLink envLink cacheLink = do
   -- Compact hero banner
-  div_ [class_ "bg-brand-50 dark:bg-brand-900/20 border-2 border-t-0 border-brand-200 dark:border-brand-800 rounded-b-xl p-6 mb-6"] $ do
+  W.viraBrandPanel_ [class_ "p-6 mb-6"] $ do
     -- Logo and title
     div_ [class_ "flex items-center space-x-4 mb-4"] $ do
       img_ [src_ logoUrl, class_ "w-12 h-12"]

--- a/packages/vira/src/Vira/Web/Pages/RegistryPage.hs
+++ b/packages/vira/src/Vira/Web/Pages/RegistryPage.hs
@@ -107,7 +107,7 @@ viewRepoList = do
               (toHtml $ toString repo.name)
 
         -- Add new repository section
-        W.viraCard_ [class_ "p-6 bg-indigo-50 dark:bg-indigo-900/20 border-2 border-indigo-200 dark:border-indigo-800"] $ do
+        W.viraCard_ [class_ "p-6 bg-cyan-50 dark:bg-cyan-900/20 border-2 border-cyan-200 dark:border-cyan-800"] $ do
           h3_ [class_ "text-xl font-bold text-gray-900 dark:text-gray-100 mb-4 flex items-center"] $ do
             div_ [class_ "w-5 h-5 mr-2 flex items-center justify-center"] $ toHtmlRaw Icon.plus
             "Add New Repository"

--- a/packages/vira/src/Vira/Web/Pages/RegistryPage.hs
+++ b/packages/vira/src/Vira/Web/Pages/RegistryPage.hs
@@ -107,7 +107,7 @@ viewRepoList = do
               (toHtml $ toString repo.name)
 
         -- Add new repository section
-        W.viraCard_ [class_ "p-6 bg-cyan-50 dark:bg-cyan-900/20 border-2 border-cyan-200 dark:border-cyan-800"] $ do
+        W.viraCard_ [class_ "p-6 bg-brand-50 dark:bg-brand-900/20 border-2 border-brand-200 dark:border-brand-800"] $ do
           h3_ [class_ "text-xl font-bold text-gray-900 dark:text-gray-100 mb-4 flex items-center"] $ do
             div_ [class_ "w-5 h-5 mr-2 flex items-center justify-center"] $ toHtmlRaw Icon.plus
             "Add New Repository"

--- a/packages/vira/src/Vira/Web/Pages/RepoPage.hs
+++ b/packages/vira/src/Vira/Web/Pages/RepoPage.hs
@@ -142,7 +142,7 @@ viewRepo repo branchDetails isPruned = do
         div_ [class_ "relative"] $ do
           input_
             [ type_ "text"
-            , class_ "w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 bg-white dark:bg-gray-700 dark:text-gray-100 transition-colors duration-200 pr-10"
+            , class_ "w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:border-cyan-500 bg-white dark:bg-gray-700 dark:text-gray-100 transition-colors duration-200 pr-10"
             , placeholder_ "Filter branches..."
             , name_ "q"
             , hxGet_ filterUrl

--- a/packages/vira/src/Vira/Web/Pages/RepoPage.hs
+++ b/packages/vira/src/Vira/Web/Pages/RepoPage.hs
@@ -142,7 +142,7 @@ viewRepo repo branchDetails isPruned = do
         div_ [class_ "relative"] $ do
           input_
             [ type_ "text"
-            , class_ "w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:border-cyan-500 bg-white dark:bg-gray-700 dark:text-gray-100 transition-colors duration-200 pr-10"
+            , class_ "w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-brand-500 bg-white dark:bg-gray-700 dark:text-gray-100 transition-colors duration-200 pr-10"
             , placeholder_ "Filter branches..."
             , name_ "q"
             , hxGet_ filterUrl

--- a/packages/vira/src/Vira/Web/Pages/RepoPage.hs
+++ b/packages/vira/src/Vira/Web/Pages/RepoPage.hs
@@ -147,7 +147,6 @@ viewRepo repo branchDetails isPruned = do
           , hxTarget_ "#branch-listing"
           , hxTrigger_ "keyup changed delay:300ms"
           ]
-          []
 
       -- Branch listing
       div_ [id_ "branch-listing"] $ do

--- a/packages/vira/src/Vira/Web/Pages/RepoPage.hs
+++ b/packages/vira/src/Vira/Web/Pages/RepoPage.hs
@@ -30,6 +30,7 @@ import Vira.Web.Lucid (AppHtml, getLink, getLinkUrl, runAppHtml)
 import Vira.Web.Stack qualified as Web
 import Vira.Web.Widgets.Alert qualified as W
 import Vira.Web.Widgets.Button qualified as W
+import Vira.Web.Widgets.Form qualified as W
 import Vira.Web.Widgets.JobsListing qualified as W
 import Vira.Web.Widgets.Layout qualified as W
 import Vira.Web.Widgets.Modal (ErrorModal (..))
@@ -136,21 +137,17 @@ viewRepo repo branchDetails isPruned = do
               show @Text (length branchDetails) <> " branches"
         div_ [class_ "h-px bg-gray-200 dark:bg-gray-700"] mempty
 
-      -- Branch filter input
+      -- Branch filter input (server-side filter via HTMX)
       div_ [class_ "mb-6"] $ do
         filterUrl <- lift $ getLinkUrl $ LinkTo.RepoBranchFilter repo.name
-        div_ [class_ "relative"] $ do
-          input_
-            [ type_ "text"
-            , class_ "w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-brand-500 bg-white dark:bg-gray-700 dark:text-gray-100 transition-colors duration-200 pr-10"
-            , placeholder_ "Filter branches..."
-            , name_ "q"
-            , hxGet_ filterUrl
-            , hxTarget_ "#branch-listing"
-            , hxTrigger_ "keyup changed delay:300ms"
-            ]
-          div_ [class_ "absolute inset-y-0 right-0 flex items-center pr-3 pointer-events-none"] $ do
-            div_ [class_ "text-gray-500 dark:text-gray-400 w-4 h-4 flex items-center justify-center"] $ toHtmlRaw Icon.search
+        W.viraFilterInputShell_
+          [ placeholder_ "Filter branches..."
+          , name_ "q"
+          , hxGet_ filterUrl
+          , hxTarget_ "#branch-listing"
+          , hxTrigger_ "keyup changed delay:300ms"
+          ]
+          []
 
       -- Branch listing
       div_ [id_ "branch-listing"] $ do

--- a/packages/vira/src/Vira/Web/Stream/Log.hs
+++ b/packages/vira/src/Vira/Web/Stream/Log.hs
@@ -229,7 +229,7 @@ logViewerWidget job w = do
       h4_ [class_ "text-sm font-semibold text-gray-700 uppercase tracking-wider"] "Build Output"
       a_
         [ target_ "blank"
-        , class_ "text-sm text-gray-600 hover:text-indigo-600 transition-colors font-medium"
+        , class_ "text-sm text-gray-600 hover:text-cyan-600 transition-colors font-medium"
         , href_ jobLogUrl
         ]
         "View Full Log →"

--- a/packages/vira/src/Vira/Web/Stream/Log.hs
+++ b/packages/vira/src/Vira/Web/Stream/Log.hs
@@ -229,7 +229,7 @@ logViewerWidget job w = do
       h4_ [class_ "text-sm font-semibold text-gray-700 uppercase tracking-wider"] "Build Output"
       a_
         [ target_ "blank"
-        , class_ "text-sm text-gray-600 hover:text-cyan-600 transition-colors font-medium"
+        , class_ "text-sm text-gray-600 hover:text-brand-600 transition-colors font-medium"
         , href_ jobLogUrl
         ]
         "View Full Log →"

--- a/packages/vira/src/Vira/Web/Widgets/Button.hs
+++ b/packages/vira/src/Vira/Web/Widgets/Button.hs
@@ -58,7 +58,7 @@ W.viraButton_ W.ButtonPrimary [type_ "submit", form_ "my-form"] "Submit"
 
 = Variant Guidelines
 
-- **ButtonPrimary**: Main actions, form submissions (indigo)
+- **ButtonPrimary**: Main actions, form submissions (brand accent)
 - **ButtonSuccess**: Positive actions like build, save (green)
 - **ButtonDestructive**: Delete, disconnect, kill actions (red)
 - **ButtonSecondary**: Less important actions, cancel (gray)
@@ -70,7 +70,7 @@ Colors are automatically managed by the variant type, preventing inconsistent st
 viraButton_ :: forall {result}. (Term [Attributes] result) => ButtonVariant -> [Attributes] -> result
 viraButton_ variant attrs =
   let (colorClasses, focusRing) = case variant of
-        ButtonPrimary -> ("bg-indigo-600 hover:bg-indigo-700 text-white", "focus:ring-indigo-500")
+        ButtonPrimary -> ("bg-cyan-600 hover:bg-cyan-700 text-white", "focus:ring-cyan-500")
         ButtonSuccess -> ("bg-green-600 hover:bg-green-700 text-white", "focus:ring-green-500")
         ButtonDestructive -> ("bg-red-600 hover:bg-red-700 text-white", "focus:ring-red-500")
         ButtonSecondary -> ("bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 text-gray-900 dark:text-gray-100", "focus:ring-gray-500")

--- a/packages/vira/src/Vira/Web/Widgets/Button.hs
+++ b/packages/vira/src/Vira/Web/Widgets/Button.hs
@@ -70,7 +70,7 @@ Colors are automatically managed by the variant type, preventing inconsistent st
 viraButton_ :: forall {result}. (Term [Attributes] result) => ButtonVariant -> [Attributes] -> result
 viraButton_ variant attrs =
   let (colorClasses, focusRing) = case variant of
-        ButtonPrimary -> ("bg-cyan-600 hover:bg-cyan-700 text-white", "focus:ring-cyan-500")
+        ButtonPrimary -> ("bg-brand-600 hover:bg-brand-700 text-white", "focus:ring-brand-500")
         ButtonSuccess -> ("bg-green-600 hover:bg-green-700 text-white", "focus:ring-green-500")
         ButtonDestructive -> ("bg-red-600 hover:bg-red-700 text-white", "focus:ring-red-500")
         ButtonSecondary -> ("bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 text-gray-900 dark:text-gray-100", "focus:ring-gray-500")

--- a/packages/vira/src/Vira/Web/Widgets/Button.hs
+++ b/packages/vira/src/Vira/Web/Widgets/Button.hs
@@ -18,7 +18,7 @@ import Vira.Web.Widgets.Modal (viraGlobalModalId)
 
 -- | Button variant types for consistent styling
 data ButtonVariant
-  = -- | Indigo - primary actions, forms
+  = -- | Brand accent - primary actions, forms
     ButtonPrimary
   | -- | Red - delete, disconnect, kill actions
     ButtonDestructive

--- a/packages/vira/src/Vira/Web/Widgets/Card.hs
+++ b/packages/vira/src/Vira/Web/Widgets/Card.hs
@@ -63,8 +63,8 @@ W.viraNavigationCard_ (show repoUrl) (toHtml $ toString repo.name)
 viraNavigationCard_ :: (Monad m) => Text -> HtmlT m () -> HtmlT m ()
 viraNavigationCard_ href title = do
   a_ [href_ href, class_ "group block"] $ do
-    viraCard_ [class_ "p-6 hover:shadow-lg transition-all duration-300 group-hover:border-cyan-300 dark:group-hover:border-cyan-600"] $ do
+    viraCard_ [class_ "p-6 hover:shadow-lg transition-all duration-300 group-hover:border-brand-300 dark:group-hover:border-brand-600"] $ do
       div_ [class_ "flex items-center justify-between"] $ do
-        h3_ [class_ "text-xl font-semibold text-gray-900 dark:text-gray-100 group-hover:text-cyan-700 dark:group-hover:text-cyan-400 transition-colors"] title
-        div_ [class_ "text-gray-400 dark:text-gray-500 group-hover:text-cyan-500 dark:group-hover:text-cyan-400 transition-colors ml-4 w-6 h-6 flex items-center justify-center"] $
+        h3_ [class_ "text-xl font-semibold text-gray-900 dark:text-gray-100 group-hover:text-brand-700 dark:group-hover:text-brand-400 transition-colors"] title
+        div_ [class_ "text-gray-400 dark:text-gray-500 group-hover:text-brand-500 dark:group-hover:text-brand-400 transition-colors ml-4 w-6 h-6 flex items-center justify-center"] $
           toHtmlRaw Icon.chevron_right

--- a/packages/vira/src/Vira/Web/Widgets/Card.hs
+++ b/packages/vira/src/Vira/Web/Widgets/Card.hs
@@ -63,8 +63,8 @@ W.viraNavigationCard_ (show repoUrl) (toHtml $ toString repo.name)
 viraNavigationCard_ :: (Monad m) => Text -> HtmlT m () -> HtmlT m ()
 viraNavigationCard_ href title = do
   a_ [href_ href, class_ "group block"] $ do
-    viraCard_ [class_ "p-6 hover:shadow-lg transition-all duration-300 group-hover:border-indigo-300 dark:group-hover:border-indigo-600"] $ do
+    viraCard_ [class_ "p-6 hover:shadow-lg transition-all duration-300 group-hover:border-cyan-300 dark:group-hover:border-cyan-600"] $ do
       div_ [class_ "flex items-center justify-between"] $ do
-        h3_ [class_ "text-xl font-semibold text-gray-900 dark:text-gray-100 group-hover:text-indigo-700 dark:group-hover:text-indigo-400 transition-colors"] title
-        div_ [class_ "text-gray-400 dark:text-gray-500 group-hover:text-indigo-500 dark:group-hover:text-indigo-400 transition-colors ml-4 w-6 h-6 flex items-center justify-center"] $
+        h3_ [class_ "text-xl font-semibold text-gray-900 dark:text-gray-100 group-hover:text-cyan-700 dark:group-hover:text-cyan-400 transition-colors"] title
+        div_ [class_ "text-gray-400 dark:text-gray-500 group-hover:text-cyan-500 dark:group-hover:text-cyan-400 transition-colors ml-4 w-6 h-6 flex items-center justify-center"] $
           toHtmlRaw Icon.chevron_right

--- a/packages/vira/src/Vira/Web/Widgets/Form.hs
+++ b/packages/vira/src/Vira/Web/Widgets/Form.hs
@@ -67,11 +67,11 @@ W.viraInput_ [type_ "text", name_ "repo", value_ existingValue]
 
 Inherits full width (w-full) by default.
 Override styling with additional classes as needed.
-Focus ring uses cyan-500 to match brand colors.
+Focus ring uses brand-500 to match brand colors.
 -}
 viraInput_ :: forall (m :: Type -> Type). (Monad m) => [Attributes] -> HtmlT m ()
 viraInput_ attrs = do
-  input_ ([class_ "block w-full px-4 py-3 text-sm border border-gray-300 dark:border-gray-600 rounded-lg shadow-sm placeholder-gray-500 dark:placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:border-cyan-500 bg-white dark:bg-gray-700 dark:text-gray-100 transition-colors duration-200"] <> attrs)
+  input_ ([class_ "block w-full px-4 py-3 text-sm border border-gray-300 dark:border-gray-600 rounded-lg shadow-sm placeholder-gray-500 dark:placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-brand-500 bg-white dark:bg-gray-700 dark:text-gray-100 transition-colors duration-200"] <> attrs)
 
 {- |
 Form label component with consistent typography and spacing.
@@ -226,7 +226,7 @@ viraFilterInput_ targetSelector attrs = do
   div_ [class_ "relative"] $ do
     input_
       ( [ type_ "text"
-        , class_ "w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:border-cyan-500 bg-white dark:bg-gray-700 dark:text-gray-100 transition-colors duration-200 pr-10"
+        , class_ "w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-brand-500 bg-white dark:bg-gray-700 dark:text-gray-100 transition-colors duration-200 pr-10"
         , hyperscript_ $
             "on input "
               <> "set filterText to my.value.toLowerCase() "

--- a/packages/vira/src/Vira/Web/Widgets/Form.hs
+++ b/packages/vira/src/Vira/Web/Widgets/Form.hs
@@ -29,6 +29,7 @@ module Vira.Web.Widgets.Form (
   viraLabel_,
   viraFormGroup_,
   viraFilterInput_,
+  viraFilterInputShell_,
 ) where
 
 import Data.Char (toUpper)
@@ -223,24 +224,39 @@ viraFilterInput_ targetSelector attrs = do
       capitalize t = case T.uncons t of
         Nothing -> t
         Just (c, cs) -> cons (toUpper c) cs
+  viraFilterInputShell_
+    [ hyperscript_ $
+        "on input "
+          <> "set filterText to my.value.toLowerCase() "
+          <> "for item in document.querySelectorAll('"
+          <> targetSelector
+          <> "') "
+          <> "set itemValue to item.dataset."
+          <> filterAttribute
+          <> " "
+          <> "if filterText is '' then show item "
+          <> "else if itemValue and itemValue.toLowerCase().includes(filterText) then show item "
+          <> "else hide item "
+          <> "end"
+    ]
+    attrs
+
+{- |
+Filter-input chrome (rounded text input + trailing search icon) without
+filtering behavior. Pass behavior attributes (hyperscript, htmx, plain
+@onchange@, etc.) via @inputAttrs@; @attrs@ merges into the @\<input\>@.
+
+Use this directly when 'viraFilterInput_'\'s built-in client-side
+hyperscript filtering doesn't fit (e.g., server-side HTMX filtering).
+-}
+viraFilterInputShell_ :: (Monad m) => [Attributes] -> [Attributes] -> HtmlT m ()
+viraFilterInputShell_ inputAttrs attrs = do
   div_ [class_ "relative"] $ do
     input_
       ( [ type_ "text"
         , class_ "w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-brand-500 bg-white dark:bg-gray-700 dark:text-gray-100 transition-colors duration-200 pr-10"
-        , hyperscript_ $
-            "on input "
-              <> "set filterText to my.value.toLowerCase() "
-              <> "for item in document.querySelectorAll('"
-              <> targetSelector
-              <> "') "
-              <> "set itemValue to item.dataset."
-              <> filterAttribute
-              <> " "
-              <> "if filterText is '' then show item "
-              <> "else if itemValue and itemValue.toLowerCase().includes(filterText) then show item "
-              <> "else hide item "
-              <> "end"
         ]
+          <> inputAttrs
           <> attrs
       )
     div_ [class_ "absolute inset-y-0 right-0 flex items-center pr-3 pointer-events-none"] $ do

--- a/packages/vira/src/Vira/Web/Widgets/Form.hs
+++ b/packages/vira/src/Vira/Web/Widgets/Form.hs
@@ -43,7 +43,7 @@ Form input component with consistent styling and focus states.
 
 Provides standardized input fields across the application with:
 - Consistent padding, borders, and border radius
-- Proper focus states with indigo accent colors
+- Proper focus states with brand accent colors
 - Background and transition styling
 - Accessibility features
 
@@ -67,11 +67,11 @@ W.viraInput_ [type_ "text", name_ "repo", value_ existingValue]
 
 Inherits full width (w-full) by default.
 Override styling with additional classes as needed.
-Focus ring uses indigo-500 to match brand colors.
+Focus ring uses cyan-500 to match brand colors.
 -}
 viraInput_ :: forall (m :: Type -> Type). (Monad m) => [Attributes] -> HtmlT m ()
 viraInput_ attrs = do
-  input_ ([class_ "block w-full px-4 py-3 text-sm border border-gray-300 dark:border-gray-600 rounded-lg shadow-sm placeholder-gray-500 dark:placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 bg-white dark:bg-gray-700 dark:text-gray-100 transition-colors duration-200"] <> attrs)
+  input_ ([class_ "block w-full px-4 py-3 text-sm border border-gray-300 dark:border-gray-600 rounded-lg shadow-sm placeholder-gray-500 dark:placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:border-cyan-500 bg-white dark:bg-gray-700 dark:text-gray-100 transition-colors duration-200"] <> attrs)
 
 {- |
 Form label component with consistent typography and spacing.
@@ -226,7 +226,7 @@ viraFilterInput_ targetSelector attrs = do
   div_ [class_ "relative"] $ do
     input_
       ( [ type_ "text"
-        , class_ "w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 bg-white dark:bg-gray-700 dark:text-gray-100 transition-colors duration-200 pr-10"
+        , class_ "w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:border-cyan-500 bg-white dark:bg-gray-700 dark:text-gray-100 transition-colors duration-200 pr-10"
         , hyperscript_ $
             "on input "
               <> "set filterText to my.value.toLowerCase() "

--- a/packages/vira/src/Vira/Web/Widgets/Form.hs
+++ b/packages/vira/src/Vira/Web/Widgets/Form.hs
@@ -224,9 +224,9 @@ viraFilterInput_ targetSelector attrs = do
       capitalize t = case T.uncons t of
         Nothing -> t
         Just (c, cs) -> cons (toUpper c) cs
-  viraFilterInputShell_
-    [ hyperscript_ $
-        "on input "
+  viraFilterInputShell_ $
+    hyperscript_
+      ( "on input "
           <> "set filterText to my.value.toLowerCase() "
           <> "for item in document.querySelectorAll('"
           <> targetSelector
@@ -238,25 +238,24 @@ viraFilterInput_ targetSelector attrs = do
           <> "else if itemValue and itemValue.toLowerCase().includes(filterText) then show item "
           <> "else hide item "
           <> "end"
-    ]
-    attrs
+      )
+      : attrs
 
 {- |
 Filter-input chrome (rounded text input + trailing search icon) without
 filtering behavior. Pass behavior attributes (hyperscript, htmx, plain
-@onchange@, etc.) via @inputAttrs@; @attrs@ merges into the @\<input\>@.
+@onchange@, etc.) via @attrs@; they're merged onto the @\<input\>@.
 
 Use this directly when 'viraFilterInput_'\'s built-in client-side
 hyperscript filtering doesn't fit (e.g., server-side HTMX filtering).
 -}
-viraFilterInputShell_ :: (Monad m) => [Attributes] -> [Attributes] -> HtmlT m ()
-viraFilterInputShell_ inputAttrs attrs = do
+viraFilterInputShell_ :: (Monad m) => [Attributes] -> HtmlT m ()
+viraFilterInputShell_ attrs = do
   div_ [class_ "relative"] $ do
     input_
       ( [ type_ "text"
         , class_ "w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-brand-500 bg-white dark:bg-gray-700 dark:text-gray-100 transition-colors duration-200 pr-10"
         ]
-          <> inputAttrs
           <> attrs
       )
     div_ [class_ "absolute inset-y-0 right-0 flex items-center pr-3 pointer-events-none"] $ do

--- a/packages/vira/src/Vira/Web/Widgets/JobsListing.hs
+++ b/packages/vira/src/Vira/Web/Widgets/JobsListing.hs
@@ -130,7 +130,7 @@ viraJobContextHeader_ :: Text -> AppHtml () -> AppHtml ()
 viraJobContextHeader_ url content = do
   a_
     [ href_ url
-    , class_ "group block mb-2 pl-3 text-lg font-bold text-gray-900 dark:text-gray-100 hover:text-cyan-600 dark:hover:text-cyan-400 transition-colors"
+    , class_ "group block mb-2 pl-3 text-lg font-bold text-gray-900 dark:text-gray-100 hover:text-brand-600 dark:hover:text-brand-400 transition-colors"
     ]
     content
 

--- a/packages/vira/src/Vira/Web/Widgets/JobsListing.hs
+++ b/packages/vira/src/Vira/Web/Widgets/JobsListing.hs
@@ -130,7 +130,7 @@ viraJobContextHeader_ :: Text -> AppHtml () -> AppHtml ()
 viraJobContextHeader_ url content = do
   a_
     [ href_ url
-    , class_ "group block mb-2 pl-3 text-lg font-bold text-gray-900 dark:text-gray-100 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors"
+    , class_ "group block mb-2 pl-3 text-lg font-bold text-gray-900 dark:text-gray-100 hover:text-cyan-600 dark:hover:text-cyan-400 transition-colors"
     ]
     content
 

--- a/packages/vira/src/Vira/Web/Widgets/Layout.hs
+++ b/packages/vira/src/Vira/Web/Widgets/Layout.hs
@@ -33,6 +33,7 @@ module Vira.Web.Widgets.Layout (
   appLogoUrl,
   viraPageHeader_,
   viraPageHeaderWithIcon_,
+  viraBrandPanel_,
   viraSection_,
   viraDivider_,
 ) where
@@ -254,15 +255,21 @@ breadcrumbs rs' = do
       span_ [class_ "mx-1 text-white/60"] $ toHtmlRaw ("<svg xmlns='http://www.w3.org/2000/svg' class='h-5 w-5' fill='none' viewBox='0 0 24 24' stroke='currentColor' stroke-width='2'><path stroke-linecap='round' stroke-linejoin='round' d='M9 5l7 7-7 7'/></svg>" :: Text)
 
 {- |
+Brand-tinted panel chrome — the rounded-bottom card that visually
+connects to the breadcrumbs bar. Spacing (padding, margin) is the
+caller's responsibility; pass via @attrs@.
+-}
+viraBrandPanel_ :: forall {result}. (Term [Attributes] result) => [Attributes] -> result
+viraBrandPanel_ attrs =
+  div_ ([class_ "bg-brand-50 dark:bg-brand-900/20 border-2 border-t-0 border-brand-200 dark:border-brand-800 rounded-b-xl"] <> attrs)
+
+{- |
 Standardized page header with title and subtitle.
 
 Features brand-accent styling that connects visually with breadcrumbs.
 -}
 viraPageHeader_ :: (Monad m) => Text -> HtmlT m () -> HtmlT m ()
-viraPageHeader_ title subtitle = do
-  div_ [class_ "bg-brand-50 dark:bg-brand-900/20 border-2 border-t-0 border-brand-200 dark:border-brand-800 rounded-b-xl p-4 mb-6"] $ do
-    h1_ [class_ "text-2xl font-bold text-brand-900 dark:text-brand-200 tracking-tight mb-2"] $ toHtml title
-    div_ [class_ "text-brand-700 dark:text-brand-300"] subtitle
+viraPageHeader_ = viraPageHeaderWithIcon_ mempty
 
 {- |
 Standardized page header with icon, title and subtitle.
@@ -270,8 +277,8 @@ Standardized page header with icon, title and subtitle.
 Features brand-accent styling that connects visually with breadcrumbs, with an icon displayed alongside the title.
 -}
 viraPageHeaderWithIcon_ :: (Monad m) => HtmlT m () -> Text -> HtmlT m () -> HtmlT m ()
-viraPageHeaderWithIcon_ icon title subtitle = do
-  div_ [class_ "bg-brand-50 dark:bg-brand-900/20 border-2 border-t-0 border-brand-200 dark:border-brand-800 rounded-b-xl p-4 mb-6"] $ do
+viraPageHeaderWithIcon_ icon title subtitle =
+  viraBrandPanel_ [class_ "p-4 mb-6"] $ do
     h1_ [class_ "text-2xl font-bold text-brand-900 dark:text-brand-200 tracking-tight mb-2 flex items-center"] $ do
       div_ [class_ "w-6 h-6 mr-3 flex items-center justify-center text-brand-900 dark:text-brand-200"] icon
       toHtml title

--- a/packages/vira/src/Vira/Web/Widgets/Layout.hs
+++ b/packages/vira/src/Vira/Web/Widgets/Layout.hs
@@ -101,12 +101,6 @@ layout crumbs content = do
       link_ [rel_ "icon", type_ "image/svg+xml", href_ logoUrl]
       htmx
       link_ [rel_ "stylesheet", type_ "text/css", href_ "tailwind.css"]
-      -- Custom styles for the new design
-      style_ $
-        unlines
-          [ "html { overflow-y: scroll; }" -- Scrollbar always visible, to prevent jankiness
-          , ".transition-smooth { transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1); }"
-          ]
     body_ [class_ "bg-gray-50 dark:bg-gray-900 min-h-screen font-sans"] $ do
       -- Add SSE listener for auto-refresh (if page supports it)
       Stream.viewStreamScoped crumbs

--- a/packages/vira/src/Vira/Web/Widgets/Layout.hs
+++ b/packages/vira/src/Vira/Web/Widgets/Layout.hs
@@ -90,15 +90,12 @@ layout crumbs content = do
         let baseTitle = linkTitle <$> viaNonEmpty last crumbs
         toHtml $ pageTitle instanceInfo baseTitle
       base_ [href_ basePath]
-      -- Google Fonts - Inter (variable) for UI, JetBrains Mono for code/logs
-      -- Preconnect hints for faster font loading
+      -- Google Fonts - Geist for UI, Geist Mono for code/logs
       link_ [rel_ "preconnect", href_ "https://fonts.googleapis.com"]
       link_ [rel_ "preconnect", href_ "https://fonts.gstatic.com", crossorigin_ ""]
-      -- Preload the font stylesheets
-      link_ [rel_ "preload", href_ interFontUrl, makeAttributes "as" "style"]
+      link_ [rel_ "preload", href_ sansFontUrl, makeAttributes "as" "style"]
       link_ [rel_ "preload", href_ monoFontUrl, makeAttributes "as" "style"]
-      -- Load fonts: Inter variable (300-700) + JetBrains Mono (400,500,700)
-      link_ [href_ interFontUrl, rel_ "stylesheet"]
+      link_ [href_ sansFontUrl, rel_ "stylesheet"]
       link_ [href_ monoFontUrl, rel_ "stylesheet"]
       link_ [rel_ "icon", type_ "image/svg+xml", href_ logoUrl]
       htmx
@@ -107,11 +104,9 @@ layout crumbs content = do
       style_ $
         unlines
           [ "html { overflow-y: scroll; }" -- Scrollbar always visible, to prevent jankiness
-          , "body { font-family: 'Inter', ui-sans-serif, system-ui, sans-serif; }"
-          , ":root { --font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; }"
           , ".transition-smooth { transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1); }"
           ]
-    body_ [class_ "bg-gray-50 dark:bg-gray-900 min-h-screen font-inter"] $ do
+    body_ [class_ "bg-gray-50 dark:bg-gray-900 min-h-screen font-sans"] $ do
       -- Add SSE listener for auto-refresh (if page supports it)
       Stream.viewStreamScoped crumbs
       -- Global modal container for all pages
@@ -123,9 +118,9 @@ layout crumbs content = do
           content
         footer crumbs
   where
-    -- Font URLs
-    interFontUrl = "https://fonts.googleapis.com/css2?family=Inter:wght@300..700&display=swap"
-    monoFontUrl = "https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&display=swap"
+    -- Font URLs (Geist variable + Geist Mono variable)
+    sansFontUrl = "https://fonts.googleapis.com/css2?family=Geist:wght@300..700&display=swap"
+    monoFontUrl = "https://fonts.googleapis.com/css2?family=Geist+Mono:wght@400;500;700&display=swap"
     -- Mobile friendly head tags
     mobileFriendly = do
       meta_ [charset_ "utf-8", name_ "viewport", content_ "width=device-width, initial-scale=1"]
@@ -216,7 +211,7 @@ breadcrumbs :: [LinkTo] -> AppHtml ()
 breadcrumbs rs' = do
   logoUrl <- appLogoUrl
   let logo = img_ [src_ logoUrl, alt_ "Vira Logo", class_ "h-8 w-8 rounded-lg"]
-  nav_ [id_ "breadcrumbs", class_ "flex items-center justify-between px-4 py-2 bg-indigo-600 rounded-t-xl"] $ do
+  nav_ [id_ "breadcrumbs", class_ "flex items-center justify-between px-4 py-2 bg-cyan-600 rounded-t-xl"] $ do
     ol_ [class_ "flex flex-1 items-center space-x-2 text-base list-none"] $ do
       -- Logo as first element
       li_ [class_ "flex items-center"] $ do
@@ -261,26 +256,26 @@ breadcrumbs rs' = do
 {- |
 Standardized page header with title and subtitle.
 
-Features indigo styling that connects visually with breadcrumbs.
+Features brand-accent styling that connects visually with breadcrumbs.
 -}
 viraPageHeader_ :: (Monad m) => Text -> HtmlT m () -> HtmlT m ()
 viraPageHeader_ title subtitle = do
-  div_ [class_ "bg-indigo-50 dark:bg-indigo-900/20 border-2 border-t-0 border-indigo-200 dark:border-indigo-800 rounded-b-xl p-4 mb-6"] $ do
-    h1_ [class_ "text-2xl font-bold text-indigo-900 dark:text-indigo-200 tracking-tight mb-2"] $ toHtml title
-    div_ [class_ "text-indigo-700 dark:text-indigo-300"] subtitle
+  div_ [class_ "bg-cyan-50 dark:bg-cyan-900/20 border-2 border-t-0 border-cyan-200 dark:border-cyan-800 rounded-b-xl p-4 mb-6"] $ do
+    h1_ [class_ "text-2xl font-bold text-cyan-900 dark:text-cyan-200 tracking-tight mb-2"] $ toHtml title
+    div_ [class_ "text-cyan-700 dark:text-cyan-300"] subtitle
 
 {- |
 Standardized page header with icon, title and subtitle.
 
-Features indigo styling that connects visually with breadcrumbs, with an icon displayed alongside the title.
+Features brand-accent styling that connects visually with breadcrumbs, with an icon displayed alongside the title.
 -}
 viraPageHeaderWithIcon_ :: (Monad m) => HtmlT m () -> Text -> HtmlT m () -> HtmlT m ()
 viraPageHeaderWithIcon_ icon title subtitle = do
-  div_ [class_ "bg-indigo-50 dark:bg-indigo-900/20 border-2 border-t-0 border-indigo-200 dark:border-indigo-800 rounded-b-xl p-4 mb-6"] $ do
-    h1_ [class_ "text-2xl font-bold text-indigo-900 dark:text-indigo-200 tracking-tight mb-2 flex items-center"] $ do
-      div_ [class_ "w-6 h-6 mr-3 flex items-center justify-center text-indigo-900 dark:text-indigo-200"] icon
+  div_ [class_ "bg-cyan-50 dark:bg-cyan-900/20 border-2 border-t-0 border-cyan-200 dark:border-cyan-800 rounded-b-xl p-4 mb-6"] $ do
+    h1_ [class_ "text-2xl font-bold text-cyan-900 dark:text-cyan-200 tracking-tight mb-2 flex items-center"] $ do
+      div_ [class_ "w-6 h-6 mr-3 flex items-center justify-center text-cyan-900 dark:text-cyan-200"] icon
       toHtml title
-    div_ [class_ "text-indigo-700 dark:text-indigo-300"] subtitle
+    div_ [class_ "text-cyan-700 dark:text-cyan-300"] subtitle
 
 {- |
 Section component for grouping and spacing page content.

--- a/packages/vira/src/Vira/Web/Widgets/Layout.hs
+++ b/packages/vira/src/Vira/Web/Widgets/Layout.hs
@@ -211,7 +211,7 @@ breadcrumbs :: [LinkTo] -> AppHtml ()
 breadcrumbs rs' = do
   logoUrl <- appLogoUrl
   let logo = img_ [src_ logoUrl, alt_ "Vira Logo", class_ "h-8 w-8 rounded-lg"]
-  nav_ [id_ "breadcrumbs", class_ "flex items-center justify-between px-4 py-2 bg-cyan-600 rounded-t-xl"] $ do
+  nav_ [id_ "breadcrumbs", class_ "flex items-center justify-between px-4 py-2 bg-brand-600 rounded-t-xl"] $ do
     ol_ [class_ "flex flex-1 items-center space-x-2 text-base list-none"] $ do
       -- Logo as first element
       li_ [class_ "flex items-center"] $ do
@@ -260,9 +260,9 @@ Features brand-accent styling that connects visually with breadcrumbs.
 -}
 viraPageHeader_ :: (Monad m) => Text -> HtmlT m () -> HtmlT m ()
 viraPageHeader_ title subtitle = do
-  div_ [class_ "bg-cyan-50 dark:bg-cyan-900/20 border-2 border-t-0 border-cyan-200 dark:border-cyan-800 rounded-b-xl p-4 mb-6"] $ do
-    h1_ [class_ "text-2xl font-bold text-cyan-900 dark:text-cyan-200 tracking-tight mb-2"] $ toHtml title
-    div_ [class_ "text-cyan-700 dark:text-cyan-300"] subtitle
+  div_ [class_ "bg-brand-50 dark:bg-brand-900/20 border-2 border-t-0 border-brand-200 dark:border-brand-800 rounded-b-xl p-4 mb-6"] $ do
+    h1_ [class_ "text-2xl font-bold text-brand-900 dark:text-brand-200 tracking-tight mb-2"] $ toHtml title
+    div_ [class_ "text-brand-700 dark:text-brand-300"] subtitle
 
 {- |
 Standardized page header with icon, title and subtitle.
@@ -271,11 +271,11 @@ Features brand-accent styling that connects visually with breadcrumbs, with an i
 -}
 viraPageHeaderWithIcon_ :: (Monad m) => HtmlT m () -> Text -> HtmlT m () -> HtmlT m ()
 viraPageHeaderWithIcon_ icon title subtitle = do
-  div_ [class_ "bg-cyan-50 dark:bg-cyan-900/20 border-2 border-t-0 border-cyan-200 dark:border-cyan-800 rounded-b-xl p-4 mb-6"] $ do
-    h1_ [class_ "text-2xl font-bold text-cyan-900 dark:text-cyan-200 tracking-tight mb-2 flex items-center"] $ do
-      div_ [class_ "w-6 h-6 mr-3 flex items-center justify-center text-cyan-900 dark:text-cyan-200"] icon
+  div_ [class_ "bg-brand-50 dark:bg-brand-900/20 border-2 border-t-0 border-brand-200 dark:border-brand-800 rounded-b-xl p-4 mb-6"] $ do
+    h1_ [class_ "text-2xl font-bold text-brand-900 dark:text-brand-200 tracking-tight mb-2 flex items-center"] $ do
+      div_ [class_ "w-6 h-6 mr-3 flex items-center justify-center text-brand-900 dark:text-brand-200"] icon
       toHtml title
-    div_ [class_ "text-cyan-700 dark:text-cyan-300"] subtitle
+    div_ [class_ "text-brand-700 dark:text-brand-300"] subtitle
 
 {- |
 Section component for grouping and spacing page content.

--- a/packages/vira/src/Vira/Web/Widgets/Tabs.hs
+++ b/packages/vira/src/Vira/Web/Widgets/Tabs.hs
@@ -48,7 +48,7 @@ viraTabs_ []
 
 = Design
 
-Active tabs use cyan-600 border and background tint.
+Active tabs use brand-600 border and background tint.
 Inactive tabs use transparent border with hover effects.
 Badges adapt colors based on active/inactive state.
 -}
@@ -63,7 +63,7 @@ viraTabs_ attrs tabs =
               "px-4 py-3 font-semibold text-sm transition-colors border-b-2 "
                 <> (if isJust badge then "flex items-center gap-2 " else "")
                 <> if isActive
-                  then "border-cyan-600 dark:border-cyan-400 text-cyan-600 dark:text-cyan-400 bg-cyan-50 dark:bg-cyan-900/20"
+                  then "border-brand-600 dark:border-brand-400 text-brand-600 dark:text-brand-400 bg-brand-50 dark:bg-brand-900/20"
                   else "border-transparent text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-800/50"
           ]
           $ do
@@ -74,7 +74,7 @@ viraTabs_ attrs tabs =
                   [ class_ $
                       "inline-flex items-center justify-center px-2 py-0.5 text-xs font-semibold rounded-full "
                         <> if isActive
-                          then "bg-cyan-600 dark:bg-cyan-500 text-white"
+                          then "bg-brand-600 dark:bg-brand-500 text-white"
                           else "bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300"
                   ]
                 $ toHtml (show count :: String)

--- a/packages/vira/src/Vira/Web/Widgets/Tabs.hs
+++ b/packages/vira/src/Vira/Web/Widgets/Tabs.hs
@@ -31,7 +31,7 @@ Creates a horizontal tab bar with consistent styling following Vira Design Syste
 
 = Features
 
-- Active state with indigo accent
+- Active state with brand accent
 - Inactive tabs with hover states
 - Optional badge counts
 - Full dark mode support
@@ -48,7 +48,7 @@ viraTabs_ []
 
 = Design
 
-Active tabs use indigo-600 border and background tint.
+Active tabs use cyan-600 border and background tint.
 Inactive tabs use transparent border with hover effects.
 Badges adapt colors based on active/inactive state.
 -}
@@ -63,7 +63,7 @@ viraTabs_ attrs tabs =
               "px-4 py-3 font-semibold text-sm transition-colors border-b-2 "
                 <> (if isJust badge then "flex items-center gap-2 " else "")
                 <> if isActive
-                  then "border-indigo-600 dark:border-indigo-400 text-indigo-600 dark:text-indigo-400 bg-indigo-50 dark:bg-indigo-900/20"
+                  then "border-cyan-600 dark:border-cyan-400 text-cyan-600 dark:text-cyan-400 bg-cyan-50 dark:bg-cyan-900/20"
                   else "border-transparent text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-800/50"
           ]
           $ do
@@ -74,7 +74,7 @@ viraTabs_ attrs tabs =
                   [ class_ $
                       "inline-flex items-center justify-center px-2 py-0.5 text-xs font-semibold rounded-full "
                         <> if isActive
-                          then "bg-indigo-600 dark:bg-indigo-500 text-white"
+                          then "bg-cyan-600 dark:bg-cyan-500 text-white"
                           else "bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300"
                   ]
                 $ toHtml (show count :: String)

--- a/packages/vira/src/style.css
+++ b/packages/vira/src/style.css
@@ -7,4 +7,18 @@
   --font-mono:
     "Geist Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
     "Liberation Mono", "Courier New", monospace;
+
+  /* Brand accent — single source of truth for primary/highlight color.
+     Aliased to Tailwind's cyan scale today; change these var() targets
+     to shift the brand without touching widget code. */
+  --color-brand-50: var(--color-cyan-50);
+  --color-brand-100: var(--color-cyan-100);
+  --color-brand-200: var(--color-cyan-200);
+  --color-brand-300: var(--color-cyan-300);
+  --color-brand-400: var(--color-cyan-400);
+  --color-brand-500: var(--color-cyan-500);
+  --color-brand-600: var(--color-cyan-600);
+  --color-brand-700: var(--color-cyan-700);
+  --color-brand-800: var(--color-cyan-800);
+  --color-brand-900: var(--color-cyan-900);
 }

--- a/packages/vira/src/style.css
+++ b/packages/vira/src/style.css
@@ -1,0 +1,10 @@
+@import "tailwindcss";
+
+@theme {
+  --font-sans:
+    "Geist", ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji",
+    "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  --font-mono:
+    "Geist Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    "Liberation Mono", "Courier New", monospace;
+}

--- a/packages/vira/src/style.css
+++ b/packages/vira/src/style.css
@@ -21,16 +21,16 @@ html {
     "Liberation Mono", "Courier New", monospace;
 
   /* Brand accent — single source of truth for primary/highlight color.
-     Aliased to Tailwind's cyan scale today; change these var() targets
+     Aliased to Tailwind's sky scale today; change these var() targets
      to shift the brand without touching widget code. */
-  --color-brand-50: var(--color-cyan-50);
-  --color-brand-100: var(--color-cyan-100);
-  --color-brand-200: var(--color-cyan-200);
-  --color-brand-300: var(--color-cyan-300);
-  --color-brand-400: var(--color-cyan-400);
-  --color-brand-500: var(--color-cyan-500);
-  --color-brand-600: var(--color-cyan-600);
-  --color-brand-700: var(--color-cyan-700);
-  --color-brand-800: var(--color-cyan-800);
-  --color-brand-900: var(--color-cyan-900);
+  --color-brand-50: var(--color-sky-50);
+  --color-brand-100: var(--color-sky-100);
+  --color-brand-200: var(--color-sky-200);
+  --color-brand-300: var(--color-sky-300);
+  --color-brand-400: var(--color-sky-400);
+  --color-brand-500: var(--color-sky-500);
+  --color-brand-600: var(--color-sky-600);
+  --color-brand-700: var(--color-sky-700);
+  --color-brand-800: var(--color-sky-800);
+  --color-brand-900: var(--color-sky-900);
 }

--- a/packages/vira/src/style.css
+++ b/packages/vira/src/style.css
@@ -21,16 +21,16 @@ html {
     "Liberation Mono", "Courier New", monospace;
 
   /* Brand accent — single source of truth for primary/highlight color.
-     Aliased to Tailwind's sky scale today; change these var() targets
+     Aliased to Tailwind's blue scale today; change these var() targets
      to shift the brand without touching widget code. */
-  --color-brand-50: var(--color-sky-50);
-  --color-brand-100: var(--color-sky-100);
-  --color-brand-200: var(--color-sky-200);
-  --color-brand-300: var(--color-sky-300);
-  --color-brand-400: var(--color-sky-400);
-  --color-brand-500: var(--color-sky-500);
-  --color-brand-600: var(--color-sky-600);
-  --color-brand-700: var(--color-sky-700);
-  --color-brand-800: var(--color-sky-800);
-  --color-brand-900: var(--color-sky-900);
+  --color-brand-50: var(--color-blue-50);
+  --color-brand-100: var(--color-blue-100);
+  --color-brand-200: var(--color-blue-200);
+  --color-brand-300: var(--color-blue-300);
+  --color-brand-400: var(--color-blue-400);
+  --color-brand-500: var(--color-blue-500);
+  --color-brand-600: var(--color-blue-600);
+  --color-brand-700: var(--color-blue-700);
+  --color-brand-800: var(--color-blue-800);
+  --color-brand-900: var(--color-blue-900);
 }

--- a/packages/vira/src/style.css
+++ b/packages/vira/src/style.css
@@ -1,5 +1,17 @@
 @import "tailwindcss";
 
+/* Always render a vertical scrollbar to prevent layout shift between
+   pages whose content does/doesn't overflow the viewport. */
+html {
+  overflow-y: scroll;
+}
+
+/* Smooth transition for interactive elements that change colors / spacing
+   on hover or focus. Referenced by class via `transition-smooth`. */
+.transition-smooth {
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
 @theme {
   --font-sans:
     "Geist", ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji",

--- a/packages/vira/static/tailwind.css
+++ b/packages/vira/static/tailwind.css
@@ -45,16 +45,6 @@
     --color-green-900: oklch(39.3% 0.095 152.535);
     --color-cyan-400: oklch(78.9% 0.154 211.53);
     --color-cyan-500: oklch(71.5% 0.143 215.221);
-    --color-sky-50: oklch(97.7% 0.013 236.62);
-    --color-sky-100: oklch(95.1% 0.026 236.824);
-    --color-sky-200: oklch(90.1% 0.058 230.902);
-    --color-sky-300: oklch(82.8% 0.111 230.318);
-    --color-sky-400: oklch(74.6% 0.16 232.661);
-    --color-sky-500: oklch(68.5% 0.169 237.323);
-    --color-sky-600: oklch(58.8% 0.158 241.966);
-    --color-sky-700: oklch(50% 0.134 242.749);
-    --color-sky-800: oklch(44.3% 0.11 240.79);
-    --color-sky-900: oklch(39.1% 0.09 240.876);
     --color-blue-50: oklch(97% 0.014 254.604);
     --color-blue-100: oklch(93.2% 0.032 255.585);
     --color-blue-200: oklch(88.2% 0.059 254.128);
@@ -121,16 +111,16 @@
     --default-transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
     --default-font-family: var(--font-sans);
     --default-mono-font-family: var(--font-mono);
-    --color-brand-50: var(--color-sky-50);
-    --color-brand-100: var(--color-sky-100);
-    --color-brand-200: var(--color-sky-200);
-    --color-brand-300: var(--color-sky-300);
-    --color-brand-400: var(--color-sky-400);
-    --color-brand-500: var(--color-sky-500);
-    --color-brand-600: var(--color-sky-600);
-    --color-brand-700: var(--color-sky-700);
-    --color-brand-800: var(--color-sky-800);
-    --color-brand-900: var(--color-sky-900);
+    --color-brand-50: var(--color-blue-50);
+    --color-brand-100: var(--color-blue-100);
+    --color-brand-200: var(--color-blue-200);
+    --color-brand-300: var(--color-blue-300);
+    --color-brand-400: var(--color-blue-400);
+    --color-brand-500: var(--color-blue-500);
+    --color-brand-600: var(--color-blue-600);
+    --color-brand-700: var(--color-blue-700);
+    --color-brand-800: var(--color-blue-800);
+    --color-brand-900: var(--color-blue-900);
   }
 }
 @layer base {
@@ -1720,7 +1710,7 @@
   }
   .dark\:bg-brand-900\/20 {
     @media (prefers-color-scheme: dark) {
-      background-color: color-mix(in srgb, oklch(39.1% 0.09 240.876) 20%, transparent);
+      background-color: color-mix(in srgb, oklch(37.9% 0.146 265.522) 20%, transparent);
       @supports (color: color-mix(in lab, red, red)) {
         background-color: color-mix(in oklab, var(--color-brand-900) 20%, transparent);
       }

--- a/packages/vira/static/tailwind.css
+++ b/packages/vira/static/tailwind.css
@@ -1,12 +1,10 @@
-/*! tailwindcss v4.1.18 | MIT License | https://tailwindcss.com */
+/*! tailwindcss v4.2.2 | MIT License | https://tailwindcss.com */
 @layer properties;
 @layer theme, base, components, utilities;
 @layer theme {
   :root, :host {
-    --font-sans: ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
-    'Noto Color Emoji';
-    --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
-    monospace;
+    --font-sans: "Geist", ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+    --font-mono: "Geist Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
     --color-red-50: oklch(97.1% 0.013 17.38);
     --color-red-100: oklch(93.6% 0.032 17.717);
     --color-red-200: oklch(88.5% 0.062 18.334);
@@ -43,8 +41,16 @@
     --color-green-700: oklch(52.7% 0.154 150.069);
     --color-green-800: oklch(44.8% 0.119 151.328);
     --color-green-900: oklch(39.3% 0.095 152.535);
+    --color-cyan-50: oklch(98.4% 0.019 200.873);
+    --color-cyan-100: oklch(95.6% 0.045 203.388);
+    --color-cyan-200: oklch(91.7% 0.08 205.041);
+    --color-cyan-300: oklch(86.5% 0.127 207.078);
     --color-cyan-400: oklch(78.9% 0.154 211.53);
     --color-cyan-500: oklch(71.5% 0.143 215.221);
+    --color-cyan-600: oklch(60.9% 0.126 221.723);
+    --color-cyan-700: oklch(52% 0.105 223.128);
+    --color-cyan-800: oklch(45% 0.085 224.283);
+    --color-cyan-900: oklch(39.8% 0.07 227.392);
     --color-blue-50: oklch(97% 0.014 254.604);
     --color-blue-100: oklch(93.2% 0.032 255.585);
     --color-blue-200: oklch(88.2% 0.059 254.128);
@@ -278,6 +284,9 @@
   .collapse {
     visibility: collapse;
   }
+  .visible {
+    visibility: visible;
+  }
   .absolute {
     position: absolute;
   }
@@ -295,6 +304,12 @@
   }
   .inset-y-0 {
     inset-block: calc(var(--spacing) * 0);
+  }
+  .start {
+    inset-inline-start: var(--spacing);
+  }
+  .end {
+    inset-inline-end: var(--spacing);
   }
   .-top-3 {
     top: calc(var(--spacing) * -3);
@@ -422,6 +437,9 @@
   .block {
     display: block;
   }
+  .contents {
+    display: contents;
+  }
   .flex {
     display: flex;
   }
@@ -538,6 +556,9 @@
     --tw-scale-y: 95%;
     --tw-scale-z: 95%;
     scale: var(--tw-scale-x) var(--tw-scale-y);
+  }
+  .transform {
+    transform: var(--tw-rotate-x,) var(--tw-rotate-y,) var(--tw-rotate-z,) var(--tw-skew-x,) var(--tw-skew-y,);
   }
   .animate-spin {
     animation: var(--animate-spin);
@@ -803,6 +824,12 @@
   .border-blue-300 {
     border-color: var(--color-blue-300);
   }
+  .border-cyan-200 {
+    border-color: var(--color-cyan-200);
+  }
+  .border-cyan-600 {
+    border-color: var(--color-cyan-600);
+  }
   .border-gray-200 {
     border-color: var(--color-gray-200);
   }
@@ -811,12 +838,6 @@
   }
   .border-green-200 {
     border-color: var(--color-green-200);
-  }
-  .border-indigo-200 {
-    border-color: var(--color-indigo-200);
-  }
-  .border-indigo-600 {
-    border-color: var(--color-indigo-600);
   }
   .border-purple-300 {
     border-color: var(--color-purple-300);
@@ -845,6 +866,15 @@
   .bg-blue-100 {
     background-color: var(--color-blue-100);
   }
+  .bg-cyan-50 {
+    background-color: var(--color-cyan-50);
+  }
+  .bg-cyan-100 {
+    background-color: var(--color-cyan-100);
+  }
+  .bg-cyan-600 {
+    background-color: var(--color-cyan-600);
+  }
   .bg-gray-50 {
     background-color: var(--color-gray-50);
   }
@@ -865,15 +895,6 @@
   }
   .bg-green-600 {
     background-color: var(--color-green-600);
-  }
-  .bg-indigo-50 {
-    background-color: var(--color-indigo-50);
-  }
-  .bg-indigo-100 {
-    background-color: var(--color-indigo-100);
-  }
-  .bg-indigo-600 {
-    background-color: var(--color-indigo-600);
   }
   .bg-orange-100 {
     background-color: var(--color-orange-100);
@@ -1004,6 +1025,9 @@
   .font-mono {
     font-family: var(--font-mono);
   }
+  .font-sans {
+    font-family: var(--font-sans);
+  }
   .\!text-xs {
     font-size: var(--text-xs) !important;
     line-height: var(--tw-leading, var(--text-xs--line-height)) !important;
@@ -1099,6 +1123,18 @@
   .text-cyan-400 {
     color: var(--color-cyan-400);
   }
+  .text-cyan-600 {
+    color: var(--color-cyan-600);
+  }
+  .text-cyan-700 {
+    color: var(--color-cyan-700);
+  }
+  .text-cyan-800 {
+    color: var(--color-cyan-800);
+  }
+  .text-cyan-900 {
+    color: var(--color-cyan-900);
+  }
   .text-gray-100 {
     color: var(--color-gray-100);
   }
@@ -1131,18 +1167,6 @@
   }
   .text-green-800 {
     color: var(--color-green-800);
-  }
-  .text-indigo-600 {
-    color: var(--color-indigo-600);
-  }
-  .text-indigo-700 {
-    color: var(--color-indigo-700);
-  }
-  .text-indigo-800 {
-    color: var(--color-indigo-800);
-  }
-  .text-indigo-900 {
-    color: var(--color-indigo-900);
   }
   .text-orange-600 {
     color: var(--color-orange-600);
@@ -1286,24 +1310,24 @@
     -webkit-user-select: none;
     user-select: none;
   }
-  .group-hover\:border-indigo-300 {
+  .group-hover\:border-cyan-300 {
     &:is(:where(.group):hover *) {
       @media (hover: hover) {
-        border-color: var(--color-indigo-300);
+        border-color: var(--color-cyan-300);
       }
     }
   }
-  .group-hover\:text-indigo-500 {
+  .group-hover\:text-cyan-500 {
     &:is(:where(.group):hover *) {
       @media (hover: hover) {
-        color: var(--color-indigo-500);
+        color: var(--color-cyan-500);
       }
     }
   }
-  .group-hover\:text-indigo-700 {
+  .group-hover\:text-cyan-700 {
     &:is(:where(.group):hover *) {
       @media (hover: hover) {
-        color: var(--color-indigo-700);
+        color: var(--color-cyan-700);
       }
     }
   }
@@ -1318,6 +1342,13 @@
     &:hover {
       @media (hover: hover) {
         background-color: var(--color-red-100) !important;
+      }
+    }
+  }
+  .hover\:bg-cyan-700 {
+    &:hover {
+      @media (hover: hover) {
+        background-color: var(--color-cyan-700);
       }
     }
   }
@@ -1346,13 +1377,6 @@
     &:hover {
       @media (hover: hover) {
         background-color: var(--color-green-700);
-      }
-    }
-  }
-  .hover\:bg-indigo-700 {
-    &:hover {
-      @media (hover: hover) {
-        background-color: var(--color-indigo-700);
       }
     }
   }
@@ -1393,6 +1417,13 @@
       }
     }
   }
+  .hover\:text-cyan-600 {
+    &:hover {
+      @media (hover: hover) {
+        color: var(--color-cyan-600);
+      }
+    }
+  }
   .hover\:text-gray-600 {
     &:hover {
       @media (hover: hover) {
@@ -1418,13 +1449,6 @@
     &:hover {
       @media (hover: hover) {
         color: var(--color-gray-900);
-      }
-    }
-  }
-  .hover\:text-indigo-600 {
-    &:hover {
-      @media (hover: hover) {
-        color: var(--color-indigo-600);
       }
     }
   }
@@ -1478,15 +1502,20 @@
       }
     }
   }
-  .focus\:border-indigo-500 {
+  .focus\:border-cyan-500 {
     &:focus {
-      border-color: var(--color-indigo-500);
+      border-color: var(--color-cyan-500);
     }
   }
   .focus\:ring-2 {
     &:focus {
       --tw-ring-shadow: var(--tw-ring-inset,) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentcolor);
       box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+    }
+  }
+  .focus\:ring-cyan-500 {
+    &:focus {
+      --tw-ring-color: var(--color-cyan-500);
     }
   }
   .focus\:ring-gray-500 {
@@ -1497,11 +1526,6 @@
   .focus\:ring-green-500 {
     &:focus {
       --tw-ring-color: var(--color-green-500);
-    }
-  }
-  .focus\:ring-indigo-500 {
-    &:focus {
-      --tw-ring-color: var(--color-indigo-500);
     }
   }
   .focus\:ring-red-500 {
@@ -1606,6 +1630,16 @@
       border-color: var(--color-blue-800);
     }
   }
+  .dark\:border-cyan-400 {
+    @media (prefers-color-scheme: dark) {
+      border-color: var(--color-cyan-400);
+    }
+  }
+  .dark\:border-cyan-800 {
+    @media (prefers-color-scheme: dark) {
+      border-color: var(--color-cyan-800);
+    }
+  }
   .dark\:border-gray-600 {
     @media (prefers-color-scheme: dark) {
       border-color: var(--color-gray-600);
@@ -1619,16 +1653,6 @@
   .dark\:border-green-800 {
     @media (prefers-color-scheme: dark) {
       border-color: var(--color-green-800);
-    }
-  }
-  .dark\:border-indigo-400 {
-    @media (prefers-color-scheme: dark) {
-      border-color: var(--color-indigo-400);
-    }
-  }
-  .dark\:border-indigo-800 {
-    @media (prefers-color-scheme: dark) {
-      border-color: var(--color-indigo-800);
     }
   }
   .dark\:border-purple-700 {
@@ -1680,6 +1704,24 @@
       }
     }
   }
+  .dark\:bg-cyan-500 {
+    @media (prefers-color-scheme: dark) {
+      background-color: var(--color-cyan-500);
+    }
+  }
+  .dark\:bg-cyan-700 {
+    @media (prefers-color-scheme: dark) {
+      background-color: var(--color-cyan-700);
+    }
+  }
+  .dark\:bg-cyan-900\/20 {
+    @media (prefers-color-scheme: dark) {
+      background-color: color-mix(in srgb, oklch(39.8% 0.07 227.392) 20%, transparent);
+      @supports (color: color-mix(in lab, red, red)) {
+        background-color: color-mix(in oklab, var(--color-cyan-900) 20%, transparent);
+      }
+    }
+  }
   .dark\:bg-gray-700 {
     @media (prefers-color-scheme: dark) {
       background-color: var(--color-gray-700);
@@ -1708,24 +1750,6 @@
       background-color: color-mix(in srgb, oklch(39.3% 0.095 152.535) 30%, transparent);
       @supports (color: color-mix(in lab, red, red)) {
         background-color: color-mix(in oklab, var(--color-green-900) 30%, transparent);
-      }
-    }
-  }
-  .dark\:bg-indigo-500 {
-    @media (prefers-color-scheme: dark) {
-      background-color: var(--color-indigo-500);
-    }
-  }
-  .dark\:bg-indigo-700 {
-    @media (prefers-color-scheme: dark) {
-      background-color: var(--color-indigo-700);
-    }
-  }
-  .dark\:bg-indigo-900\/20 {
-    @media (prefers-color-scheme: dark) {
-      background-color: color-mix(in srgb, oklch(35.9% 0.144 278.697) 20%, transparent);
-      @supports (color: color-mix(in lab, red, red)) {
-        background-color: color-mix(in oklab, var(--color-indigo-900) 20%, transparent);
       }
     }
   }
@@ -1822,6 +1846,26 @@
       color: var(--color-blue-400);
     }
   }
+  .dark\:text-cyan-100 {
+    @media (prefers-color-scheme: dark) {
+      color: var(--color-cyan-100);
+    }
+  }
+  .dark\:text-cyan-200 {
+    @media (prefers-color-scheme: dark) {
+      color: var(--color-cyan-200);
+    }
+  }
+  .dark\:text-cyan-300 {
+    @media (prefers-color-scheme: dark) {
+      color: var(--color-cyan-300);
+    }
+  }
+  .dark\:text-cyan-400 {
+    @media (prefers-color-scheme: dark) {
+      color: var(--color-cyan-400);
+    }
+  }
   .dark\:text-cyan-500 {
     @media (prefers-color-scheme: dark) {
       color: var(--color-cyan-500);
@@ -1865,26 +1909,6 @@
   .dark\:text-green-400 {
     @media (prefers-color-scheme: dark) {
       color: var(--color-green-400);
-    }
-  }
-  .dark\:text-indigo-100 {
-    @media (prefers-color-scheme: dark) {
-      color: var(--color-indigo-100);
-    }
-  }
-  .dark\:text-indigo-200 {
-    @media (prefers-color-scheme: dark) {
-      color: var(--color-indigo-200);
-    }
-  }
-  .dark\:text-indigo-300 {
-    @media (prefers-color-scheme: dark) {
-      color: var(--color-indigo-300);
-    }
-  }
-  .dark\:text-indigo-400 {
-    @media (prefers-color-scheme: dark) {
-      color: var(--color-indigo-400);
     }
   }
   .dark\:text-orange-300 {
@@ -1959,20 +1983,20 @@
       }
     }
   }
-  .dark\:group-hover\:border-indigo-600 {
+  .dark\:group-hover\:border-cyan-600 {
     @media (prefers-color-scheme: dark) {
       &:is(:where(.group):hover *) {
         @media (hover: hover) {
-          border-color: var(--color-indigo-600);
+          border-color: var(--color-cyan-600);
         }
       }
     }
   }
-  .dark\:group-hover\:text-indigo-400 {
+  .dark\:group-hover\:text-cyan-400 {
     @media (prefers-color-scheme: dark) {
       &:is(:where(.group):hover *) {
         @media (hover: hover) {
-          color: var(--color-indigo-400);
+          color: var(--color-cyan-400);
         }
       }
     }
@@ -1994,6 +2018,15 @@
           @supports (color: color-mix(in lab, red, red)) {
             background-color: color-mix(in oklab, var(--color-red-900) 30%, transparent) !important;
           }
+        }
+      }
+    }
+  }
+  .dark\:hover\:bg-cyan-600 {
+    @media (prefers-color-scheme: dark) {
+      &:hover {
+        @media (hover: hover) {
+          background-color: var(--color-cyan-600);
         }
       }
     }
@@ -2037,11 +2070,11 @@
       }
     }
   }
-  .dark\:hover\:bg-indigo-600 {
+  .dark\:hover\:text-cyan-400 {
     @media (prefers-color-scheme: dark) {
       &:hover {
         @media (hover: hover) {
-          background-color: var(--color-indigo-600);
+          color: var(--color-cyan-400);
         }
       }
     }
@@ -2064,15 +2097,6 @@
       }
     }
   }
-  .dark\:hover\:text-indigo-400 {
-    @media (prefers-color-scheme: dark) {
-      &:hover {
-        @media (hover: hover) {
-          color: var(--color-indigo-400);
-        }
-      }
-    }
-  }
 }
 @property --tw-scale-x {
   syntax: "*";
@@ -2088,6 +2112,26 @@
   syntax: "*";
   inherits: false;
   initial-value: 1;
+}
+@property --tw-rotate-x {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-rotate-y {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-rotate-z {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-skew-x {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-skew-y {
+  syntax: "*";
+  inherits: false;
 }
 @property --tw-space-y-reverse {
   syntax: "*";
@@ -2290,6 +2334,11 @@
       --tw-scale-x: 1;
       --tw-scale-y: 1;
       --tw-scale-z: 1;
+      --tw-rotate-x: initial;
+      --tw-rotate-y: initial;
+      --tw-rotate-z: initial;
+      --tw-skew-x: initial;
+      --tw-skew-y: initial;
       --tw-space-y-reverse: 0;
       --tw-space-x-reverse: 0;
       --tw-divide-y-reverse: 0;

--- a/packages/vira/static/tailwind.css
+++ b/packages/vira/static/tailwind.css
@@ -43,16 +43,18 @@
     --color-green-700: oklch(52.7% 0.154 150.069);
     --color-green-800: oklch(44.8% 0.119 151.328);
     --color-green-900: oklch(39.3% 0.095 152.535);
-    --color-cyan-50: oklch(98.4% 0.019 200.873);
-    --color-cyan-100: oklch(95.6% 0.045 203.388);
-    --color-cyan-200: oklch(91.7% 0.08 205.041);
-    --color-cyan-300: oklch(86.5% 0.127 207.078);
     --color-cyan-400: oklch(78.9% 0.154 211.53);
     --color-cyan-500: oklch(71.5% 0.143 215.221);
-    --color-cyan-600: oklch(60.9% 0.126 221.723);
-    --color-cyan-700: oklch(52% 0.105 223.128);
-    --color-cyan-800: oklch(45% 0.085 224.283);
-    --color-cyan-900: oklch(39.8% 0.07 227.392);
+    --color-sky-50: oklch(97.7% 0.013 236.62);
+    --color-sky-100: oklch(95.1% 0.026 236.824);
+    --color-sky-200: oklch(90.1% 0.058 230.902);
+    --color-sky-300: oklch(82.8% 0.111 230.318);
+    --color-sky-400: oklch(74.6% 0.16 232.661);
+    --color-sky-500: oklch(68.5% 0.169 237.323);
+    --color-sky-600: oklch(58.8% 0.158 241.966);
+    --color-sky-700: oklch(50% 0.134 242.749);
+    --color-sky-800: oklch(44.3% 0.11 240.79);
+    --color-sky-900: oklch(39.1% 0.09 240.876);
     --color-blue-50: oklch(97% 0.014 254.604);
     --color-blue-100: oklch(93.2% 0.032 255.585);
     --color-blue-200: oklch(88.2% 0.059 254.128);
@@ -119,16 +121,16 @@
     --default-transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
     --default-font-family: var(--font-sans);
     --default-mono-font-family: var(--font-mono);
-    --color-brand-50: var(--color-cyan-50);
-    --color-brand-100: var(--color-cyan-100);
-    --color-brand-200: var(--color-cyan-200);
-    --color-brand-300: var(--color-cyan-300);
-    --color-brand-400: var(--color-cyan-400);
-    --color-brand-500: var(--color-cyan-500);
-    --color-brand-600: var(--color-cyan-600);
-    --color-brand-700: var(--color-cyan-700);
-    --color-brand-800: var(--color-cyan-800);
-    --color-brand-900: var(--color-cyan-900);
+    --color-brand-50: var(--color-sky-50);
+    --color-brand-100: var(--color-sky-100);
+    --color-brand-200: var(--color-sky-200);
+    --color-brand-300: var(--color-sky-300);
+    --color-brand-400: var(--color-sky-400);
+    --color-brand-500: var(--color-sky-500);
+    --color-brand-600: var(--color-sky-600);
+    --color-brand-700: var(--color-sky-700);
+    --color-brand-800: var(--color-sky-800);
+    --color-brand-900: var(--color-sky-900);
   }
 }
 @layer base {
@@ -1718,7 +1720,7 @@
   }
   .dark\:bg-brand-900\/20 {
     @media (prefers-color-scheme: dark) {
-      background-color: color-mix(in srgb, oklch(39.8% 0.07 227.392) 20%, transparent);
+      background-color: color-mix(in srgb, oklch(39.1% 0.09 240.876) 20%, transparent);
       @supports (color: color-mix(in lab, red, red)) {
         background-color: color-mix(in oklab, var(--color-brand-900) 20%, transparent);
       }

--- a/packages/vira/static/tailwind.css
+++ b/packages/vira/static/tailwind.css
@@ -2100,6 +2100,12 @@
     }
   }
 }
+html {
+  overflow-y: scroll;
+}
+.transition-smooth {
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
 @property --tw-scale-x {
   syntax: "*";
   inherits: false;

--- a/packages/vira/static/tailwind.css
+++ b/packages/vira/static/tailwind.css
@@ -3,8 +3,10 @@
 @layer theme, base, components, utilities;
 @layer theme {
   :root, :host {
-    --font-sans: "Geist", ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
-    --font-mono: "Geist Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+    --font-sans: "Geist", ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji",
+    "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+    --font-mono: "Geist Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    "Liberation Mono", "Courier New", monospace;
     --color-red-50: oklch(97.1% 0.013 17.38);
     --color-red-100: oklch(93.6% 0.032 17.717);
     --color-red-200: oklch(88.5% 0.062 18.334);
@@ -61,16 +63,6 @@
     --color-blue-700: oklch(48.8% 0.243 264.376);
     --color-blue-800: oklch(42.4% 0.199 265.638);
     --color-blue-900: oklch(37.9% 0.146 265.522);
-    --color-indigo-50: oklch(96.2% 0.018 272.314);
-    --color-indigo-100: oklch(93% 0.034 272.788);
-    --color-indigo-200: oklch(87% 0.065 274.039);
-    --color-indigo-300: oklch(78.5% 0.115 274.713);
-    --color-indigo-400: oklch(67.3% 0.182 276.935);
-    --color-indigo-500: oklch(58.5% 0.233 277.117);
-    --color-indigo-600: oklch(51.1% 0.262 276.966);
-    --color-indigo-700: oklch(45.7% 0.24 277.023);
-    --color-indigo-800: oklch(39.8% 0.195 277.366);
-    --color-indigo-900: oklch(35.9% 0.144 278.697);
     --color-purple-100: oklch(94.6% 0.033 307.174);
     --color-purple-200: oklch(90.2% 0.063 306.703);
     --color-purple-300: oklch(82.7% 0.119 306.383);
@@ -127,6 +119,16 @@
     --default-transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
     --default-font-family: var(--font-sans);
     --default-mono-font-family: var(--font-mono);
+    --color-brand-50: var(--color-cyan-50);
+    --color-brand-100: var(--color-cyan-100);
+    --color-brand-200: var(--color-cyan-200);
+    --color-brand-300: var(--color-cyan-300);
+    --color-brand-400: var(--color-cyan-400);
+    --color-brand-500: var(--color-cyan-500);
+    --color-brand-600: var(--color-cyan-600);
+    --color-brand-700: var(--color-cyan-700);
+    --color-brand-800: var(--color-cyan-800);
+    --color-brand-900: var(--color-cyan-900);
   }
 }
 @layer base {
@@ -824,11 +826,11 @@
   .border-blue-300 {
     border-color: var(--color-blue-300);
   }
-  .border-cyan-200 {
-    border-color: var(--color-cyan-200);
+  .border-brand-200 {
+    border-color: var(--color-brand-200);
   }
-  .border-cyan-600 {
-    border-color: var(--color-cyan-600);
+  .border-brand-600 {
+    border-color: var(--color-brand-600);
   }
   .border-gray-200 {
     border-color: var(--color-gray-200);
@@ -866,14 +868,14 @@
   .bg-blue-100 {
     background-color: var(--color-blue-100);
   }
-  .bg-cyan-50 {
-    background-color: var(--color-cyan-50);
+  .bg-brand-50 {
+    background-color: var(--color-brand-50);
   }
-  .bg-cyan-100 {
-    background-color: var(--color-cyan-100);
+  .bg-brand-100 {
+    background-color: var(--color-brand-100);
   }
-  .bg-cyan-600 {
-    background-color: var(--color-cyan-600);
+  .bg-brand-600 {
+    background-color: var(--color-brand-600);
   }
   .bg-gray-50 {
     background-color: var(--color-gray-50);
@@ -1120,20 +1122,20 @@
   .text-blue-900 {
     color: var(--color-blue-900);
   }
+  .text-brand-600 {
+    color: var(--color-brand-600);
+  }
+  .text-brand-700 {
+    color: var(--color-brand-700);
+  }
+  .text-brand-800 {
+    color: var(--color-brand-800);
+  }
+  .text-brand-900 {
+    color: var(--color-brand-900);
+  }
   .text-cyan-400 {
     color: var(--color-cyan-400);
-  }
-  .text-cyan-600 {
-    color: var(--color-cyan-600);
-  }
-  .text-cyan-700 {
-    color: var(--color-cyan-700);
-  }
-  .text-cyan-800 {
-    color: var(--color-cyan-800);
-  }
-  .text-cyan-900 {
-    color: var(--color-cyan-900);
   }
   .text-gray-100 {
     color: var(--color-gray-100);
@@ -1310,24 +1312,24 @@
     -webkit-user-select: none;
     user-select: none;
   }
-  .group-hover\:border-cyan-300 {
+  .group-hover\:border-brand-300 {
     &:is(:where(.group):hover *) {
       @media (hover: hover) {
-        border-color: var(--color-cyan-300);
+        border-color: var(--color-brand-300);
       }
     }
   }
-  .group-hover\:text-cyan-500 {
+  .group-hover\:text-brand-500 {
     &:is(:where(.group):hover *) {
       @media (hover: hover) {
-        color: var(--color-cyan-500);
+        color: var(--color-brand-500);
       }
     }
   }
-  .group-hover\:text-cyan-700 {
+  .group-hover\:text-brand-700 {
     &:is(:where(.group):hover *) {
       @media (hover: hover) {
-        color: var(--color-cyan-700);
+        color: var(--color-brand-700);
       }
     }
   }
@@ -1345,10 +1347,10 @@
       }
     }
   }
-  .hover\:bg-cyan-700 {
+  .hover\:bg-brand-700 {
     &:hover {
       @media (hover: hover) {
-        background-color: var(--color-cyan-700);
+        background-color: var(--color-brand-700);
       }
     }
   }
@@ -1417,10 +1419,10 @@
       }
     }
   }
-  .hover\:text-cyan-600 {
+  .hover\:text-brand-600 {
     &:hover {
       @media (hover: hover) {
-        color: var(--color-cyan-600);
+        color: var(--color-brand-600);
       }
     }
   }
@@ -1502,9 +1504,9 @@
       }
     }
   }
-  .focus\:border-cyan-500 {
+  .focus\:border-brand-500 {
     &:focus {
-      border-color: var(--color-cyan-500);
+      border-color: var(--color-brand-500);
     }
   }
   .focus\:ring-2 {
@@ -1513,9 +1515,9 @@
       box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
     }
   }
-  .focus\:ring-cyan-500 {
+  .focus\:ring-brand-500 {
     &:focus {
-      --tw-ring-color: var(--color-cyan-500);
+      --tw-ring-color: var(--color-brand-500);
     }
   }
   .focus\:ring-gray-500 {
@@ -1630,14 +1632,14 @@
       border-color: var(--color-blue-800);
     }
   }
-  .dark\:border-cyan-400 {
+  .dark\:border-brand-400 {
     @media (prefers-color-scheme: dark) {
-      border-color: var(--color-cyan-400);
+      border-color: var(--color-brand-400);
     }
   }
-  .dark\:border-cyan-800 {
+  .dark\:border-brand-800 {
     @media (prefers-color-scheme: dark) {
-      border-color: var(--color-cyan-800);
+      border-color: var(--color-brand-800);
     }
   }
   .dark\:border-gray-600 {
@@ -1704,21 +1706,21 @@
       }
     }
   }
-  .dark\:bg-cyan-500 {
+  .dark\:bg-brand-500 {
     @media (prefers-color-scheme: dark) {
-      background-color: var(--color-cyan-500);
+      background-color: var(--color-brand-500);
     }
   }
-  .dark\:bg-cyan-700 {
+  .dark\:bg-brand-700 {
     @media (prefers-color-scheme: dark) {
-      background-color: var(--color-cyan-700);
+      background-color: var(--color-brand-700);
     }
   }
-  .dark\:bg-cyan-900\/20 {
+  .dark\:bg-brand-900\/20 {
     @media (prefers-color-scheme: dark) {
       background-color: color-mix(in srgb, oklch(39.8% 0.07 227.392) 20%, transparent);
       @supports (color: color-mix(in lab, red, red)) {
-        background-color: color-mix(in oklab, var(--color-cyan-900) 20%, transparent);
+        background-color: color-mix(in oklab, var(--color-brand-900) 20%, transparent);
       }
     }
   }
@@ -1846,24 +1848,24 @@
       color: var(--color-blue-400);
     }
   }
-  .dark\:text-cyan-100 {
+  .dark\:text-brand-100 {
     @media (prefers-color-scheme: dark) {
-      color: var(--color-cyan-100);
+      color: var(--color-brand-100);
     }
   }
-  .dark\:text-cyan-200 {
+  .dark\:text-brand-200 {
     @media (prefers-color-scheme: dark) {
-      color: var(--color-cyan-200);
+      color: var(--color-brand-200);
     }
   }
-  .dark\:text-cyan-300 {
+  .dark\:text-brand-300 {
     @media (prefers-color-scheme: dark) {
-      color: var(--color-cyan-300);
+      color: var(--color-brand-300);
     }
   }
-  .dark\:text-cyan-400 {
+  .dark\:text-brand-400 {
     @media (prefers-color-scheme: dark) {
-      color: var(--color-cyan-400);
+      color: var(--color-brand-400);
     }
   }
   .dark\:text-cyan-500 {
@@ -1983,20 +1985,20 @@
       }
     }
   }
-  .dark\:group-hover\:border-cyan-600 {
+  .dark\:group-hover\:border-brand-600 {
     @media (prefers-color-scheme: dark) {
       &:is(:where(.group):hover *) {
         @media (hover: hover) {
-          border-color: var(--color-cyan-600);
+          border-color: var(--color-brand-600);
         }
       }
     }
   }
-  .dark\:group-hover\:text-cyan-400 {
+  .dark\:group-hover\:text-brand-400 {
     @media (prefers-color-scheme: dark) {
       &:is(:where(.group):hover *) {
         @media (hover: hover) {
-          color: var(--color-cyan-400);
+          color: var(--color-brand-400);
         }
       }
     }
@@ -2022,11 +2024,11 @@
       }
     }
   }
-  .dark\:hover\:bg-cyan-600 {
+  .dark\:hover\:bg-brand-600 {
     @media (prefers-color-scheme: dark) {
       &:hover {
         @media (hover: hover) {
-          background-color: var(--color-cyan-600);
+          background-color: var(--color-brand-600);
         }
       }
     }
@@ -2070,11 +2072,11 @@
       }
     }
   }
-  .dark\:hover\:text-cyan-400 {
+  .dark\:hover\:text-brand-400 {
     @media (prefers-color-scheme: dark) {
       &:hover {
         @media (hover: hover) {
-          color: var(--color-cyan-400);
+          color: var(--color-brand-400);
         }
       }
     }


### PR DESCRIPTION
**Vira's UI now ships on a deliberate aesthetic foundation** — Geist + Geist Mono in place of Inter + JetBrains Mono, and a `--color-brand-*` token scale (aliased to cyan today) as the single edit point for the primary accent. Indigo is gone; widget code no longer encodes _which_ color is the brand.

This is the foundation pass of a multi-PR redesign. The visible change is a fresh palette and typeface; the durable change is that the next aesthetic shift lands in `packages/vira/src/style.css` alone, not as another mechanical sweep across 13 widget/page files. _Status-as-hero, log-viewer polish, and atmospheric backgrounds are deferred follow-ups._

The diff also introduces `style.css` as the Tailwind v4 input file (wired through `vira-dev.nix` with `-i ./style.css`), extracts a shared `viraBrandPanel_` chrome widget that replaces three near-identical brand-tinted card definitions, and unifies the filter-input styling between `viraFilterInput_` (hyperscript) and `RepoPage`'s server-side branch filter (HTMX) via a shared `viraFilterInputShell_`.

> **Heads-up for downstream forks**: any code referencing `bg-indigo-*`, `text-indigo-*`, or the `font-inter` body class needs to migrate to `bg-brand-*` / `text-brand-*` / `font-sans`. The vira-design skill (`.apm/skills/vira-design/SKILL.md`) is updated accordingly.

### Try it locally

```sh
nix run github:juspay/vira/redesign/aesthetic-foundation -- web --port 5005
```

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-7`)._